### PR TITLE
remove extra_coords from the NDCubeBase class.

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -80,10 +80,6 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
     def dimensions(self):
         pass
 
-    @abc.abstractproperty
-    def extra_coords(self):
-        pass
-
     @abc.abstractmethod
     def crop_by_coords(self, lower_left_corner, dimension_widths):
         """


### PR DESCRIPTION
The plan is to do improvements to the rest of the package to support not having
extra_coords during the 1.x cycle

closes #43 