### PR TITLE
Refactor NDCubeSequence.common_axis_extra_coords

### DIFF
--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -34,7 +34,10 @@ class NDCubeSequence:
     def __init__(self, data_list, meta=None, common_axis=None, **kwargs):
         self.data = data_list
         self.meta = meta
-        self._common_axis = common_axis
+        if common_axis is not None:
+            self._common_axis = int(common_axis)
+        else:
+            self._common_axis = common_axis
 
     def __getitem__(self, item):
         return utils.sequence.slice_sequence(self, item)

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -131,37 +131,19 @@ Axis Types of 1st NDCube: {axis_type}
 
     @property
     def common_axis_extra_coords(self):
-        common_extra_coords = None
-        if self._common_axis in range(self.data[0].wcs.naxis):
-            if self.data[0].extra_coords:
-                common_extra_coords = {}
-                coord_names = list(self.data[0].extra_coords.keys())
-                for coord_name in coord_names:
-                    if self.data[0].extra_coords[coord_name]["axis"] == self._common_axis:
-                        try:
-                            coord_unit = self.data[0].extra_coords[coord_name]["value"].unit
-                            qs = tuple([np.asarray(
-                                c.extra_coords[coord_name]["value"].to(coord_unit).value)
-                                        for c in self.data])
-                            common_extra_coords[coord_name] = u.Quantity(np.concatenate(qs),
-                                                                         unit=coord_unit)
-                        except AttributeError:
-                            qs = tuple([np.asarray(c.extra_coords[coord_name]["value"])
-                                        for c in self.data])
-                            common_extra_coords[coord_name] = np.concatenate(qs)
-        return common_extra_coords
+        if not isinstance(self._common_axis, int):
+            raise ValueError("Common axis is not set.")
+        # Get names and units of coords along common axis.
+        axis_coord_names, axis_coord_units = utils.sequence._get_axis_extra_coord_names_and_units(
+            self.data, self._common_axis)
+        # Compile dictionary of common axis extra coords.
+        return utils.sequence._get_int_axis_extra_coords(
+            self.data, axis_coord_names, axis_coord_units, self._common_axis)
 
     @property
     def sequence_axis_extra_coords(self):
-        # Identify all extra coord names not assigned to a cube data axis.
-        sequence_coord_names = []
-        for cube in self.data:
-            all_extra_coords = cube.extra_coords
-            all_extra_coords_keys = list(all_extra_coords.keys())
-            for coord_key in all_extra_coords_keys:
-                if all_extra_coords[coord_key]["axis"] is None:
-                    sequence_coord_names.append(coord_key)
-        sequence_coord_names = set(sequence_coord_names)
+        sequence_coord_names, sequence_coord_units = \
+          utils.sequence._get_axis_extra_coord_names_and_units(self.data, None)
         # Define empty dictionary which will hold the extra coord
         # values not assigned a cube data axis.
         sequence_extra_coords = {}
@@ -183,9 +165,9 @@ Axis Types of 1st NDCube: {axis_type}
                     # along the sequence axis, we will keep checking as we
                     # move through the cubes until all cubes are checked or
                     # we have found a unit.
-                    if not sequence_coord_units[i]:
-                        if isinstance(cube_extra_coords[j][coord_key]["value"], u.Quantity):
-                            sequence_coord_units[i] = cube_extra_coords[j][coord_key]["value"].unit
+                    if (isinstance(cube_extra_coords[j][coord_key]["value"], u.Quantity) and
+                            not sequence_coord_units[i]):
+                        sequence_coord_units[i] = cube_extra_coords[j][coord_key]["value"].unit
                 except KeyError:
                     pass
             # If the extra coord is normally a Quantity, replace all
@@ -204,10 +186,9 @@ Axis Types of 1st NDCube: {axis_type}
                 coord_values = list(coord_values.value)
                 for index in w_none:
                     coord_values.insert(index, np.nan)
-                coord_values = u.Quantity(coord_values, unit=sequence_coord_units[i])
+                coord_values = u.Quantity(coord_values, unit=sequence_coord_units[i]).flatten()
             else:
                 coord_values[w_none] = np.nan
-            # Enter sequence extra coord into dictionary
             sequence_extra_coords[coord_key] = coord_values
         return sequence_extra_coords
 

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -218,7 +218,10 @@ def test_common_axis_extra_coords(test_input, expected):
     output = test_input.common_axis_extra_coords
     assert output.keys() == expected.keys()
     for key in output.keys():
-        assert (output[key] == expected[key]).all()
+        try:
+            assert output[key] == expected[key]
+        except ValueError:
+            assert (output[key] == expected[key]).all()
 
 
 @pytest.mark.parametrize(

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -95,7 +95,7 @@ cube2_time_common = NDCube(data, wm, extra_coords=[
       for i in range(1, data.shape[1]+1)])])
 
 seq = NDCubeSequence([cube1, cube2, cube3, cube4], common_axis=0)
-seq_bad_common_axis = NDCubeSequence([cube1, cube2, cube3, cube4], common_axis='0')
+seq_bad_common_axis = NDCubeSequence([cube1, cube2, cube3, cube4], common_axis=None)
 seq_time_common = NDCubeSequence([cube1_time_common, cube2_time_common], common_axis=1)
 seq1 = NDCubeSequence([cube1, cube2, cube3, cube4])
 seq2 = NDCubeSequence([cube1, cube2_no_no, cube3_no_time, cube4])

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -6,7 +6,6 @@ Utilities for ndcube.
 
 import numpy as np
 
-
 __all__ = ['wcs_axis_to_data_axis', 'data_axis_to_wcs_axis', 'select_order']
 
 


### PR DESCRIPTION
This refactor means NDCubeSequence.common_axis_extra_coords no longer assumes all cubes have the same extra_coords as the first cube.  But performs a more rigorous search along the lines of NDCubeSequence.sequence_axis_extra_coords.  See ndcube/sunpy Issue #54.