### PR TITLE
Make input arg formats consistent with astropy WCS APE

### DIFF
--- a/docs/ndcube.rst
+++ b/docs/ndcube.rst
@@ -317,13 +317,13 @@ we would do::
 
   >>> import astropy.units as u
   >>> real_world_coords = my_cube.pixel_to_world(
-  ... [Quantity([2], unit=u.pix), Quantity([3], unit=u.pix), Quantity([4], unit=u.pix)])
+  ... Quantity([2], unit=u.pix), Quantity([3], unit=u.pix), Quantity([4], unit=u.pix))
 
 To convert two pixels with pixel coordinates (2, 3, 4) and (5, 6, 7),
 we would call pixel_to_world like so::
 
   >>> real_world_coords = my_cube.pixel_to_world(
-  ... [Quantity([2, 5], unit=u.pix), Quantity([3, 6], unit=u.pix), Quantity([4, 7], unit=u.pix)])
+  ... Quantity([2, 5], unit=u.pix), Quantity([3, 6], unit=u.pix), Quantity([4, 7], unit=u.pix))
 
 As can be seen, since each `~astropy.units.Quantity` describes a
 different pixel coordinate of the same number of pixels, the lengths
@@ -350,8 +350,8 @@ is a list of `~astropy.units.Quantity` objects in pixel units is
 returned::
 
   >>> pixel_coords = my_cube.world_to_pixel(
-  ... [Quantity(1.40006967, unit="deg"), Quantity(1.49986193, unit="deg"),
-  ...  Quantity(1.10000000e-09,  unit="m")])
+  ... Quantity(1.40006967, unit="deg"), Quantity(1.49986193, unit="deg"),
+  ...  Quantity(1.10000000e-09,  unit="m"))
   >>> pixel_coords
   [<Quantity 2.00000001 pix>, <Quantity 3. pix>, <Quantity 4. pix>]
 

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -27,7 +27,7 @@ class NDCubeMetaClass(abc.ABCMeta, InheritDocstrings):
 class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
 
     @abc.abstractmethod
-    def pixel_to_world(self, quantity_axis_list):
+    def pixel_to_world(self, *quantity_axis_list):
         """
         Convert a pixel coordinate to a data (world) coordinate by using
         `~astropy.wcs.WCS.all_pix2world`.
@@ -36,6 +36,7 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
         ----------
         quantity_axis_list : iterable
             An iterable of `~astropy.units.Quantity` with unit as pixel `pix`.
+            Note that these quantities must be entered as separate arguments, not as one list.
 
         origin : `int`.
             Origin of the top-left corner. i.e. count from 0 or 1.
@@ -52,7 +53,7 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
         """
 
     @abc.abstractmethod
-    def world_to_pixel(self, quantity_axis_list):
+    def world_to_pixel(self, *quantity_axis_list):
         """
         Convert a world coordinate to a data (pixel) coordinate by using
         `~astropy.wcs.WCS.all_world2pix`.
@@ -61,6 +62,7 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
         ----------
         quantity_axis_list : iterable
             A iterable of `~astropy.units.Quantity`.
+            Note that these quantities must be entered as separate arguments, not as one list.
 
         origin : `int`
             Origin of the top-left corner. i.e. count from 0 or 1.
@@ -186,7 +188,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
         super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,
                          meta=meta, unit=unit, copy=copy, **kwargs)
 
-    def pixel_to_world(self, quantity_axis_list):
+    def pixel_to_world(self, *quantity_axis_list):
         # The docstring is defined in NDDataBase
 
         origin = 0
@@ -212,7 +214,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
             result.append(u.Quantity(pixel_to_world[index], unit=self.wcs.wcs.cunit[index]))
         return result[::-1]
 
-    def world_to_pixel(self, quantity_axis_list):
+    def world_to_pixel(self, *quantity_axis_list):
         # The docstring is defined in NDDataBase
 
         origin = 0
@@ -292,8 +294,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
             raise ValueError("min_coord_values and interval_widths must have "
                              "same number of elements as number of data dimensions.")
         # Convert coords of lower left corner to pixel units.
-        lower_pixels = self.world_to_pixel(min_coord_values)
-        upper_pixels = self.world_to_pixel([min_coord_values[i] + interval_widths[i]
+        lower_pixels = self.world_to_pixel(*min_coord_values)
+        upper_pixels = self.world_to_pixel(*[min_coord_values[i] + interval_widths[i]
                                             for i in range(n_dim)])
         # Round pixel values to nearest integer.
         lower_pixels = [int(np.rint(l.value)) for l in lower_pixels]

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -645,21 +645,21 @@ def test_slicing_error(test_input):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    (cubem[1].pixel_to_world([
+    (cubem[1].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
         ])[0],
      wm.all_pix2world(
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix), wm.wcs.crpix[2] - 1, 0)[-2]),
-    (cubem[1].pixel_to_world([
+    (cubem[1].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
         ])[1],
      wm.all_pix2world(
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix), wm.wcs.crpix[2] - 1, 0)[0]),
-    (cubem[0:2].pixel_to_world([
+    (cubem[0:2].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
@@ -668,7 +668,7 @@ def test_slicing_error(test_input):
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix), 0)[-1]),
-    (cubem[0:2].pixel_to_world([
+    (cubem[0:2].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
@@ -677,7 +677,7 @@ def test_slicing_error(test_input):
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix), 0)[1]),
-    (cubem[0:2].pixel_to_world([
+    (cubem[0:2].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
@@ -686,7 +686,7 @@ def test_slicing_error(test_input):
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix), 0)[0]),
-    (cube[1].pixel_to_world([
+    (cube[1].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
         ])[0],
@@ -694,7 +694,7 @@ def test_slicing_error(test_input):
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix), wt.wcs.crpix[2] - 1,
          wt.wcs.crpix[3] - 1, 0)[1]),
-    (cube[1].pixel_to_world([
+    (cube[1].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
         ])[1],
@@ -702,7 +702,7 @@ def test_slicing_error(test_input):
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix), wt.wcs.crpix[2] - 1,
          wt.wcs.crpix[3] - 1, 0)[0]),
-    (cube[0:2].pixel_to_world([
+    (cube[0:2].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
@@ -711,7 +711,7 @@ def test_slicing_error(test_input):
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix), wt.wcs.crpix[3] - 1, 0)[2]),
-    (cube[0:2].pixel_to_world([
+    (cube[0:2].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
@@ -720,7 +720,7 @@ def test_slicing_error(test_input):
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix),
          u.Quantity(np.arange(4), unit=u.pix), wt.wcs.crpix[3] - 1, 0)[1]),
-    (cube[0:2].pixel_to_world([
+    (cube[0:2].pixel_to_world(*[
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix),
         u.Quantity(np.arange(4), unit=u.pix)
@@ -734,14 +734,14 @@ def test_pixel_to_world(test_input, expected):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    (cubem[1].world_to_pixel([
+    (cubem[1].world_to_pixel(*[
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.m)
         ])[1],
      wm.all_world2pix(
          u.Quantity(np.arange(4), unit=u.deg),
          u.Quantity(np.arange(4), unit=u.m), wm.wcs.crpix[2] - 1, 0)[0]),
-    (cubem[0:2].world_to_pixel([
+    (cubem[0:2].world_to_pixel(*[
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.m)
@@ -750,7 +750,7 @@ def test_pixel_to_world(test_input, expected):
          u.Quantity(np.arange(4), unit=u.deg),
          u.Quantity(np.arange(4), unit=u.deg),
          u.Quantity(np.arange(4), unit=u.m), 0)[-1]),
-    (cubem[0:2].world_to_pixel([
+    (cubem[0:2].world_to_pixel(*[
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.m)
@@ -759,7 +759,7 @@ def test_pixel_to_world(test_input, expected):
          u.Quantity(np.arange(4), unit=u.deg),
          u.Quantity(np.arange(4), unit=u.deg),
          u.Quantity(np.arange(4), unit=u.m), 0)[1]),
-    (cubem[0:2].world_to_pixel([
+    (cubem[0:2].world_to_pixel(*[
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.m)
@@ -768,7 +768,7 @@ def test_pixel_to_world(test_input, expected):
          u.Quantity(np.arange(4), unit=u.deg),
          u.Quantity(np.arange(4), unit=u.deg),
          u.Quantity(np.arange(4), unit=u.m), 0)[0]),
-    (cube[1].world_to_pixel([
+    (cube[1].world_to_pixel(*[
         u.Quantity(np.arange(4), unit=u.m),
         u.Quantity(np.arange(4), unit=u.min)
         ])[0],
@@ -776,7 +776,7 @@ def test_pixel_to_world(test_input, expected):
          u.Quantity(np.arange(4), unit=u.m),
          u.Quantity(np.arange(4), unit=u.min), wt.wcs.crpix[2] - 1,
          wt.wcs.crpix[3] - 1, 0)[1]),
-    (cube[1].world_to_pixel([
+    (cube[1].world_to_pixel(*[
         u.Quantity(np.arange(4), unit=u.m),
         u.Quantity(np.arange(4), unit=u.min)
         ])[1],
@@ -784,7 +784,7 @@ def test_pixel_to_world(test_input, expected):
          u.Quantity(np.arange(4), unit=u.m),
          u.Quantity(np.arange(4), unit=u.min), wt.wcs.crpix[2] - 1,
          wt.wcs.crpix[3] - 1, 0)[0]),
-    (cube[0:2].world_to_pixel([
+    (cube[0:2].world_to_pixel(*[
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.m),
         u.Quantity(np.arange(4), unit=u.min)
@@ -793,7 +793,7 @@ def test_pixel_to_world(test_input, expected):
          u.Quantity(np.arange(4), unit=u.deg),
          u.Quantity(np.arange(4), unit=u.m),
          u.Quantity(np.arange(4), unit=u.min), wt.wcs.crpix[3] - 1, 0)[2]),
-    (cube[0:2].world_to_pixel([
+    (cube[0:2].world_to_pixel(*[
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.m),
         u.Quantity(np.arange(4), unit=u.min)
@@ -802,7 +802,7 @@ def test_pixel_to_world(test_input, expected):
          u.Quantity(np.arange(4), unit=u.deg),
          u.Quantity(np.arange(4), unit=u.m),
          u.Quantity(np.arange(4), unit=u.min), wt.wcs.crpix[3] - 1, 0)[1]),
-    (cube[0:2].world_to_pixel([
+    (cube[0:2].world_to_pixel(*[
         u.Quantity(np.arange(4), unit=u.deg),
         u.Quantity(np.arange(4), unit=u.m),
         u.Quantity(np.arange(4), unit=u.min)


### PR DESCRIPTION
In previous merge, it was overlooked that the inputs to ```pixel_to_world``` and ```world_to_pixel``` must be entered as separate args to be consistent with the astropy WCS APE.  This PR rectifies that and adjusts tests, docs, etc. accordingly.