### PR TITLE
Arithmetic Mixin in NDCube's inheritance

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -110,7 +110,7 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
         """
 
 
-class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, NDCubeBase):
+class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMixin, NDCubeBase):
     """
     Class representing N dimensional cubes.
     Extra arguments are passed on to `~astropy.nddata.NDData`.


### PR DESCRIPTION
This PR adds astropy.nddata.NDArithmeticMixin to NDCube's inheritance for future investigation of its usefulness in performing arithmetic operations on NDCubes.