### PR TITLE
NDCubeSequence.common_axis_extra_coords Bugfix

### DIFF
--- a/ndcube/cube_utils.py
+++ b/ndcube/cube_utils.py
@@ -95,9 +95,9 @@ def index_sequence_as_cube(cubesequence, item):
     """
     Enables CubeSequence to be indexed as a single Cube.
 
-    This is only possible if cubesequence.common_axis is set,
+    This is only possible if cubesequence._common_axis is set,
     i.e. if the Cubes are sequence in order along one of the Cube axes.
-    For example, if cubesequence.common_axis=1 where the first axis is
+    For example, if cubesequence._common_axis=1 where the first axis is
     time, and the Cubes are sequence chronologically such that the last
     time slice of one Cube is directly followed in time by the first time
     slice of the next Cube, then this function allows the CubeSequence to
@@ -124,59 +124,59 @@ def index_sequence_as_cube(cubesequence, item):
 
     """
     # Determine starting slice of each cube along common axis.
-    cumul_cube_lengths = np.cumsum(np.array([c.data.shape[cubesequence.common_axis]
+    cumul_cube_lengths = np.cumsum(np.array([c.data.shape[cubesequence._common_axis]
                                              for c in cubesequence.data]))
     # Case 1: Item is int and common axis is 0. Not yet supported.
     if isinstance(item, int):
-        if cubesequence.common_axis != 0:
+        if cubesequence._common_axis != 0:
             raise ValueError("Input can only be indexed with an int if "
                              "CubeSequence's common axis is 0. common "
-                             "axis = {0}".format(cubesequence.common_axis))
+                             "axis = {0}".format(cubesequence._common_axis))
         else:
             sequence_index, cube_index = _convert_cube_like_index_to_sequence_indices(
                 item, cumul_cube_lengths)
             item_list = [item]
     # Case 2: Item is slice and common axis is 0.
     elif isinstance(item, slice):
-        if cubesequence.common_axis != 0:
+        if cubesequence._common_axis != 0:
             raise ValueError("Input can only be sliced with a single slice if "
                              "CubeSequence's common axis is 0. common "
-                             "axis = {0}".format(cubesequence.common_axis))
+                             "axis = {0}".format(cubesequence._common_axis))
         else:
             sequence_index, cube_index = _convert_cube_like_slice_to_sequence_slices(
                 item, cumul_cube_lengths)
             item_list = [item]
     # Case 3: Item is tuple and common axis index is int.
-    elif isinstance(item[cubesequence.common_axis], int):
+    elif isinstance(item[cubesequence._common_axis], int):
         # Since item must be a tuple, convert to list to
         # make ensure it's mutable for next cases.
         item_list = list(item)
         # Check item is long enough to include common axis.
-        if len(item_list) < cubesequence.common_axis:
+        if len(item_list) < cubesequence._common_axis:
             raise ValueError("Input item not long enough to include common axis."
                              "Must have length of of between "
                              "{0} and {1} inclusive.".format(
-                                 cubesequence.common_axis, len(cubesequence[0].data.shape)))
+                                 cubesequence._common_axis, len(cubesequence[0].data.shape)))
         sequence_index, cube_index = _convert_cube_like_index_to_sequence_indices(
-            item_list[cubesequence.common_axis], cumul_cube_lengths)
+            item_list[cubesequence._common_axis], cumul_cube_lengths)
     # Case 4: Item is tuple and common axis index is slice.
-    elif isinstance(item[cubesequence.common_axis], slice):
+    elif isinstance(item[cubesequence._common_axis], slice):
         # Since item must be a tuple, convert to list to
         # make ensure it's mutable for next cases.
         item_list = list(item)
         # Check item is long enough to include common axis.
-        if len(item_list) < cubesequence.common_axis:
+        if len(item_list) < cubesequence._common_axis:
             raise ValueError("Input item not long enough to include common axis."
                              "Must have length of of between "
                              "{0} and {1} inclusive.".format(
-                                 cubesequence.common_axis, len(cubesequence[0].data.shape)))
+                                 cubesequence._common_axis, len(cubesequence[0].data.shape)))
         sequence_index, cube_index = _convert_cube_like_slice_to_sequence_slices(
-            item_list[cubesequence.common_axis], cumul_cube_lengths)
+            item_list[cubesequence._common_axis], cumul_cube_lengths)
     else:
         raise ValueError("Invalid index/slice input.")
     # Replace common axis index/slice with corresponding
     # index/slice with cube.
-    item_list[cubesequence.common_axis] = cube_index
+    item_list[cubesequence._common_axis] = cube_index
     # Insert corresponding index/slice of required cube in sequence.
     item_list.insert(0, sequence_index)
     item_tuple = tuple(item_list)

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -492,7 +492,7 @@ class NDCubeSequence(object):
     def __init__(self, data_list, meta=None, common_axis=None, **kwargs):
         self.data = data_list
         self.meta = meta
-        self.common_axis = common_axis
+        self._common_axis = common_axis
 
     def __getitem__(self, item):
         if item is None or (isinstance(item, tuple) and None in item):
@@ -523,8 +523,8 @@ class NDCubeSequence(object):
             The axis along which the data is to be changed.
         """
         # if axis is None then set axis as common axis.
-        if self.common_axis is not None:
-            if self.common_axis != axis:
+        if self._common_axis is not None:
+            if self._common_axis != axis:
                 raise ValueError("axis and common_axis should be equal.")
         # is axis is -ve then calculate the axis from the length of the dimensions of one cube
         if axis < 0:
@@ -562,17 +562,22 @@ Axis Types of 1st NDCube: {axis_type}
 
     @property
     def common_axis_extra_coords(self):
-        if self.common_axis:
+        if self._common_axis in range(self.data[0].wcs.naxis):
             common_extra_coords = {}
-            common_extra_coords_list = []
-            coord_names = list(self[0].extra_coords.keys())
+            coord_names = list(self.data[0]._extra_coords.keys())
             for coord_name in coord_names:
-                if self[0].extra_coords[coord_name]["axis"] == self.common_axis:
-                    coord_unit = self[0].extra_coords[coord_name]["value"].unit
-                    qs = tuple([np.asarray(c.extra_coords["time"]["value"].to(coord_unit).value)
-                                for c in self])
-                    common_extra_coords[coord_name] = u.Quantity(
-                        np.concatenate(qs), unit=coord_unit)
+                if self.data[0]._extra_coords[coord_name]["axis"] == self._common_axis:
+                    try:
+                        coord_unit = self.data[0]._extra_coords[coord_name]["value"].unit
+                        qs = tuple([np.asarray(
+                            c._extra_coords[coord_name]["value"].to(coord_unit).value)
+                                    for c in self.data])
+                        common_extra_coords[coord_name] = u.Quantity(np.concatenate(qs),
+                                                                     unit=coord_unit)
+                    except AttributeError:
+                        qs = tuple([np.asarray(c._extra_coords[coord_name]["value"])
+                                    for c in self.data])
+                        common_extra_coords[coord_name] = np.concatenate(qs)
         else:
             common_extra_coords = None
         return common_extra_coords
@@ -587,7 +592,7 @@ Axis Types of 1st NDCube: {axis_type}
     @property
     def index_as_cube(self):
         """
-        Method to slice the NDcubesequence instance as a single cube
+        Method to slice the NDCubesequence instance as a single cube
 
         Example
         -------
@@ -599,7 +604,7 @@ Axis Types of 1st NDCube: {axis_type}
         >>> # Return same slice using this function
         >>> cs.index_sequence_as_cube[3:6, 0, :] # doctest: +SKIP
         """
-        if self.common_axis is None:
+        if self._common_axis is None:
             raise ValueError("common_axis cannot be None")
         return _IndexAsCubeSlicer(self)
 


### PR DESCRIPTION
This PR makes ```NDCubeSequence.common_axis_extra_coords``` work and also makes ```common_axis``` attribute hidden.