### PR TITLE
fixing the error of slicing across one cube in cubesequence 

### DIFF
--- a/ndcube/cube_utils.py
+++ b/ndcube/cube_utils.py
@@ -252,7 +252,7 @@ def _convert_cube_like_slice_to_sequence_slices(cube_like_slice, cumul_cube_leng
         else:
             sequence_slice = slice(sequence_start_index, sequence_stop_index, cube_like_slice.step)
     else:
-        cube_slice = slice(cube_start_index, cube_stop_index, cube_like_slice.step)
+        cube_slice = [slice(cube_start_index, cube_stop_index, cube_like_slice.step)]
         sequence_slice = slice(sequence_start_index, sequence_stop_index+1, cube_like_slice.step)
     return sequence_slice, cube_slice
 

--- a/ndcube/tests/test_cube_utils.py
+++ b/ndcube/tests/test_cube_utils.py
@@ -54,7 +54,7 @@ def test_convert_cube_like_index_to_sequence_indices(test_input, expected):
 
 @pytest.mark.parametrize("test_input,expected", [
     (cu._convert_cube_like_slice_to_sequence_slices(
-        slice(2, 5), np.array([8, 16, 24, 32])), (slice(0, 1), slice(2, 5))),
+        slice(2, 5), np.array([8, 16, 24, 32])), (slice(0, 1), [slice(2, 5)])),
     (cu._convert_cube_like_slice_to_sequence_slices(
         slice(5, 15), np.array([8, 16, 24, 32])), (slice(0, 2), [slice(5, 8), slice(0, 7)])),
     (cu._convert_cube_like_slice_to_sequence_slices(


### PR DESCRIPTION
like seq[0:1] for cube with first dimension size 2.
@DanRyanIrish 