### PR TITLE
Make pixel_to_world and world_to_pixel unit aware

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -297,13 +297,13 @@ class NDCube(astropy.nddata.NDData):
                              "same number of elements as number of data dimensions.")
         # Convert coords of lower left corner to pixel units.
         lower_pixels = self.world_to_pixel(lower_left_corner)
-        upper_pixels = self.world_to_pixel([lower_left_corner[i]+dimension_widths[i] for i in range(n_dim)])
+        upper_pixels = self.world_to_pixel([lower_left_corner[i]+dimension_widths[i]
+                                            for i in range(n_dim)])
         # Round pixel values to nearest integer.
         lower_pixels = [int(np.rint(l.value)) for l in lower_pixels]
         upper_pixels = [int(np.rint(u.value)) for u in upper_pixels]
         slic = tuple([slice(lower_pixels[i], upper_pixels[i]) for i in range(n_dim)])
         return self[slic]
-
 
     def __getitem__(self, item):
         if item is None or (isinstance(item, tuple) and None in item):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -125,16 +125,17 @@ class NDCube(astropy.nddata.NDData):
         indexed_not_as_one = []
         result = []
         quantity_index = 0
-        for i, _ in enumerate(self.missing_axis):
+        for i in range(len(self.missing_axis)):
+            wcs_index = self.wcs.naxis-1-i
             # the cases where the wcs dimension was made 1 and the missing_axis is True
-            if self.missing_axis[self.wcs.naxis-1-i]:
-                list_arg.append(self.wcs.wcs.crpix[self.wcs.naxis-1-i]-1+origin)
+            if self.missing_axis[wcs_index]:
+                list_arg.append(self.wcs.wcs.crpix[wcs_index]-1+origin)
             else:
                 # else it is not the case where the dimension of wcs is 1.
-                list_arg.append(quantity_axis_list[quantity_index])
+                list_arg.append(quantity_axis_list[quantity_index].to(u.pix).value)
                 quantity_index += 1
-            # appending all the indexes to be returned in the answer
-                indexed_not_as_one.append(self.wcs.naxis-1-i)
+                # appending all the indexes to be returned in the answer
+                indexed_not_as_one.append(wcs_index)
         list_arguments = list_arg[::-1]
         pixel_to_world = self.wcs.all_pix2world(*list_arguments, origin)
         # collecting all the needed answer in this list.
@@ -170,18 +171,20 @@ class NDCube(astropy.nddata.NDData):
         indexed_not_as_one = []
         result = []
         quantity_index = 0
-        for i, _ in enumerate(self.missing_axis):
+        for i in range(len(self.missing_axis)):
+            wcs_index = self.wcs.naxis-1-i
             # the cases where the wcs dimension was made 1 and the missing_axis is True
-            if self.missing_axis[self.wcs.naxis-1-i]:
-                list_arg.append(self.wcs.wcs.crval[self.wcs.naxis-1-i]+1-origin)
+            if self.missing_axis[wcs_index]:
+                list_arg.append(self.wcs.wcs.crval[wcs_index]+1-origin)
             else:
                 # else it is not the case where the dimension of wcs is 1.
-                list_arg.append(quantity_axis_list[quantity_index])
+                list_arg.append(
+                    quantity_axis_list[quantity_index].to(self.wcs.wcs.cunit[wcs_index]).value)
                 quantity_index += 1
-            # appending all the indexes to be returned in the answer
-                indexed_not_as_one.append(self.wcs.naxis-1-i)
-        list_arguemnts = list_arg[::-1]
-        world_to_pixel = self.wcs.all_world2pix(*list_arguemnts, origin)
+                # appending all the indexes to be returned in the answer
+                indexed_not_as_one.append(wcs_index)
+        list_arguments = list_arg[::-1]
+        world_to_pixel = self.wcs.all_world2pix(*list_arguments, origin)
         # collecting all the needed answer in this list.
         for index in indexed_not_as_one[::-1]:
             result.append(u.Quantity(world_to_pixel[index], unit=u.pix))
@@ -266,6 +269,41 @@ class NDCube(astropy.nddata.NDData):
         elif self.data.ndim is 1:
             plot = _plot_1D_cube(self, unit=unit, origin=origin)
         return plot
+
+    def crop_by_coords(self, lower_left_corner, dimension_widths):
+        """
+        Crops an NDCube given a lower left corner and widths of region of interest.
+
+        Parameters
+        ----------
+        lower_left_corner: `list` of `astropy.units.Quantity`s
+            The lower left corner of the region of interest described in physical units
+            consistent with the NDCube's wcs object.  The length of the iterable must
+            equal the number of data dimensions and must have the same order as the data.
+
+        dimension_widths: iterable of `astropy.units.Quantity`s
+            The width of the region of interest in each dimension in physical units
+            consistent with the NDCube's wcs object.  The length of the iterable must
+            equal the number of data dimensions and must have the same order as the data.
+
+        Returns
+        -------
+        result: NDCube
+
+        """
+        n_dim = len(self.dimensions.shape)
+        if len(lower_left_corner) != len(dimension_widths) != n_dim:
+            raise ValueError("lower_left_corner and dimension_widths must have "
+                             "same number of elements as number of data dimensions.")
+        # Convert coords of lower left corner to pixel units.
+        lower_pixels = self.world_to_pixel(lower_left_corner)
+        upper_pixels = self.world_to_pixel([lower_left_corner[i]+dimension_widths[i] for i in range(n_dim)])
+        # Round pixel values to nearest integer.
+        lower_pixels = [int(np.rint(l.value)) for l in lower_pixels]
+        upper_pixels = [int(np.rint(u.value)) for u in upper_pixels]
+        slic = tuple([slice(lower_pixels[i], upper_pixels[i]) for i in range(n_dim)])
+        return self[slic]
+
 
     def __getitem__(self, item):
         if item is None or (isinstance(item, tuple) and None in item):


### PR DESCRIPTION
Before this PR ```NDCube.pixel_to_world``` and ```NDCube.world_to_pixel``` implicitly assumed that the values entered by the users were in the the appropriate SI units for the given dimension.  This negated the point of the user entering the values as ```Quantities```.  This PR now converts the inputs to SI before applying them to ```wcs.all_world2pix``` and ```wcs.all_pix2world```.  In doing so, it will also break if the units are not compatible with the wcs cunits of the dimension, e.g. if 'deg' is input for a WAVE dimension in , the programs will crash.