### PR TITLE
[WIP] Implement an Abstract Base Class to define the NDData API

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -185,8 +185,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
         else:
             self._extra_coords_wcs_axis = None
         # Initialize NDCube.
-        super(NDCube, self).__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,
-                                     meta=meta, unit=unit, copy=copy, **kwargs)
+        super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,
+                         meta=meta, unit=unit, copy=copy, **kwargs)
 
     def pixel_to_world(self, quantity_axis_list, origin=0):
         list_arg = []

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -85,6 +85,11 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
         e.g. WAVE or HPLT-TAN for wavelength of helioprojected latitude.
         """
 
+    @abc.abstractproperty
+    def extra_coords(self):
+        """
+        """
+
     @abc.abstractmethod
     def crop_by_coords(self, lower_left_corner, dimension_widths):
         """

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -77,18 +77,14 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
             reverse of the wcs axis order.
         """
 
+    # InheritDocstrings doesn't work on property methods.
     @abc.abstractproperty
     def dimensions(self):
-        """
-        Returns a named tuple with two attributes: 'shape' gives the shape
-        of the data dimensions; 'axis_types' gives the WCS axis type of each dimension,
-        e.g. WAVE or HPLT-TAN for wavelength of helioprojected latitude.
-        """
+        pass
 
     @abc.abstractproperty
     def extra_coords(self):
-        """
-        """
+        pass
 
     @abc.abstractmethod
     def crop_by_coords(self, lower_left_corner, dimension_widths):
@@ -260,7 +256,11 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
 
     @property
     def dimensions(self):
-        # The docstring is defined in NDDataBase
+        """
+        Returns a named tuple with two attributes: 'shape' gives the shape
+        of the data dimensions; 'axis_types' gives the WCS axis type of each dimension,
+        e.g. WAVE or HPLT-TAN for wavelength of helioprojected latitude.
+        """
 
         ctype = list(self.wcs.wcs.ctype)
         axes_ctype = []
@@ -289,7 +289,19 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
 
     @property
     def extra_coords(self):
-        # The docstring is defined in NDDataBase
+        """
+        Dictionary of extra coords where each key is the name of an extra
+        coordinate supplied by user during instantiation of the NDCube.
+
+        The value of each key is itself a dictionary with the following keys:
+          | 'axis': `int`
+          |     The number of the data axis to which the extra coordinate corresponds.
+          | 'value': `astropy.units.Quantity` or array-like
+          |     The value of the extra coordinate at each pixel/array element along the
+          |     corresponding axis (given by the 'axis' key, above).  Note this means
+          |     that the length of 'value' must be equal to the length of the data axis
+          |     to which is corresponds.
+        """
 
         if not self._extra_coords_wcs_axis:
             result = None

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -14,12 +14,12 @@ from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
 from ndcube import DimensionPair
 
 
-__all__ = ['NDCube', 'NDCubeOrdered']
+__all__ = ['NDCubeBase', 'NDCube', 'NDCubeOrdered']
 
 
 class NDCubeMetaClass(abc.ABCMeta, InheritDocstrings):
     """
-    Metaclass for NDCube.
+    A metaclass that combines `abc.ABCMeta` and `~astropy.utils.misc.InheritDocstrings`.
     """
 
 

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -194,6 +194,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
                          meta=meta, unit=unit, copy=copy, **kwargs)
 
     def pixel_to_world(self, quantity_axis_list, origin=0):
+        # The docstring is defined in NDDataBase
+
         list_arg = []
         indexed_not_as_one = []
         result = []
@@ -217,6 +219,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
         return result[::-1]
 
     def world_to_pixel(self, quantity_axis_list, origin=0):
+        # The docstring is defined in NDDataBase
+
         list_arg = []
         indexed_not_as_one = []
         result = []
@@ -256,6 +260,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
 
     @property
     def dimensions(self):
+        # The docstring is defined in NDDataBase
+
         ctype = list(self.wcs.wcs.ctype)
         axes_ctype = []
         for i, axis in enumerate(self.missing_axis):
@@ -265,6 +271,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
         return DimensionPair(shape=shape, axis_types=axes_ctype[::-1])
 
     def crop_by_coords(self, lower_left_corner, dimension_widths):
+        # The docstring is defined in NDDataBase
+
         n_dim = len(self.dimensions.shape)
         if len(lower_left_corner) != len(dimension_widths) != n_dim:
             raise ValueError("lower_left_corner and dimension_widths must have "
@@ -281,6 +289,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
 
     @property
     def extra_coords(self):
+        # The docstring is defined in NDDataBase
+
         if not self._extra_coords_wcs_axis:
             result = None
         else:

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -125,7 +125,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
         The array holding the actual data in this object.
 
     wcs: `ndcube.wcs.wcs.WCS`
-        The WCS object containing the axes information
+        The WCS object containing the axes' information
 
     uncertainty : any type, optional
         Uncertainty in the dataset. Should have an attribute uncertainty_type

--- a/ndcube/wcs_util.py
+++ b/ndcube/wcs_util.py
@@ -10,8 +10,6 @@ import numpy as np
 from astropy import wcs
 from astropy.wcs._wcs import InconsistentAxisTypesError
 
-from ndcube import cube_utils as cu
-
 
 class WCS(wcs.WCS):
 


### PR DESCRIPTION
This refactors the `NDCube` class a little so that the API is defined in a `NDCubeBase` object, which can not be instantiated itself but allows tests like `isinstance(inst, NDCubeBase)` to ensure API compatibility with things that look like `NDCube` 

This is now based on #34 