### PR TITLE
New method: NDCube.all_world_coords

### DIFF
--- a/docs/ndcube.rst
+++ b/docs/ndcube.rst
@@ -379,7 +379,7 @@ coordinates for each pixel along a given data axis.  So in the case of
 we could call::
 
   >>> my_cube.all_world_coords(axes=2)
-  [<Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>]
+  <Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>
 
 Note we set ``axes`` to ``2`` since ``axes`` is defined in data axis
 order.  We can also define the axis we want using any unique substring
@@ -390,7 +390,7 @@ from the axis names defined in
   ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl')
   >>> # Since 'wl' is unique to the wavelength axis name, let's use that.
   >>> my_cube.all_world_coords(axes='wl')
-  [<Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>]
+  <Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>
 
 Notice how this returns the same result as when we set ``axes`` to
 the corresponding data axis number.  As discussed above, some WCS axes
@@ -408,19 +408,19 @@ longitude x latitude axis lengths.  For example::
   >>> longitude.shape
   (3, 4)
   >>> longitude
-  [<Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
-            [1.        , 1.        , 1.        , 1.        ],
-            [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>]
+  <Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
+             [1.        , 1.        , 1.        , 1.        ],
+             [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>
 
 It is also possible to request more than one axis's world coordinates
 by setting ``axes`` to an iterable of data axis number and/or axis
 type strings.::
 
   >>> my_cube.all_world_coords(axes=(2, 'lon'))
-  [<Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>,
+  (<Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>,
    <Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
               [1.        , 1.        , 1.        , 1.        ],
-              [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>]
+              [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>)
 
 Notice that the axes' coordinates have been returned in the same order
 in which they were requested.  Finally, if the user wanted the world
@@ -428,7 +428,7 @@ coordinates for all the axes, ```axes`` can be set to ``None``, which
 is in fact the default.::
 
   >>> my_cube.all_world_coords()
-  [<Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
+  (<Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
             [1.        , 1.        , 1.        , 1.        ],
             [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>,
    <Quantity [[1.26915033e-05, 4.99987815e-01, 9.99962939e-01, 
@@ -437,7 +437,7 @@ is in fact the default.::
              1.49989848e+00],
             [1.26915033e-05, 4.99987815e-01, 9.99962939e-01,
              1.49986193e+00]] deg>,
-   <Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>]
+   <Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>)
 
 As stated at the top of this guide, `~ndcube.NDCube` is only written
 to handle single arrays described by single WCS instances.  For cases

--- a/docs/ndcube.rst
+++ b/docs/ndcube.rst
@@ -396,7 +396,7 @@ the corresponding data axis number.
 
 As discussed above, some WCS axes
 are not independent.  For those axes,
-`~ndcube.NDCube.all_world_coords()` returns a
+`~ndcube.NDCube.all_world_coords` returns a
 `~astropy.units.Quantity` with the same number of dimensions as
 dependent axes.  For example, helioprojective longitude and latitude
 are dependent.  Therefore if we ask for longitude, we will get back a

--- a/docs/ndcube.rst
+++ b/docs/ndcube.rst
@@ -301,7 +301,7 @@ translate between pixel and real world coordinates.  For this purpose,
 astropy functions, `astropy.wcs.WCS.all_pix2world` and
 `astropy.wcs.WCS.all_world2pix`. These are
 `~ndcube.NDCube.pixel_to_world`, `~ndcube.NDCube.world_to_pixel`, and
-`~ndcube.NDCube.all_world_coords`. It is highly recommended that when
+`~ndcube.NDCube.axis_world_coords`. It is highly recommended that when
 using `~ndcube.NDCube` these convenience wrappers are used rather than
 the original astropy functions for a few reasons. For example, they
 can track house-keeping data, are aware of "missing" WCS axis, are
@@ -368,11 +368,11 @@ different instruments with overlapping fields of view.
 There are times however, when you only want to know the real world
 coordinates of the `~ndcube.NDCube` field of view.  To make this easy,
 `~ndcube.NDCube` has a another coordinate transformation method
-`~ndcube.NDCube.all_world_coords`.  This method returns the real world
+`~ndcube.NDCube.axis_world_coords`.  This method returns the real world
 coordinates for each pixel along a given data axis.  So in the case of
 ``my_cube``, if we wanted the wavelength axis we could call::
 
-  >>> my_cube.all_world_coords(axes=2)
+  >>> my_cube.axis_world_coords(2)
   <Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>
 
 Note we set ``axes`` to ``2`` since ``axes`` is defined in data axis
@@ -383,7 +383,7 @@ from the axis names defined in
   >>> my_cube.world_axis_physical_types
   ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl')
   >>> # Since 'wl' is unique to the wavelength axis name, let's use that.
-  >>> my_cube.all_world_coords(axes='wl')
+  >>> my_cube.axis_world_coords('wl')
   <Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>
 
 Notice how this returns the same result as when we set ``axes`` to
@@ -391,14 +391,14 @@ the corresponding data axis number.
 
 As discussed above, some WCS axes
 are not independent.  For those axes,
-`~ndcube.NDCube.all_world_coords` returns a
+`~ndcube.NDCube.axis_world_coords` returns a
 `~astropy.units.Quantity` with the same number of dimensions as
 dependent axes.  For example, helioprojective longitude and latitude
 are dependent.  Therefore if we ask for longitude, we will get back a
 2D `~astropy.units.Quantity` with the same shape as the longitude x
 latitude axes lengths.  For example::
 
-  >>> longitude = my_cube.all_world_coords(axes='lon')
+  >>> longitude = my_cube.axis_world_coords('lon')
   >>> my_cube.dimensions
   <Quantity [3., 4., 5.] pix>
   >>> longitude.shape
@@ -412,7 +412,7 @@ It is also possible to request more than one axis's world coordinates
 by setting ``axes`` to an iterable of data axis number and/or axis
 type strings.::
 
-  >>> my_cube.all_world_coords(axes=(2, 'lon'))
+  >>> my_cube.axis_world_coords(2, 'lon')
   (<Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>,
    <Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
               [1.        , 1.        , 1.        , 1.        ],
@@ -425,7 +425,7 @@ Finally, if the user wants the world
 coordinates for all the axes, ``axes`` can be set to ``None``, which
 is in fact the default.::
 
-  >>> my_cube.all_world_coords()
+  >>> my_cube.axis_world_coords()
   (<Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
             [1.        , 1.        , 1.        , 1.        ],
             [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>,

--- a/docs/ndcube.rst
+++ b/docs/ndcube.rst
@@ -77,7 +77,7 @@ uncertainty.  However, this is not required.
 Dimensions
 ----------
 
-```NDCube``` has useful properties for inspecting its data shape and
+`~ndcube.NDCube` has useful properties for inspecting its data shape and
 axis types, `~ndcube.NDCube.dimensions` and
 `~ndcube.NDCube.world_axis_physical_types`::
 
@@ -194,7 +194,7 @@ integer (pixel) steps along an axis can be stored within the object
 and accessed via the `~ndcube.NDCube.extra_coords` property. To
 attach extra coordinates to an `~ndcube.NDCube` instance, provide an
 iterable of tuples of the form (`str`, `int`,
-`~astropy.units.Quantity` or `list`) during instantiation.  The 0th
+`~astropy.units.Quantity` or array-like) during instantiation.  The 0th
 entry gives the name of the coordinate, the 1st entry gives the data
 axis to which the extra coordinate corresponds, and the 2nd entry
 gives the value of that coordinate at each pixel along the axis.  So
@@ -278,7 +278,7 @@ In addition to this, some optional kwargs can be used to customize the
 plot.  The ``axis_ranges`` kwarg can be used to set the axes ticklabels.  See the
 `~sunpy.visualization.imageanimator.ImageAnimatorWCS` documentation for
 more detail.  However, if this is not set, the axis ticklabels are
-automatically derived as real world coordinates from the WCS obect
+automatically derived in real world coordinates from the WCS object
 within the `~ndcube.NDCube`.
 
 By default the final two data dimensions are used for the plot
@@ -372,17 +372,16 @@ different instruments with overlapping fields of view.
 
 There are times however, when you only want to know the real world
 coordinates of the `~ndcube.NDCube` field of view.  To make this easy,
-`~ndcube.NDCube.` has a another coordinate transformation method
+`~ndcube.NDCube` has a another coordinate transformation method
 `~ndcube.NDCube.all_world_coords`.  This method returns the real world
 coordinates for each pixel along a given data axis.  So in the case of
-``my_cube`` we've been using above, if we wanted the wavelength axis,
-we could call::
+``my_cube``, if we wanted the wavelength axis we could call::
 
   >>> my_cube.all_world_coords(axes=2)
   <Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>
 
 Note we set ``axes`` to ``2`` since ``axes`` is defined in data axis
-order.  We can also define the axis we want using any unique substring
+order.  We can also define the axis using any unique substring
 from the axis names defined in
 `ndcube.NDCube.world_axis_physical_types`::
 
@@ -393,14 +392,16 @@ from the axis names defined in
   <Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>
 
 Notice how this returns the same result as when we set ``axes`` to
-the corresponding data axis number.  As discussed above, some WCS axes
+the corresponding data axis number.
+
+As discussed above, some WCS axes
 are not independent.  For those axes,
 `~ndcube.NDCube.all_world_coords()` returns a
-`~astropy.units.Quantity` with the same number of dimensions are there
-are dependent axes.  For example, helioprojective longitude and
-latitude are dependent.  Therefore if we ask for longitude, we will
-get back a 2D `~astropy.units.Quantity` with the same shape as the
-longitude x latitude axis lengths.  For example::
+`~astropy.units.Quantity` with the same number of dimensions as
+dependent axes.  For example, helioprojective longitude and latitude
+are dependent.  Therefore if we ask for longitude, we will get back a
+2D `~astropy.units.Quantity` with the same shape as the longitude x
+latitude axes lengths.  For example::
 
   >>> longitude = my_cube.all_world_coords(axes='lon')
   >>> my_cube.dimensions
@@ -423,7 +424,9 @@ type strings.::
               [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>)
 
 Notice that the axes' coordinates have been returned in the same order
-in which they were requested.  Finally, if the user wanted the world
+in which they were requested.
+
+Finally, if the user wanted the world
 coordinates for all the axes, ```axes`` can be set to ``None``, which
 is in fact the default.::
 
@@ -443,4 +446,4 @@ As stated at the top of this guide, `~ndcube.NDCube` is only written
 to handle single arrays described by single WCS instances.  For cases
 where data is made up of multiple arrays, each described by different
 WCS translations, `ndcube` has another class,
-``~ndcube.NDCubeSequence`, which will discuss in the next section.
+`~ndcube.NDCubeSequence`, which will discuss in the next section.

--- a/docs/ndcube.rst
+++ b/docs/ndcube.rst
@@ -24,8 +24,8 @@ where every value is 1::
 
 Now let's create an `astropy.wcs.WCS` object describing the
 translation from the array element coordinates to real world
-coordinates.  Let's the first data axis be helioprojective longitude,
-the second by helioprojective latitude, and the third be wavelength.
+coordinates.  Let the first data axis be helioprojective longitude,
+the second be helioprojective latitude, and the third be wavelength.
 Note that due to (confusing) convention, the order of the axes in the
 WCS object is reversed relative to the data array.
 
@@ -55,7 +55,7 @@ tracking "missing axes", etc. (See section on :ref:`missing_axes`.)
 Thanks to the fact that `~ndcube.NDCube` is subclassed from
 `astropy.nddata.NDData`, you can also supply additional data to the
 `~ndcube.NDCube` instance.  These include: metadata (`dict` or
-dict-like) located at `NDCube.metadata`; a data mask
+dict-like) located at `NDCube.meta`; a data mask
 (boolean `numpy.ndarray`) located at`NDCube.mask` highlighting, for
 example, reliable and unreliable pixels; an uncertainty array
 (`numpy.ndarray`) located at `NDCube.uncertainty` describing the
@@ -77,7 +77,7 @@ uncertainty.  However, this is not required.
 Dimensions
 ----------
 
-NDCube has useful properties for inspecting its data shape and
+```NDCube``` has useful properties for inspecting its data shape and
 axis types, `~ndcube.NDCube.dimensions` and
 `~ndcube.NDCube.world_axis_physical_types`::
 
@@ -89,9 +89,12 @@ axis types, `~ndcube.NDCube.dimensions` and
 `~ndcube.NDCube.dimensions` returns an `~astropy.units.Quantity` of
 pixel units giving the length of each dimension in the
 `~ndcube.NDCube` while `~ndcube.NDCube.world_axis_physical_types`
-returns an iterable of strings denoted the type of physical property
-represented by each axis.  Here the shape and axis types are given in
-data order, not WCS order.
+returns an iterable of strings denoting the type of physical property
+represented by each axis.  The axis names are in accordance with the
+International Virtual Observatory Alliance (IVOA) `UCD1+ controlled
+vocabulary <
+http://www.ivoa.net/documents/REC/UCD/UCDlist-20070402.html>`. Here 
+the shape and axis types are given in data order, not WCS order. 
 
 .. _ndcube_slicing:
 
@@ -99,11 +102,11 @@ Slicing
 -------
 
 Arguably NDCube's most powerful capability is its slicing.  Slicing an
-`~ndcube.NDCube` object using the standard slicing notation allows
+`~ndcube.NDCube` instance using the standard slicing notation allows
 users to access sub-regions of their data while simultaneously slicing
 not only the other array attributes (e.g. uncertainty, mask, etc.) but
 also the WCS object.  This ensures that even though the data array has
-changed size and shape, each array element will still corresponding to
+changed size and shape, each array element will still correspond to
 the same real world coordinates as they did before.  An example of how
 to slice a 3-D `~ndcube.NDCube` object is::
 
@@ -114,13 +117,14 @@ Slicing can also reduce the dimension of an `~ndcube.NDCube`, e.g.::
   >>> my_2d_cube = my_cube[0, 10:100, 30:37]
 
 In addition to slicing by index, `~ndcube.NDCube` supports a basic
-version of slicing/index by real world coordinate via the
+version of slicing/indexing by real world coordinates via the
 `~ndcube.NDCube.crop_by_coords` method.  This takes a list of
-`astropy.units.Quantity` representing the real world coordinates of
-the lower left corner of the region of interest.  The order of the
-coordinates must be the same as the order of the data axes.  A second
-iterable of `~astropy.units.Quantity` must also be provided which gives
-the widths of the region of interest in each data axis::
+`astropy.units.Quantity` instances representing the minimum real world
+coordinates of the region of interest in each dimension.  The
+order of the coordinates must be the same as the order of the data
+axes.  A second iterable of `~astropy.units.Quantity` must also be
+provided which gives the widths of the region of interest in each data
+axis::
 
   >>> from astropy.units import Quantity
   >>> my_cube_roi = my_cube.crop_by_coords(
@@ -128,11 +132,11 @@ the widths of the region of interest in each data axis::
   ... [Quantity(0.6, unit="deg"), Quantity(1., unit="deg"), Quantity(0.08e-9, unit="m")])
 
 This method does not rebin or interpolate the data if the region of interest
-defined does not perfectly map onto the array's "pixel" grid.  Instead
+does not perfectly map onto the array's "pixel" grid.  Instead
 it translates from real world to pixel coordinates and rounds to the
-nearest integer before indexing/slicing the `~ndcube.NDCube` object.
-Therefore it should be noted that slightly different inputs to this
-method can result in the same output.
+nearest integer pixel before indexing/slicing the `~ndcube.NDCube`
+instance. Therefore it should be noted that slightly different inputs to
+this method can result in the same output.
 
 .. _missing_axes:
 
@@ -155,18 +159,19 @@ spatial axis, e.g. in data from a slit-spectrograph instrument.  In
 this case, simply extracting the corresponding latitude or longitude
 axis from the WCS object would cause the translations to break.
 
-To deal with this scenario, `~ndcube.NDCube` supports "missing" WCS axes.  An
-additional attribute is added to the object (NDCube.wcs.missing_axis) which
-is a list of `bool` type indicating which WCS axes do not have a
-corresponding data axis.  This allows translation information on
-coupled axes to persist even if the data axes do not.  This feature
-makes in possible for `~ndcube.NDCube` to seamlessly reduce the data
-dimensionality via slicing and also handle data types with only one
-spatial dimension, like those from a slit-spectrograph instrument
-which would have otherwise been impossible.  In the majority of cases
-a user will not need to worry about this feature.  But it is useful to
-be aware of as many of the coordinate transformation functionalities
-of `~ndcube.NDCube` are only made possible by the missing axis feature.
+To deal with this scenario, `~ndcube.NDCube` supports "missing" WCS
+axes.  An additional attribute is added to the WCS object
+(`NDCube.wcs.missing_axis`) which  is a list of `bool` type indicating
+which WCS axes do not have a corresponding data axis.  This allows
+translation information on coupled axes to persist even if the data
+axes do not.  This feature makes in possible for `~ndcube.NDCube` to
+seamlessly reduce the data dimensionality via slicing and handle
+data with only one spatial dimension, like those from a
+slit-spectrograph, which would have otherwise been
+impossible.  In the majority of cases a user will not need to worry
+about this feature.  But it is useful to be aware of as many of the
+coordinate transformation functionalities of `~ndcube.NDCube` are only
+made possible by the missing axis feature.
 
 Extra Coordinates
 -----------------
@@ -181,19 +186,19 @@ the third axis corresponds to wavelength.  However, the first axis also
 corresponds to time, as it takes time for the slit to move and then
 take another exposure which results in a new spectrogram (y-position
 vs. wavelength). It would be very useful to have the measurement times
-associated along the x-axis associated.  However, the WCS can only
-handle one translation per axis.
+also associated with the x-axis.  However, the WCS may only handle one
+translation per axis.
 
 Fortunately, `~ndcube.NDCube` has a solution to this.  Values at
 integer (pixel) steps along an axis can be stored within the object
 and accessed via the `~ndcube.NDCube.extra_coords` property. To
-attach extra coordinates to an `~ndcube.NDCube` instance, provide a
-iterable of tuples of the form (`str`, `int`, `~astropy.units.Quantity`
-or `list`) where the 0th entry gives the name of the coordinate, the
-1st entry gives the data axis to which the extra coordinate
-corresponds, and the 2nd entry gives the value of that coordinate at
-each pixel along the axis.  So to add timestamps along the 0th axis of
-``my_cube`` we do:: 
+attach extra coordinates to an `~ndcube.NDCube` instance, provide an
+iterable of tuples of the form (`str`, `int`,
+`~astropy.units.Quantity` or `list`) during instantiation.  The 0th
+entry gives the name of the coordinate, the 1st entry gives the data
+axis to which the extra coordinate corresponds, and the 2nd entry
+gives the value of that coordinate at each pixel along the axis.  So
+to add timestamps along the 0th axis of ``my_cube`` we do:: 
 
   >>> from datetime import datetime, timedelta
   >>> # Define our timestamps.  Must be same length as data axis.
@@ -217,7 +222,7 @@ supplied by the user::
   {'time': {'axis': 0, 'value': [datetime.datetime(2000, 1, 1, 0, 0), datetime.datetime(2000, 1, 1, 0, 1), datetime.datetime(2000, 1, 1, 0, 2)]}}
 
 Just like the data array and the WCS object, the extra coordinates are
-sliced automatically when the `~ndcube.NDCube` object is sliced.  So
+sliced automatically when the `~ndcube.NDCube` instance is sliced.  So
 if we take the first slice of ``my_cube`` in the 0th axis, the extra
 time coordinate will only contain the value from that slice.::
 
@@ -273,7 +278,7 @@ In addition to this, some optional kwargs can be used to customize the
 plot.  The ``axis_ranges`` kwarg can be used to set the axes ticklabels.  See the
 `~sunpy.visualization.imageanimator.ImageAnimatorWCS` documentation for
 more detail.  However, if this is not set, the axis ticklabels are
-automatically derived in real world coordination from the WCS obect
+automatically derived as real world coordinates from the WCS obect
 within the `~ndcube.NDCube`.
 
 By default the final two data dimensions are used for the plot
@@ -298,11 +303,12 @@ translate between pixel and real world coordinates.  For this purpose,
 `~ndcube.NDCube` provides convenience wrappers for the better known
 astropy functions, `astropy.wcs.WCS.all_pix2world` and
 `astropy.wcs.WCS.all_world2pix`. These are
-`~ndcube.NDCube.pixel_to_world` and `~ndcube.NDCube.world_to_pixel`.
-It is highly recommended that when using `~ndcube.NDCube` these
-convenience wrappers are used rather than the original astropy
-functions for a few reasons. For example, they can track house-keeping
-data, are aware of "missing" WCS axis, are unit-aware, etc.
+`~ndcube.NDCube.pixel_to_world`, `~ndcube.NDCube.world_to_pixel`, and
+`~ndcube.NDCube.all_world_coords`. It is highly recommended that when
+using `~ndcube.NDCube` these convenience wrappers are used rather than
+the original astropy functions for a few reasons. For example, they
+can track house-keeping data, are aware of "missing" WCS axis, are
+unit-aware, etc.
 
 To use `~ndcube.NDCube.pixel_to_world`, simply input a list of
 `~astropy.units.Quantity` objects with pixel units. Each
@@ -330,7 +336,7 @@ different pixel coordinate of the same number of pixels, the lengths
 of each `~astropy.units.Quantity` must be the same.
 
 `~ndcube.NDCube.pixel_to_world` returns a similar list of Quantities
-as to those that were input, except that they are now in real world
+to those that were input, except that they are now in real world
 coordinates::
 
   >>> real_world_coords
@@ -355,12 +361,86 @@ returned::
   >>> pixel_coords
   [<Quantity 2.00000001 pix>, <Quantity 3. pix>, <Quantity 4. pix>]
 
-Both `~ndcube.NDCube.pixel_to_world` and
-`~ndcube.NDCube.world_to_pixel` have an additional optional kwarg,
-``origin``, whose default is 0.  This is the same as the ``origin`` arg in
-`~astropy.wcs.WCS.all_pix2world` and `~astropy.wcs.WCS.all_world2pix`
-and defines whether the WCS translation is 0-based (C) or 1-based
-(FORTRAN).  Changing this kwarg will result in the pixel coordinates
-being offset by 1.  In most cases, the approriate setting will be
-``origin=0``, but 1-based may be required for writing the WCS
-translations to a FITS header.
+Note that both `~ndcube.NDCube.pixel_to_pixel` and
+`~ndcube.NDCube.world_to_pixel` can handle non-integer pixels.
+Moreover, they can also handle pixel beyond the bounds of the
+`~ndcube.NDCube` and even negative pixels.  This is because the WCS
+translations should be valid anywhere in space, and not just within
+the field of view of the `~ndcube.NDCube`.  This capability has many
+useful applications, for example, in comparing observations from
+different instruments with overlapping fields of view.
+
+There are times however, when you only want to know the real world
+coordinates of the `~ndcube.NDCube` field of view.  To make this easy,
+`~ndcube.NDCube.` has a another coordinate transformation method
+`~ndcube.NDCube.all_world_coords`.  This method returns the real world
+coordinates for each pixel along a given data axis.  So in the case of
+``my_cube`` we've been using above, if we wanted the wavelength axis,
+we could call::
+
+  >>> my_cube.all_world_coords(axes=2)
+  [<Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>]
+
+Note we set ``axes`` to ``2`` since ``axes`` is defined in data axis
+order.  We can also define the axis we want using any unique substring
+from the axis names defined in
+`ndcube.NDCube.world_axis_physical_types`::
+
+  >>> my_cube.world_axis_physical_types
+  ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl')
+  >>> # Since 'wl' is unique to the wavelength axis name, let's use that.
+  >>> my_cube.all_world_coords(axes='wl')
+  [<Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>]
+
+Notice how this returns the same result as when we set ``axes`` to
+the corresponding data axis number.  As discussed above, some WCS axes
+are not independent.  For those axes,
+`~ndcube.NDCube.all_world_coords()` returns a
+`~astropy.units.Quantity` with the same number of dimensions are there
+are dependent axes.  For example, helioprojective longitude and
+latitude are dependent.  Therefore if we ask for longitude, we will
+get back a 2D `~astropy.units.Quantity` with the same shape as the
+longitude x latitude axis lengths.  For example::
+
+  >>> longitude = my_cube.all_world_coords(axes='lon')
+  >>> my_cube.dimensions
+  <Quantity [3., 4., 5.] pix>
+  >>> longitude.shape
+  (3, 4)
+  >>> longitude
+  [<Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
+            [1.        , 1.        , 1.        , 1.        ],
+            [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>]
+
+It is also possible to request more than one axis's world coordinates
+by setting ``axes`` to an iterable of data axis number and/or axis
+type strings.::
+
+  >>> my_cube.all_world_coords(axes=(2, 'lon'))
+  [<Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>,
+   <Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
+              [1.        , 1.        , 1.        , 1.        ],
+              [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>]
+
+Notice that the axes' coordinates have been returned in the same order
+in which they were requested.  Finally, if the user wanted the world
+coordinates for all the axes, ```axes`` can be set to ``None``, which
+is in fact the default.::
+
+  >>> my_cube.all_world_coords()
+  [<Quantity [[0.60002173, 0.59999127, 0.5999608 , 0.59993033],
+            [1.        , 1.        , 1.        , 1.        ],
+            [1.39997827, 1.40000873, 1.4000392 , 1.40006967]] deg>,
+   <Quantity [[1.26915033e-05, 4.99987815e-01, 9.99962939e-01, 
+               1.49986193e+00],
+            [1.26918126e-05, 5.00000000e-01, 9.99987308e-01,
+             1.49989848e+00],
+            [1.26915033e-05, 4.99987815e-01, 9.99962939e-01,
+             1.49986193e+00]] deg>,
+   <Quantity [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09, 1.10e-09] m>]
+
+As stated at the top of this guide, `~ndcube.NDCube` is only written
+to handle single arrays described by single WCS instances.  For cases
+where data is made up of multiple arrays, each described by different
+WCS translations, `ndcube` has another class,
+``~ndcube.NDCubeSequence`, which will discuss in the next section.

--- a/docs/ndcubesequence.rst
+++ b/docs/ndcubesequence.rst
@@ -73,12 +73,12 @@ N.B. The above warnings are due to the fact that
 `astropy.nddata.uncertainty` is recommended to have an
 ``uncertainty_type`` attribute giving a string describing the type of
 uncertainty.  However, this is not required.  Also note that due to
-laziness, we have used the same WCS instance in each
-`~ndcube.NDCube` above.  However, it would be more common for each
-`~ndcube.NDCube` to have a different WCS, and the usefulness of
-`~ndcube.NDCubeSequence` is more pronounced when they are
-different. Nonetheless, this can still be used to adequately
-demonstrate the power of `~ndcube.NDCubeSequence`.
+laziness, we have used the same WCS translations in each
+`~ndcube.NDCube` instance above.  However, it would be more common for
+each `~ndcube.NDCube` instance to have a different WCS, and in that
+case the usefulness of `~ndcube.NDCubeSequence` is more
+pronounced. Nonetheless, this case can still be used to adequately
+demonstrate the capabilities of `~ndcube.NDCubeSequence`.
 
 Finally, creating an `~ndcube.NDCubeSequence` becomes is simple::
   
@@ -133,29 +133,40 @@ Defining a common axis enables the full range of the
 `ndcube.NDCubeSequence.index_as_cube`. See following sections for
 more details on these features.
 
+.. _dimensions:
+
 Dimensions
 ----------
 
-Analagous to `ndcube.NDCube.dimensions`, there are also
-`~ndcube.NDCubeSequence.dimensions` and
-`~ndcube.NDCubeSequence.world_axis_physical_types` properties for
-easily inspecting the shape and phsyical axis types of an
-`~ndcube.NDCubeSequence` instance::
+Analagous to `ndcube.NDCube.dimensions`, there are also a
+`ndcube.NDCubeSequence.dimensions` property for
+easily inspecting the shape of an `~ndcube.NDCubeSequence` instance::
 
   >>> my_sequence.dimensions
   (<Quantity 3. pix>, <Quantity 3. pix>, <Quantity 4. pix>, <Quantity 5. pix>)
 
-Slightly differently to `~ndcube.NDCube` it returns a tuple of
+Slightly differently to `ndcube.NDCube.dimensions`,
+`ndcube.NDCubeSequence.dimensions` returns a tuple of
 `astropy.units.Quantity` instances with pixel units, giving the length
-of each axis.  Meanwhile, the
-`~ndcube.NDCubeSequence.world_axis_physical_types` returns a tuple of
-the physical axis types, as it does for `~ndcube.NDCube`::
+of each axis.  This is in constrast to the single
+`~astropy.units.Quantity` returned by `~ndcube.NDCube`. This is
+because `~ndcube.NDCubeSequence` supports sub-cubes of different
+lengths along the common axis if it is set.  In that case, the
+corresponding quantity in the dimensions tuple will have a length
+greater than 1 and list the length of each sub-cube along the common
+axis.
+
+Equivalent to `ndcube.NDCube.world_axis_physical_types`,
+`ndcube.NDCubeSequence.world_axis_physical_types` returns a tuple of
+the physical axis types.  The same `IVOA UCD1+ controlled words
+<http://www.ivoa.net/documents/REC/UCD/UCDlist-20070402.html>` are
+used for the cube axes as is used in
+`ndcube.NDCube.world_axis_physical_types`.  The sequence axis is given
+the label ``'meta.obs.sequence'`` as it is the IVOA UCD1+ controlled
+word that best describes it.  To call, simply do::
   
   >>> my_sequence.world_axis_physical_types
   ('meta.obs.sequence', 'custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl')
-
-The sequence axis is given the label ``'meta.obs.sequence'`` as it is
-the IVOA UCD1+ controlled word that best describes it.
 
 .. _sequence_slicing:
 
@@ -226,9 +237,14 @@ this corresponds to slices 2 to 7 along to the 0th cube axis::
 
   >>> roi_across_subcubes = my_sequence.index_as_cube[2:7, 1:3, 1:4]
   >>> roi_across_subcubes.dimensions
-  (<Quantity 3. pix>, <Quantity 1. pix>, <Quantity 2. pix>, <Quantity 3. pix>)
+  (<Quantity 3. pix>, <Quantity [1., 3., 1.] pix>, <Quantity 2. pix>, <Quantity 3. pix>)
   >>> roi_across_subcubes.world_axis_physical_types
   ('meta.obs.sequence', 'custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl')
+
+Notice that since the sub-cubes are now of lengths along the common
+axis, the corresponding `~astropy.units.Quantity` gives the lengths of
+each cube individually.  See section on :ref:`dimensions` for
+more detail.
 
 Common Axis Extra Coordinates
 -----------------------------
@@ -273,13 +289,13 @@ Sequence Axis Extra Coordinates
 -------------------------------
 Analgous to `~ndcube.NDCubeSequence.common_axis_extra_coords`, it is
 also possible to access the extra coordinates that are not assigned to any
-`ndcube.NDCube` data axis via the
+`~ndcube.NDCube` data axis via the
 `ndcube.NDCubeSequence.sequence_axis_extra_coords` property.  Whereas
 `~ndcube.NDCubeSequence.common_axis_extra_coords` returns all the
 extra coords with an ``'axis'`` value equal to the common axis,
 `~ndcube.NDCubeSequence.sequence_axis_extra_coords` returns all extra
 coords with an ``'axis'`` value of ``None``.  Another way of thinking
-about this is when there is no common axis set, is that they are
+about this when there is no common axis set, is that they are
 assigned to the sequence axis, hence the property name.::
 
   >>> my_sequence.sequence_axis_extra_coords

--- a/docs/ndcubesequence.rst
+++ b/docs/ndcubesequence.rst
@@ -247,6 +247,31 @@ common axis, the corresponding `~astropy.units.Quantity` gives the
 lengths of each cube individually.  See section on :ref:`dimensions`
 for more detail.
 
+Cube-like Dimensions
+--------------------
+
+To help with handling an `~ndcube.NDCubeSequence` with a common axis
+as if it were a single cube, there exist cube-like equivalents of the
+`~ndcube.NDCubeSequence.dimensions`  and
+`~ndcube.NDCubeSequence.world_axis_physical_types` methods.  They are
+intuitively named `~ndcube.NDCubeSequence.cube_like_dimensions`  and
+`~ndcube.NDCubeSequence.cube_like_world_axis_physical_types`.  These
+give the lengths and physical types of the axes as if the data were
+stored in a single `~ndcube.NDCube`.  So in the case of
+``my_sequence``, with three sub-cubes, each with a length of 3 along
+the common axis, we get::
+
+  >>> my_sequence.cube_like_dimensions
+  <Quantity [9., 4., 5.] pix>
+  >>> my_sequence.cube_like_world_axis_physical_types
+  ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl')
+
+Note that `~ndcube.NDCubeSequence.cube_like_dimensions` returns a
+single `~astropy.units.Quantity` in pixel units, as if it were
+`ndcube.NDCube.dimensions`.  This is in contrast to
+`ndcube.NDCubeSequence.dimensions` that returns a `tuple` of
+`~astropy.units.Quantity`.
+
 Common Axis Extra Coordinates
 -----------------------------
 

--- a/docs/ndcubesequence.rst
+++ b/docs/ndcubesequence.rst
@@ -15,10 +15,11 @@ methods attached.
 Initialization
 --------------
 
-To initialize the most basic `~ndcube.NDCube` object, all you need is
-a list of `~ndcube.NDCube` instances.  So let us first define three 3-D
-NDCubes for slit-spectrograph data as we did in the NDCube section of
-this tutorial.  First we define the data arrays and WCS objects::
+To initialize the most basic `~ndcube.NDCubeSequence` object, all you
+need is a list of `~ndcube.NDCube` instances.  So let us first define
+three 3-D NDCubes for slit-spectrograph data as we did in the NDCube
+section of this tutorial.  First we define the data arrays and WCS
+objects::
   
   >>> # Define data for cubes
   >>> import numpy as np
@@ -138,7 +139,7 @@ more details on these features.
 Dimensions
 ----------
 
-Analagous to `ndcube.NDCube.dimensions`, there are also a
+Analagous to `ndcube.NDCube.dimensions`, there is also a
 `ndcube.NDCubeSequence.dimensions` property for
 easily inspecting the shape of an `~ndcube.NDCubeSequence` instance::
 
@@ -241,10 +242,10 @@ this corresponds to slices 2 to 7 along to the 0th cube axis::
   >>> roi_across_subcubes.world_axis_physical_types
   ('meta.obs.sequence', 'custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl')
 
-Notice that since the sub-cubes are now of lengths along the common
-axis, the corresponding `~astropy.units.Quantity` gives the lengths of
-each cube individually.  See section on :ref:`dimensions` for
-more detail.
+Notice that since the sub-cubes are now of different lengths along the
+common axis, the corresponding `~astropy.units.Quantity` gives the
+lengths of each cube individually.  See section on :ref:`dimensions`
+for more detail.
 
 Common Axis Extra Coordinates
 -----------------------------
@@ -266,7 +267,7 @@ one contiguous Cube.  This can be done using the
         datetime.datetime(2000, 1, 1, 0, 7),
         datetime.datetime(2000, 1, 1, 0, 8)], dtype=object)}
 
-This returns a dictionary where each key gives the name of the
+This returns a dictionary where each key gives the name of a
 coordinate.  The value of each key is the values of that coordinate
 at each pixel along the common axis.  Since all these coordinates must
 be along the common axis, it is not necessary to supply axis
@@ -296,7 +297,7 @@ extra coords with an ``'axis'`` value equal to the common axis,
 `~ndcube.NDCubeSequence.sequence_axis_extra_coords` returns all extra
 coords with an ``'axis'`` value of ``None``.  Another way of thinking
 about this when there is no common axis set, is that they are
-assigned to the sequence axis, hence the property name.::
+assigned to the sequence axis.  Hence the property's name.::
 
   >>> my_sequence.sequence_axis_extra_coords
   {'label': array(['hello', 'world', '!'], dtype=object)}
@@ -316,12 +317,12 @@ Explode Along Axis
 
 During analysis of some data - say of a stack of images - it may be
 necessary to make some different fine-pointing adjustments to each
-image that isn't accounted for the in the original WCS translations in
-your data, e.g. due to satellite wobble.  If these changes are not
-describable with a single WCS object, it may be desirable to break up
-the N-D sub-cubes of an `~ndcube.NDCubeSequence` into an sequence of
-sub-cubes with dimension N-1. This would enable a separate WCS object
-to be associated with each image and hence allow individual pointing
+image that isn't accounted for the in the original WCS translations,
+e.g. due to satellite wobble.  If these changes are not describable
+with a single WCS object, it may be desirable to break up the N-D
+sub-cubes of an `~ndcube.NDCubeSequence` into an sequence of sub-cubes
+with dimension N-1. This would enable a separate WCS object to be
+associated with each image and hence allow individual pointing
 adjustments.
 
 Rather than manually dividing the datacubes up and deriving the

--- a/ndcube/__init__.py
+++ b/ndcube/__init__.py
@@ -10,10 +10,6 @@ This is a SunPy affiliated package.
 from ._sunpy_init import *
 # ----------------------------------------------------------------------------
 
-from collections import namedtuple as _nt
-DimensionPair = _nt('DimensionPair', 'shape axis_types')
-SequenceDimensionPair = _nt('SequenceDimensionPair', 'shape axis_types')
-
 if not _ASTROPY_SETUP_:
     # For egg_info test builds to pass, put package imports here.
     from .ndcube import NDCube, NDCubeOrdered

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -151,7 +151,7 @@ class NDCubePlotMixin:
                 index_not_one.append(i)
         if unit is None:
             unit = self.wcs.wcs.cunit[index_not_one[0]]
-        plot = plt.plot(self.pixel_to_world(
-            [u.Quantity(np.arange(self.data.shape[0]), unit=u.pix)], origin=origin)[0].to(unit),
+        plot = plt.plot(self.pixel_to_world(*[u.Quantity(np.arange(self.data.shape[0]),
+                                                         unit=u.pix)])[0].to(unit),
                         self.data)
         return plot

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -445,8 +445,17 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                 else:
                     # If the axis is dependent on another, perform
                     # translations on all dependent axes.
-                    quantity_list = utils.cube._get_pixel_quantities_for_dependent_axes(
-                        dependent_axes[i], cube_dimensions)
+                    # Construct pixel quantities in each dimension letting
+                    # other dimensions all have 0 pixel value.
+                    quantity_list = [u.Quantity(np.zeros(tuple(
+                        [cube_dimensions[k] for k in dependent_axes[i]])),
+                        unit=u.pix)] * n_dimensions
+                    # Construct orthogonal pixel index arrays for dependent axes.
+                    dependent_pixel_quantities = np.meshgrid(
+                        *[np.arange(cube_dimensions[k]) * u.pix
+                          for k in dependent_axes[i]], indexing="ij")
+                    for k, axis in enumerate(dependent_axes[i]):
+                        quantity_list[axis] = dependent_pixel_quantities[k]
                 # Perform wcs translation
                 dependent_axes_coords = self.pixel_to_world(*quantity_list)
                 # Place world coords into output list

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -370,7 +370,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
     @property
     def all_world_coords(self):
         """Returns WCS coordinate values of all pixels for all axes."""
-        cube_dimensions = np.array(self.dimensions.shape.value, dtype=int)
+        cube_dimensions = np.array(self.dimensions.value, dtype=int)
         n_dimensions = len(cube_dimensions)
         all_coords = [None]*n_dimensions
         axes_translated = np.array([False] * n_dimensions)
@@ -401,7 +401,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                     quantity_list = utils.cube._get_pixel_quantities_for_dependent_axes(
                         dependent_axes[axis], cube_dimensions)
                 # Perform wcs translation
-                dependent_axes_coords = self.pixel_to_world(quantity_list)
+                dependent_axes_coords = self.pixel_to_world(*quantity_list)
                 # Place world coords into output list
                 for dependent_axis in dependent_axes[axis]:
                     all_coords[dependent_axis] = dependent_axes_coords[dependent_axis]

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -297,7 +297,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
         # Convert coords of lower left corner to pixel units.
         lower_pixels = self.world_to_pixel(*min_coord_values)
         upper_pixels = self.world_to_pixel(*[min_coord_values[i] + interval_widths[i]
-                                            for i in range(n_dim)])
+                                             for i in range(n_dim)])
         # Round pixel values to nearest integer.
         lower_pixels = [int(np.rint(l.value)) for l in lower_pixels]
         upper_pixels = [int(np.rint(u.value)) for u in upper_pixels]
@@ -408,7 +408,6 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                 # Remove axes from list that have now been translated.
                 axes_translated[dependent_axes[axis]] = True
         return all_coords
-
 
     def __repr__(self):
         return (

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -370,13 +370,13 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                     "value": self._extra_coords_wcs_axis[key]["value"]}
         return result
 
-    def all_world_coords(self, axes=None):
+    def axis_world_coords(self, *axes):
         """
         Returns WCS coordinate values of all pixels for all axes.
 
         Parameters
         ----------
-        axes: `int` or `str`, or iterable of `int` or `str`
+        axes: `int` or `str`, or multiple `int` or `str`
             Axis number in numpy ordering or unique substring of
             `~ndcube.NDCube.world_axis_physical_types`
             of axes for which real world coordinates are desired.
@@ -398,7 +398,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
         n_dimensions = cube_dimensions.size
         world_axis_types = self.world_axis_physical_types
         # Determine axis numbers of user supplied axes.
-        if axes is None:
+        if axes == ():
             int_axes = np.arange(n_dimensions)
         else:
             if isinstance(axes, int):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -85,15 +85,7 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
 
     @abc.abstractproperty
     def world_axis_physical_types(self):
-        """
-        Returns an iterable of strings describing the physical type for each world axis.
-
-        The strings conform to the International Virtual Observatory Alliance
-        standard, UCD1+ controlled Vocabulary.  For a description of the standard and
-        definitions of the different strings and string components,
-        see http://www.ivoa.net/documents/latest/UCDlist.html.
-
-        """
+        pass
 
     @abc.abstractmethod
     def crop_by_coords(self, min_coord_values, interval_widths):
@@ -279,8 +271,15 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
 
     @property
     def world_axis_physical_types(self):
-        # The docstring is defined in NDDataBase
+        """
+        Returns an iterable of strings describing the physical type for each world axis.
 
+        The strings conform to the International Virtual Observatory Alliance
+        standard, UCD1+ controlled Vocabulary.  For a description of the standard and
+        definitions of the different strings and string components,
+        see http://www.ivoa.net/documents/latest/UCDlist.html.
+
+        """
         ctype = list(self.wcs.wcs.ctype)
         axes_ctype = []
         for i, axis in enumerate(self.missing_axis):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -84,6 +84,18 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
     def dimensions(self):
         pass
 
+    @abc.abstractproperty
+    def world_axis_physical_types(self):
+        """
+        Returns an iterable of strings describing the physical type for each world axis.
+
+        The strings conform to the International Virtual Observatory Alliance
+        standard, UCD1+ controlled Vocabulary.  For a description of the standard and
+        definitions of the different strings and string components,
+        see http://www.ivoa.net/documents/latest/UCDlist.html.
+
+        """
+
     @abc.abstractmethod
     def crop_by_coords(self, min_coord_values, interval_widths):
         """
@@ -268,15 +280,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
 
     @property
     def world_axis_physical_types(self):
-        """
-        Returns an iterable of strings describing the physical type for each world axis.
+        # The docstring is defined in NDDataBase
 
-        The strings conform to the International Virtual Observatory Alliance
-        standard, UCD1+ controlled Vocabulary.  For a description of the standard and
-        definitions of the different strings and string components,
-        see http://www.ivoa.net/documents/latest/UCDlist.html.
-
-        """
         ctype = list(self.wcs.wcs.ctype)
         axes_ctype = []
         for i, axis in enumerate(self.missing_axis):
@@ -413,7 +418,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                 int_axes = np.array(int_axes)
         # Ensure user has not entered the same axis twice.
         if len(np.unique(int_axes)) != len(int_axes):
-               raise ValueError("Same axis entered more than once.")
+            raise ValueError("Same axis entered more than once.")
         n_axes = len(int_axes)
         axes_coords = [None] * n_axes
         axes_translated = np.array([False] * n_axes)

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -421,7 +421,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
         # Ensure the axes are in numerical order.
         dependent_axes = np.empty(n_axes, dtype=object)
         for i, axis in enumerate(int_axes):
-            x = np.array(self.wcs.dependent_axes(axis))
+            x = np.array(utils.wcs.dependent_axes(self.wcs, axis))
             x.sort()
             dependent_axes[i] = x
         n_dependent_axes = np.array([len(da) for da in dependent_axes])

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -390,8 +390,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
 
         Example
         -------
-        >>> #NDCube.all_world_coords(('lat', 'lon')) # skip: doctest+
-        >>> #NDCube.all_world_coords(2) # skip: doctest+
+        >>> NDCube.all_world_coords(('lat', 'lon')) # doctest: +SKIP
+        >>> NDCube.all_world_coords(2) # doctest: +SKIP
 
         """
         # Define the dimensions of the cube and the total number of axes.
@@ -414,7 +414,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                         int_axes.append(axis)
                     elif isinstance(axis, str):
                         int_axes.append(
-                            utils.cube._get_axis_number_from_axis_name(axes, world_axis_types))
+                            utils.cube._get_axis_number_from_axis_name(axis, world_axis_types))
                 int_axes = np.array(int_axes)
         # Ensure user has not entered the same axis twice.
         if len(np.unique(int_axes)) != len(int_axes):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -459,7 +459,10 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                         axes_coords[j] = dependent_axes_coords[dependent_axis]
                         # Remove axis from list that have now been translated.
                         axes_translated[j] = True
-        return axes_coords
+        if len(axes_coords) == 1:
+            return axes_coords[0]
+        else:
+            return tuple(axes_coords)
 
     def __repr__(self):
         return (

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -379,9 +379,10 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
         Parameters
         ----------
         axes: `int` or `str`, or iterable of `int` or `str`
-            Axis number in numpy ordering or unique substring of world_axis_physical_types
+            Axis number in numpy ordering or unique substring of
+            `~ndcube.NDCube.world_axis_physical_types`
             of axes for which real world coordinates are desired.
-            Default=None implies all axes will be returned.
+            axes=None implies all axes will be returned.
 
         Returns
         -------
@@ -396,7 +397,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
         """
         # Define the dimensions of the cube and the total number of axes.
         cube_dimensions = np.array(self.dimensions.value, dtype=int)
-        n_dimensions = len(cube_dimensions)
+        n_dimensions = cube_dimensions.size
         world_axis_types = self.world_axis_physical_types
         # Determine axis numbers of user supplied axes.
         if axes is None:
@@ -408,38 +409,36 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                 int_axes = np.array([
                     utils.cube.get_axis_number_from_axis_name(axes, world_axis_types)])
             else:
-                int_axes = []
-                for axis in axes:
+                int_axes = np.empty(len(axes), dtype=int)
+                for i, axis in enumerate(axes):
                     if isinstance(axis, int):
-                        int_axes.append(axis)
+                        int_axes[i] = axis
                     elif isinstance(axis, str):
-                        int_axes.append(
-                            utils.cube.get_axis_number_from_axis_name(axis, world_axis_types))
-                int_axes = np.array(int_axes)
+                        int_axes[i] = utils.cube.get_axis_number_from_axis_name(
+                            axis, world_axis_types)
         # Ensure user has not entered the same axis twice.
-        if len(np.unique(int_axes)) != len(int_axes):
-            raise ValueError("Same axis entered more than once.")
+        repeats = set([x for x in int_axes if np.where(int_axes == x)[0].size > 1])
+        if repeats:
+            raise ValueError("The following axes were specified more than once: {}".format(
+                ' '.join(map(str, repeats))))
         n_axes = len(int_axes)
         axes_coords = [None] * n_axes
-        axes_translated = np.array([False] * n_axes)
+        axes_translated = np.zeros_like(int_axes, dtype=bool)
         # Determine which axes are dependent on others.
         # Ensure the axes are in numerical order.
-        dependent_axes = np.empty(n_axes, dtype=object)
-        for i, axis in enumerate(int_axes):
-            x = np.array(utils.wcs.get_dependent_axes(self.wcs, axis))
-            x.sort()
-            dependent_axes[i] = x
-        n_dependent_axes = np.array([len(da) for da in dependent_axes])
+        dependent_axes = [list(utils.wcs.get_dependent_axes(self.wcs, axis))
+                          for axis in int_axes]
+        n_dependent_axes = [len(da) for da in dependent_axes]
         # Iterate through each axis and perform WCS translation.
         for i, axis in enumerate(int_axes):
             # If axis has already been translated, do not do so again.
-            if axes_translated[i] == False:
+            if not axes_translated[i]:
                 if n_dependent_axes[i] == 1:
                     # Construct pixel quantities in each dimension letting
                     # other dimensions all have 0 pixel value.
-                    quantity_list = \
-                      [u.Quantity(np.zeros(tuple(cube_dimensions[dependent_axes[i]])),
-                                  unit=u.pix)] * n_dimensions
+                    quantity_list = [
+                        u.Quantity(np.zeros(cube_dimensions[dependent_axes[i]]),
+                                   unit=u.pix)] * n_dimensions
                     # Replace array in quantity list corresponding to current axis with
                     # np.arange array.
                     quantity_list[axis] = u.Quantity(np.arange(cube_dimensions[axis]), unit=u.pix)

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -406,7 +406,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                 int_axes = np.array([axes])
             elif isinstance(axes, str):
                 int_axes = np.array([
-                    utils.cube._get_axis_number_from_axis_name(axes, world_axis_types)])
+                    utils.cube.get_axis_number_from_axis_name(axes, world_axis_types)])
             else:
                 int_axes = []
                 for axis in axes:
@@ -414,7 +414,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
                         int_axes.append(axis)
                     elif isinstance(axis, str):
                         int_axes.append(
-                            utils.cube._get_axis_number_from_axis_name(axis, world_axis_types))
+                            utils.cube.get_axis_number_from_axis_name(axis, world_axis_types))
                 int_axes = np.array(int_axes)
         # Ensure user has not entered the same axis twice.
         if len(np.unique(int_axes)) != len(int_axes):
@@ -426,7 +426,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
         # Ensure the axes are in numerical order.
         dependent_axes = np.empty(n_axes, dtype=object)
         for i, axis in enumerate(int_axes):
-            x = np.array(utils.wcs.dependent_axes(self.wcs, axis))
+            x = np.array(utils.wcs.get_dependent_axes(self.wcs, axis))
             x.sort()
             dependent_axes[i] = x
         n_dependent_axes = np.array([len(da) for da in dependent_axes])

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -13,7 +13,6 @@ import sunpy.map
 from ndcube import utils
 from ndcube.utils.wcs import wcs_ivoa_mapping
 from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
-from ndcube import DimensionPair
 
 
 __all__ = ['NDCubeBase', 'NDCube', 'NDCubeOrdered']

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -456,20 +456,6 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
         item[extra_coord_dict["axis"]] = slice(w[0], w[1]+1)
         return self[tuple(item)]
 
-    def to_sunpy(self):
-        wcs_axes = list(self.wcs.wcs.ctype)
-        missing_axis = self.missing_axis
-        if 'TIME' in wcs_axes and len(self.dimensions) is 1:
-            result = self.pixel_to_world([u.Quantity(self.data, unit=u.pix)])
-        elif 'HPLT-TAN' in wcs_axes and 'HPLN-TAN' in wcs_axes \
-                and len(self.dimensions) is 2:
-            if not missing_axis[wcs_axes.index("HPLT-TAN")] \
-                    and not missing_axis[wcs_axes.index("HPLN-TAN")]:
-                result = sunpy.map.Map(self.data, self.meta)
-        else:
-            raise NotImplementedError("Object type not Implemented")
-        return result
-
     def __repr__(self):
         return (
             """NDCube

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -473,7 +473,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
 
     def __repr__(self):
         return (
-            """Sunpy NDCube
+            """NDCube
 ---------------------
 {wcs}
 ---------------------

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -142,59 +142,65 @@ Axis Types of 1st NDCube: {axis_type}
         axis_coord_names, axis_coord_units = utils.sequence._get_axis_extra_coord_names_and_units(
             self.data, self._common_axis)
         # Compile dictionary of common axis extra coords.
-        return utils.sequence._get_int_axis_extra_coords(
-            self.data, axis_coord_names, axis_coord_units, self._common_axis)
+        if axis_coord_names is not None:
+            return utils.sequence._get_int_axis_extra_coords(
+                self.data, axis_coord_names, axis_coord_units, self._common_axis)
+        else:
+            return None
 
     @property
     def sequence_axis_extra_coords(self):
         sequence_coord_names, sequence_coord_units = \
           utils.sequence._get_axis_extra_coord_names_and_units(self.data, None)
-        # Define empty dictionary which will hold the extra coord
-        # values not assigned a cube data axis.
-        sequence_extra_coords = {}
-        # Define list of None signifying unit of each coord.  It will
-        # be filled in in for loop below.
-        sequence_coord_units = [None]*len(sequence_coord_names)
-        # Iterate through cubes and populate values of each extra coord
-        # not assigned a cube data axis.
-        cube_extra_coords = [cube.extra_coords for cube in self.data]
-        for i, coord_key in enumerate(sequence_coord_names):
-            coord_values = np.array([None]*len(self.data), dtype=object)
-            for j, cube in enumerate(self.data):
-                # Construct list of coord values from each cube for given extra coord.
-                try:
-                    coord_values[j] = cube_extra_coords[j][coord_key]["value"]
-                    # Determine whether extra coord is a quantity by checking
-                    # whether any one value has a unit. As we are not
-                    # assuming that all cubes have the same extra coords
-                    # along the sequence axis, we will keep checking as we
-                    # move through the cubes until all cubes are checked or
-                    # we have found a unit.
-                    if (isinstance(cube_extra_coords[j][coord_key]["value"], u.Quantity) and
-                            not sequence_coord_units[i]):
-                        sequence_coord_units[i] = cube_extra_coords[j][coord_key]["value"].unit
-                except KeyError:
-                    pass
-            # If the extra coord is normally a Quantity, replace all
-            # None occurrences in coord value array with a NaN, and
-            # convert coord_values from an array of Quantities to a
-            # single Quantity of length equal to number of cubes in
-            # sequence.
-            w_none = np.where(coord_values == None)[0]
-            if sequence_coord_units[i]:
-                # This part of if statement is coded in an apparently
-                # round about way but necessitated because you can't
-                # put a NaN quantity into an array and keep its unit.
-                w_not_none = np.where(coord_values != None)[0]
-                coord_values = u.Quantity(list(coord_values[w_not_none]),
-                                          unit=sequence_coord_units[i])
-                coord_values = list(coord_values.value)
-                for index in w_none:
-                    coord_values.insert(index, np.nan)
-                coord_values = u.Quantity(coord_values, unit=sequence_coord_units[i]).flatten()
-            else:
-                coord_values[w_none] = np.nan
-            sequence_extra_coords[coord_key] = coord_values
+        if sequence_coord_names is not None:
+            # Define empty dictionary which will hold the extra coord
+            # values not assigned a cube data axis.
+            sequence_extra_coords = {}
+            # Define list of None signifying unit of each coord.  It will
+            # be filled in in for loop below.
+            sequence_coord_units = [None]*len(sequence_coord_names)
+            # Iterate through cubes and populate values of each extra coord
+            # not assigned a cube data axis.
+            cube_extra_coords = [cube.extra_coords for cube in self.data]
+            for i, coord_key in enumerate(sequence_coord_names):
+                coord_values = np.array([None]*len(self.data), dtype=object)
+                for j, cube in enumerate(self.data):
+                    # Construct list of coord values from each cube for given extra coord.
+                    try:
+                        coord_values[j] = cube_extra_coords[j][coord_key]["value"]
+                        # Determine whether extra coord is a quantity by checking
+                        # whether any one value has a unit. As we are not
+                        # assuming that all cubes have the same extra coords
+                        # along the sequence axis, we will keep checking as we
+                        # move through the cubes until all cubes are checked or
+                        # we have found a unit.
+                        if (isinstance(cube_extra_coords[j][coord_key]["value"], u.Quantity) and
+                                not sequence_coord_units[i]):
+                            sequence_coord_units[i] = cube_extra_coords[j][coord_key]["value"].unit
+                    except KeyError:
+                        pass
+                # If the extra coord is normally a Quantity, replace all
+                # None occurrences in coord value array with a NaN, and
+                # convert coord_values from an array of Quantities to a
+                # single Quantity of length equal to number of cubes in
+                # sequence.
+                w_none = np.where(coord_values == None)[0]
+                if sequence_coord_units[i]:
+                    # This part of if statement is coded in an apparently
+                    # round about way but necessitated because you can't
+                    # put a NaN quantity into an array and keep its unit.
+                    w_not_none = np.where(coord_values != None)[0]
+                    coord_values = u.Quantity(list(coord_values[w_not_none]),
+                                              unit=sequence_coord_units[i])
+                    coord_values = list(coord_values.value)
+                    for index in w_none:
+                        coord_values.insert(index, np.nan)
+                    coord_values = u.Quantity(coord_values, unit=sequence_coord_units[i]).flatten()
+                else:
+                    coord_values[w_none] = np.nan
+                sequence_extra_coords[coord_key] = coord_values
+        else:
+            sequence_extra_coords = None
         return sequence_extra_coords
 
     @classmethod

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -202,15 +202,6 @@ class NDCubeSequence:
         # creating a new sequence with the result_cubes keeping the meta and common axis as axis
         return self._new_instance(result_cubes, meta=self.meta)
 
-    def to_sunpy(self, *args, **kwargs):
-        result = None
-        if all(isinstance(instance_sequence, sunpy.map.mapbase.GenericMap)
-               for instance_sequence in self.data):
-            result = MapCube(self.data, *args, **kwargs)
-        else:
-            raise NotImplementedError("Sequence type not Implemented")
-        return result
-
     def __repr__(self):
         return (
             """NDCubeSequence

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -88,7 +88,7 @@ class NDCubeSequence:
 
     def __repr__(self):
         return (
-            """Sunpy NDCubeSequence
+            """NDCubeSequence
 ---------------------
 Length of NDCubeSequence:  {length}
 Shape of 1st NDCube: {shapeNDCube}

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -5,7 +5,6 @@ import sunpy.map
 from sunpy.map import MapCube
 
 from ndcube import utils
-from ndcube import SequenceDimensionPair
 from ndcube.visualization import animation as ani
 
 __all__ = ['NDCubeSequence']

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -103,10 +103,12 @@ Axis Types of 1st NDCube: {axis_type}
         # If there is a common axis, length of cube's along it may not
         # be the same. Therefore if the lengths are different,
         # represent them as a tuple of all the values, else as an int.
-        if self._common_axis:
-            common_axis_cube_lengths = [cube.data.shape[self._common_axis] for cube in self.data]
-            if len(np.unique(common_axis_cube_lengths)) != 1:
-                dimensions[self._common_axis+1] = tuple(common_axis_dimension)
+        if self._common_axis is not None:
+            common_axis_lengths = [cube.data.shape[self._common_axis] for cube in self.data]
+            if len(np.unique(common_axis_lengths)) != 1:
+                common_axis_dimensions = [cube.dimensions[self._common_axis] for cube in self.data]
+                dimensions[self._common_axis+1] = u.Quantity(
+                    common_axis_dimensions, unit=common_axis_dimensions[0].unit)
         return tuple(dimensions)
 
     @property

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -863,16 +863,25 @@ def test_ndcubeordered(test_input, expected):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    ((cubem, None), [u.Quantity([[0.60002173, 0.59999127, 0.5999608],
+    ((cubem, [2]), u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)),
+    ((cubem, ['em']), u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m))
+    ])
+def test_all_world_coords_with_input(test_input, expected):
+    all_coords = test_input[0].axis_world_coords(*test_input[1])
+    for i in range(len(all_coords)):
+        np.testing.assert_allclose(all_coords[i].value, expected[i].value)
+        assert all_coords[i].unit == expected[i].unit
+
+
+@pytest.mark.parametrize("test_input,expected", [
+    (cubem, (u.Quantity([[0.60002173, 0.59999127, 0.5999608],
                                  [1., 1., 1.]], unit=u.deg),
                      u.Quantity([[1.26915033e-05, 4.99987815e-01, 9.99962939e-01],
                                  [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]], unit=u.deg),
-                     u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)]),
-    ((cubem, 2), u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)),
-    ((cubem, 'em'), u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m))
+                     u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)))
     ])
-def test_all_world_coords(test_input, expected):
-    all_coords = test_input[0].all_world_coords(axes=test_input[1])
+def test_axis_world_coords_without_input(test_input, expected):
+    all_coords = test_input.axis_world_coords()
     for i in range(len(all_coords)):
         np.testing.assert_allclose(all_coords[i].value, expected[i].value)
         assert all_coords[i].unit == expected[i].unit

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -870,8 +870,8 @@ def test_ndcubeordered(test_input, expected):
                      u.Quantity([[1.26915033e-05, 4.99987815e-01, 9.99962939e-01],
                                  [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]], unit=u.deg),
                      u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)]),
-    ((cubem, 2), [u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)]),
-    ((cubem, 'em'), [u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)])
+    ((cubem, 2), u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)),
+    ((cubem, 'em'), u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m))
     ])
 def test_all_world_coords(test_input, expected):
     all_coords = test_input[0].all_world_coords(axes=test_input[1])

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -813,22 +813,6 @@ def test_world_to_pixel(test_input, expected):
     assert np.allclose(test_input.value, expected)
 
 
-@pytest.mark.parametrize(
-    "test_input,expected",
-    [(cubem[:, :, 0].to_sunpy(), sunpy.map.mapbase.GenericMap),
-     (cubem[:, 0:2, 1].to_sunpy(), sunpy.map.mapbase.GenericMap),
-     (cubem[0:2, :, 2].to_sunpy(), sunpy.map.mapbase.GenericMap)])
-def test_to_sunpy(test_input, expected):
-    assert isinstance(test_input, expected)
-
-
-@pytest.mark.parametrize("test_input", [(cubem[0, :, 0]), (cubem[:, 1, 1]),
-                                        (cubem[0:2, :, 0:2])])
-def test_to_sunpy_error(test_input):
-    with pytest.raises(NotImplementedError):
-        test_input.to_sunpy()
-
-
 @pytest.mark.parametrize("test_input,expected", [
     ((cubem, [0.7*u.deg, 1.3e-5*u.deg, 1.02e-9*u.m], [1*u.deg, 1*u.deg, 1.06*u.m]), cubem[:, :2])])
 def test_crop_by_coords(test_input, expected):

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -866,10 +866,10 @@ def test_ndcubeordered(test_input, expected):
 
 @pytest.mark.parametrize("test_input,expected", [
     ((cubem, None), [u.Quantity([[0.60002173, 0.59999127, 0.5999608],
-                         [1., 1., 1.]], unit=u.deg),
-             u.Quantity([[1.26915033e-05, 4.99987815e-01, 9.99962939e-01],
-                         [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]], unit=u.deg),
-             u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)]),
+                                 [1., 1., 1.]], unit=u.deg),
+                     u.Quantity([[1.26915033e-05, 4.99987815e-01, 9.99962939e-01],
+                                 [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]], unit=u.deg),
+                     u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)]),
     ((cubem, 2), [u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)]),
     ((cubem, 'em'), [u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)])
     ])

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -865,14 +865,16 @@ def test_ndcubeordered(test_input, expected):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    (cubem, [u.Quantity([[0.60002173, 0.59999127, 0.5999608],
+    ((cubem, None), [u.Quantity([[0.60002173, 0.59999127, 0.5999608],
                          [1., 1., 1.]], unit=u.deg),
              u.Quantity([[1.26915033e-05, 4.99987815e-01, 9.99962939e-01],
                          [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]], unit=u.deg),
-             u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)])
+             u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)]),
+    ((cubem, 2), [u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)]),
+    ((cubem, 'em'), [u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)])
     ])
 def test_all_world_coords(test_input, expected):
-    all_coords = test_input.all_world_coords
+    all_coords = test_input[0].all_world_coords(axes=test_input[1])
     for i in range(len(all_coords)):
         np.testing.assert_allclose(all_coords[i].value, expected[i].value)
         assert all_coords[i].unit == expected[i].unit

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1449,3 +1449,17 @@ def test_ndcubeordered(test_input, expected):
         NDCubeOrdered(test_input[0], test_input[1], mask=test_input[2],
                       uncertainty=test_input[3], extra_coords=test_input[4]),
         expected)
+
+
+@pytest.mark.parametrize("test_input,expected", [
+    (cubem, [u.Quantity([[0.60002173, 0.59999127, 0.5999608],
+                         [1., 1., 1.]], unit=u.deg),
+             u.Quantity([[1.26915033e-05, 4.99987815e-01, 9.99962939e-01],
+                         [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]], unit=u.deg),
+             u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)])
+    ])
+def test_all_world_coords(test_input, expected):
+    all_coords = test_input.all_world_coords
+    for i in range(len(all_coords)):
+        np.testing.assert_allclose(all_coords[i].value, expected[i].value)
+        assert all_coords[i].unit == expected[i].unit

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -14,8 +14,6 @@ from ndcube import NDCube, NDCubeOrdered
 from ndcube.utils.wcs import WCS, _wcs_slicer
 from ndcube.tests import helpers
 
-DimensionPair = namedtuple('DimensionPair', 'shape axis_types')
-
 # sample data for tests
 # TODO: use a fixture reading from a test file. file TBD.
 ht = {'CTYPE3': 'HPLT-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.5, 'CRPIX3': 0, 'CRVAL3': 0, 'NAXIS3': 2,

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -142,17 +142,22 @@ def test_slice_first_index_sequence(test_input, expected):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    (seq.index_as_cube[0:5].dimensions, (3*u.pix, 2*u.pix, 3*u.pix, 4*u.pix)),
+    (seq.index_as_cube[0:5].dimensions, (3*u.pix, [2., 2., 1.]*u.pix, 3*u.pix, 4*u.pix)),
     (seq.index_as_cube[1:3].dimensions, (2*u.pix, 1*u.pix, 3*u.pix, 4*u.pix)),
     (seq.index_as_cube[0:6].dimensions, (3*u.pix, 2*u.pix, 3*u.pix, 4*u.pix)),
     (seq.index_as_cube[0::].dimensions, (4*u.pix, 2*u.pix, 3*u.pix, 4*u.pix)),
-    (seq.index_as_cube[0:5, 0].dimensions, (3*u.pix, 2*u.pix, 4*u.pix)),
+    (seq.index_as_cube[0:5, 0].dimensions, (3*u.pix, [2., 2., 1.]*u.pix, 4*u.pix)),
     (seq.index_as_cube[1:3, 0:2].dimensions, (2*u.pix, 1*u.pix, 2*u.pix, 4*u.pix)),
     (seq.index_as_cube[0:6, 0, 0:1].dimensions, (3*u.pix, 2*u.pix, 1*u.pix)),
     (seq.index_as_cube[0::, 0, 0].dimensions, (4*u.pix, 2*u.pix)),
 ])
 def test_index_as_cube(test_input, expected):
-    assert test_input == expected
+    for i in range(len(test_input)):
+        try:
+            assert test_input[i] == expected[i]
+        except ValueError:
+            assert (test_input[i].value == expected[i].value).all()
+            assert test_input[i].unit == expected[i].unit
 
 
 @pytest.mark.parametrize("test_input,expected", [

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -110,12 +110,6 @@ nan_time_extra_coord = np.array([datetime.datetime(2000, 1, 1)+datetime.timedelt
                                  for i in range(len(seq.data))])
 nan_time_extra_coord[2] = np.nan
 
-map1 = cube2[:, :, 0].to_sunpy()
-map2 = cube2[:, :, 1].to_sunpy()
-map3 = cube2[:, :, 2].to_sunpy()
-map4 = cube2[:, :, 3].to_sunpy()
-mapcube_seq = NDCubeSequence([map1, map2, map3, map4], common_axis=0)
-
 
 @pytest.mark.parametrize("test_input,expected", [
     (seq[0], NDCube),
@@ -174,22 +168,6 @@ def test_explode_along_axis(test_input, expected):
 def test_explode_along_axis_error():
     with pytest.raises(ValueError):
         seq.explode_along_axis(1)
-
-
-@pytest.mark.parametrize("test_input,expected", [
-    (mapcube_seq.to_sunpy(), sunpy.map.mapcube.MapCube)
-])
-def test_to_sunpy(test_input, expected):
-    assert isinstance(test_input, expected)
-
-
-@pytest.mark.parametrize("test_input", [
-    (seq),
-    (seq1),
-])
-def test_to_sunpy_error(test_input):
-    with pytest.raises(NotImplementedError):
-        test_input.to_sunpy()
 
 
 @pytest.mark.parametrize(

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -12,8 +12,6 @@ from ndcube import NDCube, NDCubeSequence
 from ndcube.utils.wcs import WCS
 
 
-SequenceDimensionPair = namedtuple('SequenceDimensionPair', 'shape axis_types')
-
 # sample data for tests
 # TODO: use a fixture reading from a test file. file TBD.
 data = np.array([[[1, 2, 3, 4], [2, 4, 5, 3], [0, -1, 2, 3]],

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -94,6 +94,9 @@ cube2_time_common = NDCube(data, wm, extra_coords=[
      [cube1_time_common.extra_coords["time"]["value"][-1] + datetime.timedelta(minutes=i)
       for i in range(1, data.shape[1]+1)])])
 
+cube1_no_extra_coords = NDCube(data, wt, missing_axis=[False, False, False, True])
+cube3_no_extra_coords = NDCube(data2, wt, missing_axis=[False, False, False, True])
+
 seq = NDCubeSequence([cube1, cube2, cube3, cube4], common_axis=0)
 seq_bad_common_axis = NDCubeSequence([cube1, cube2, cube3, cube4], common_axis=None)
 seq_time_common = NDCubeSequence([cube1_time_common, cube2_time_common], common_axis=1)
@@ -101,6 +104,7 @@ seq1 = NDCubeSequence([cube1, cube2, cube3, cube4])
 seq2 = NDCubeSequence([cube1, cube2_no_no, cube3_no_time, cube4])
 seq3 = NDCubeSequence([cube1, cube2, cube3_diff_compatible_unit, cube4])
 seq4 = NDCubeSequence([cube1, cube2, cube3_diff_incompatible_unit, cube4])
+seq_no_extra_coords = NDCubeSequence([cube1_no_extra_coords, cube3_no_extra_coords], common_axis=0)
 
 nan_extra_coord = u.Quantity(range(4), unit=u.cm)
 nan_extra_coord.value[1] = np.nan
@@ -229,6 +233,11 @@ def test_common_axis_extra_coords(test_input, expected):
             assert (output[key] == expected[key]).all()
 
 
+@pytest.mark.parametrize("test_input", [(seq_no_extra_coords)])
+def test_no_common_axis_extra_coords(test_input):
+    assert seq_no_extra_coords.sequence_axis_extra_coords is None
+
+
 @pytest.mark.parametrize(
     "test_input,expected",
     [(seq,
@@ -267,6 +276,11 @@ def test_sequence_axis_extra_coords(test_input, expected):
                 # Else, is output is not a float, assert it equals expected.
                 else:
                     assert output_value == expected[key][i]
+
+
+@pytest.mark.parametrize("test_input", [(seq_no_extra_coords)])
+def test_no_sequence_axis_extra_coords(test_input):
+    assert seq_no_extra_coords.sequence_axis_extra_coords is None
 
 
 @pytest.mark.parametrize("test_input", [(seq4)])

--- a/ndcube/tests/test_utils_cube.py
+++ b/ndcube/tests/test_utils_cube.py
@@ -117,3 +117,23 @@ def test_convert_extra_coords_dict_to_input_format_error():
     with pytest.raises(KeyError):
         utils.cube.convert_extra_coords_dict_to_input_format(
             {"time": {"not axis": 0, "value": []}}, missing_axis_none)
+
+
+@pytest.mark.parametrize("test_input,expected", [
+    ((np.array([0, 1, 2]), np.array([3, 3, 3])),
+     [u.Quantity([[[0, 0, 0], [0, 0, 0], [0, 0, 0]],
+                  [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
+                  [[2, 2, 2], [2, 2, 2], [2, 2, 2]]], unit=u.pix),
+      u.Quantity([[[0, 0, 0], [1, 1, 1], [2, 2, 2]],
+                  [[0, 0, 0], [1, 1, 1], [2, 2, 2]],
+                  [[0, 0, 0], [1, 1, 1], [2, 2, 2]]], unit=u.pix),
+      u.Quantity([[[0, 1, 2], [0, 1, 2], [0, 1, 2]],
+                  [[0, 1, 2], [0, 1, 2], [0, 1, 2]],
+                  [[0, 1, 2], [0, 1, 2], [0, 1, 2]]], unit=u.pix),])
+    ])
+def test_get_pixel_quantities_for_dependent_axes(test_input, expected):
+    output = utils.cube._get_pixel_quantities_for_dependent_axes(test_input[0], test_input[1])
+    assert len(output) == len(expected)
+    for i in range(len(output)):
+        assert (output[i].value == expected[i].value).all()
+        assert output[i].unit == expected[i].unit

--- a/ndcube/tests/test_utils_cube.py
+++ b/ndcube/tests/test_utils_cube.py
@@ -117,23 +117,3 @@ def test_convert_extra_coords_dict_to_input_format_error():
     with pytest.raises(KeyError):
         utils.cube.convert_extra_coords_dict_to_input_format(
             {"time": {"not axis": 0, "value": []}}, missing_axis_none)
-
-
-@pytest.mark.parametrize("test_input,expected", [
-    ((np.array([0, 1, 2]), np.array([3, 3, 3])),
-     [u.Quantity([[[0, 0, 0], [0, 0, 0], [0, 0, 0]],
-                  [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
-                  [[2, 2, 2], [2, 2, 2], [2, 2, 2]]], unit=u.pix),
-      u.Quantity([[[0, 0, 0], [1, 1, 1], [2, 2, 2]],
-                  [[0, 0, 0], [1, 1, 1], [2, 2, 2]],
-                  [[0, 0, 0], [1, 1, 1], [2, 2, 2]]], unit=u.pix),
-      u.Quantity([[[0, 1, 2], [0, 1, 2], [0, 1, 2]],
-                  [[0, 1, 2], [0, 1, 2], [0, 1, 2]],
-                  [[0, 1, 2], [0, 1, 2], [0, 1, 2]]], unit=u.pix)])
-    ])
-def test_get_pixel_quantities_for_dependent_axes(test_input, expected):
-    output = utils.cube._get_pixel_quantities_for_dependent_axes(test_input[0], test_input[1])
-    assert len(output) == len(expected)
-    for i in range(len(output)):
-        assert (output[i].value == expected[i].value).all()
-        assert output[i].unit == expected[i].unit

--- a/ndcube/tests/test_utils_cube.py
+++ b/ndcube/tests/test_utils_cube.py
@@ -129,7 +129,7 @@ def test_convert_extra_coords_dict_to_input_format_error():
                   [[0, 0, 0], [1, 1, 1], [2, 2, 2]]], unit=u.pix),
       u.Quantity([[[0, 1, 2], [0, 1, 2], [0, 1, 2]],
                   [[0, 1, 2], [0, 1, 2], [0, 1, 2]],
-                  [[0, 1, 2], [0, 1, 2], [0, 1, 2]]], unit=u.pix),])
+                  [[0, 1, 2], [0, 1, 2], [0, 1, 2]]], unit=u.pix)])
     ])
 def test_get_pixel_quantities_for_dependent_axes(test_input, expected):
     output = utils.cube._get_pixel_quantities_for_dependent_axes(test_input[0], test_input[1])

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -9,7 +9,8 @@ import copy
 import numpy as np
 import astropy.units as u
 
-__all__ = ['wcs_axis_to_data_axis', 'data_axis_to_wcs_axis', 'select_order']
+__all__ = ['wcs_axis_to_data_axis', 'data_axis_to_wcs_axis', 'select_order',
+           'convert_extra_coords_dict_to_input_format', 'get_axis_number_from_axis_name']
 
 
 def data_axis_to_wcs_axis(data_axis, missing_axis):
@@ -182,7 +183,7 @@ def _get_pixel_quantities_for_dependent_axes(dependent_axes, cube_dimensions):
     return quantity_list
 
 
-def _get_axis_number_from_axis_name(axis_name, world_axis_physical_types):
+def get_axis_number_from_axis_name(axis_name, world_axis_physical_types):
     """
     Returns axis number (numpy ordering) given a substring unique to a world axis type string.
 

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -142,8 +142,6 @@ def _get_pixel_quantities_for_dependent_axes(dependent_axes, cube_dimensions):
         Othogonal pixel quantities describing all pixels in cube in relevant dimensions.
 
     """
-
-    print(dependent_axes)
     n_dependent_axes = len(dependent_axes)
     n_dimensions = len(cube_dimensions)
     quantity_list = [u.Quantity(np.zeros(tuple(cube_dimensions[dependent_axes])),
@@ -182,3 +180,30 @@ def _get_pixel_quantities_for_dependent_axes(dependent_axes, cube_dimensions):
         # Replace pixel array for this axis in quantity_list.
         quantity_list[dependent_axis] = u.Quantity(coord_axis_array, unit=u.pix)
     return quantity_list
+
+
+def _get_axis_number_from_axis_name(axis_name, world_axis_physical_types):
+    """
+    Returns axis number (numpy ordering) given a substring unique to a world axis type string.
+
+    Parameters
+    ----------
+    axis_name: `str`
+        Name or substring of name of axis as defined by NDCube.world_axis_physical_types
+
+    world_axis_physical_types: iterable of `str`
+        Output from NDCube.world_axis_physical_types for relevant cube,
+        i.e. iterable of string axis names.
+
+    Returns
+    -------
+    axis_index[0]: `int`
+        Axis number (numpy ordering) corresponding to axis name
+    """
+    axis_index = [axis_name in world_axis_type for world_axis_type in world_axis_physical_types]
+    axis_index = np.arange(len(world_axis_physical_types))[axis_index]
+    if len(axis_index) != 1:
+        raise ValueError("User defined axis with a string that is not unique to "
+                         "a physical axis type. {0} not in any of {1}".format(
+                             str_axis, world_axis_types))
+    return axis_index[0]

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -4,7 +4,10 @@
 Utilities for ndcube.
 """
 
+import copy
+
 import numpy as np
+import astropy.units as u
 
 
 __all__ = ['wcs_axis_to_data_axis', 'data_axis_to_wcs_axis', 'select_order']
@@ -120,3 +123,63 @@ def convert_extra_coords_dict_to_input_format(extra_coords, missing_axis):
                 raise KeyError("extra coords dict can have keys 'wcs axis' or 'axis'.  Not both.")
             result.append((name, axis, extra_coords[name]["value"]))
         return result
+
+
+def _get_pixel_quantities_for_dependent_axes(dependent_axes, cube_dimensions):
+    """
+    Returns list of othogonal pixel quantities for cube axes which have dependent WCS translations.
+
+    Parameters
+    ----------
+    dependent_axis: `list` of `int`
+        Axis numbers in the numpy convention.
+
+    cube_dimensions: Iterable of `int`
+        Number of pixels in each dimension
+
+    Returns
+    -------
+    quantity_list: `list` of `astropy.units.Quantity`
+        Othogonal pixel quantities describing all pixels in cube in relevant dimensions.
+
+    """
+
+    print(dependent_axes)
+    n_dependent_axes = len(dependent_axes)
+    n_dimensions = len(cube_dimensions)
+    quantity_list = [u.Quantity(np.zeros(tuple(cube_dimensions[dependent_axes])),
+                                unit=u.pix)] * n_dimensions
+    for i, dependent_axis in enumerate(dependent_axes):
+        # Define list of indices/slice objects for accessing
+        # sections of dependent axis arrays that are to be
+        # replaced with orthogonal np.arange arrays.
+        slice_list = [0] * n_dependent_axes
+        slice_list[i] = slice(None)
+        # Define array of indices of axes in slice list not
+        # including the axis along which we are inserting
+        # np.arange.
+        other_axes_indices = list(range(n_dependent_axes))
+        del(other_axes_indices[i])
+        other_axes_indices = np.asarray(other_axes_indices)
+        other_axes_products = np.cumprod(cube_dimensions[other_axes_indices][::-1])[::-1]
+        other_axes_products = np.append(other_axes_products, 1)[1:]
+        # Determine total number of times we are going to
+        # insert np.arange into quantity array.
+        total_iters = np.prod(cube_dimensions[other_axes_indices])
+        coord_axis_array = copy.deepcopy(quantity_list[dependent_axis].value)
+        for k in range(total_iters):
+            # Determine mapping from iteration int to
+            # indices to insert to slice_list.
+            mod = k
+            l = 0
+            # Use while loop so that l will always equal
+            # n_dependent_axes[dependent_axis]-2 when loop is exited.
+            while l < n_dependent_axes-2:
+                slice_list[other_axes_indices[l]] = int(mod/other_axes_products[l])
+                mod = mod % other_axes_products[l]
+                l += 1
+            slice_list[other_axes_indices[l]] = mod
+            coord_axis_array[tuple(slice_list)] = np.arange(cube_dimensions[dependent_axis])
+        # Replace pixel array for this axis in quantity_list.
+        quantity_list[dependent_axis] = u.Quantity(coord_axis_array, unit=u.pix)
+    return quantity_list

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -166,18 +166,18 @@ def _get_pixel_quantities_for_dependent_axes(dependent_axes, cube_dimensions):
         # insert np.arange into quantity array.
         total_iters = np.prod(cube_dimensions[other_axes_indices])
         coord_axis_array = copy.deepcopy(quantity_list[dependent_axis].value)
-        for k in range(total_iters):
+        for j in range(total_iters):
             # Determine mapping from iteration int to
             # indices to insert to slice_list.
-            mod = k
-            l = 0
+            mod = j
+            k = 0
             # Use while loop so that l will always equal
             # n_dependent_axes[dependent_axis]-2 when loop is exited.
-            while l < n_dependent_axes-2:
-                slice_list[other_axes_indices[l]] = int(mod/other_axes_products[l])
-                mod = mod % other_axes_products[l]
-                l += 1
-            slice_list[other_axes_indices[l]] = mod
+            while k < n_dependent_axes-2:
+                slice_list[other_axes_indices[k]] = int(mod/other_axes_products[k])
+                mod = mod % other_axes_products[k]
+                k += 1
+            slice_list[other_axes_indices[k]] = mod
             coord_axis_array[tuple(slice_list)] = np.arange(cube_dimensions[dependent_axis])
         # Replace pixel array for this axis in quantity_list.
         quantity_list[dependent_axis] = u.Quantity(coord_axis_array, unit=u.pix)

--- a/ndcube/utils/sequence.py
+++ b/ndcube/utils/sequence.py
@@ -12,7 +12,7 @@ import numpy as np
 import astropy.units as u
 
 
-__all__ = ['SequenceSlice', 'SequenceItem', 'convert_item_to_sequence_items',
+__all__ = ['SequenceSlice', 'SequenceItem', 'slice_sequence', 'convert_item_to_sequence_items',
            'convert_cube_like_item_to_sequence_items', 'convert_slice_nones_to_ints']
 
 
@@ -245,7 +245,7 @@ def _index_sequence_as_cube(cubesequence, item):
     >>> # return zeroth time slice of cubeB in via normal CubeSequence indexing.
     >>> cs[1,:,0,:] # doctest: +SKIP
     >>> # Return same slice using this function
-    >>> index_sequence_as_cube(cs, (slice(0, cubeB.shape[0]), 0,
+    >>> _index_sequence_as_cube(cs, (slice(0, cubeB.shape[0]), 0,
     ...                             (slice(0, cubeB.shape[2])) # doctest: +SKIP
 
     """

--- a/ndcube/utils/sequence.py
+++ b/ndcube/utils/sequence.py
@@ -600,19 +600,24 @@ def _get_axis_extra_coord_names_and_units(cube_list, axis):
     # quantity) from each cube.
     for cube in cube_list:
         all_extra_coords = cube.extra_coords
-        all_extra_coords_keys = list(all_extra_coords.keys())
-        for coord_key in all_extra_coords_keys:
-            if all_extra_coords[coord_key]["axis"] == axis:
-                axis_coord_names.append(coord_key)
-                if isinstance(all_extra_coords[coord_key]["value"], u.Quantity):
-                    axis_coord_units.append(all_extra_coords[coord_key]["value"].unit)
-                else:
-                    axis_coord_units.append(None)
+        if all_extra_coords is not None:
+            all_extra_coords_keys = list(all_extra_coords.keys())
+            for coord_key in all_extra_coords_keys:
+                if all_extra_coords[coord_key]["axis"] == axis:
+                    axis_coord_names.append(coord_key)
+                    if isinstance(all_extra_coords[coord_key]["value"], u.Quantity):
+                        axis_coord_units.append(all_extra_coords[coord_key]["value"].unit)
+                    else:
+                        axis_coord_units.append(None)
     # Extra coords common between cubes will be repeated.  Get rid of
     # duplicate names and then only keep the units corresponding to
     # the first occurence of that name.
-    axis_coord_names, ind = np.unique(np.asarray(axis_coord_names), return_index=True)
-    axis_coord_units = np.asarray(axis_coord_units)[ind]
+    if len(axis_coord_names) > 0:
+        axis_coord_names, ind = np.unique(np.asarray(axis_coord_names), return_index=True)
+        axis_coord_units = np.asarray(axis_coord_units)[ind]
+    else:
+        axis_coord_names = None
+        axis_coord_units = None
     return axis_coord_names, axis_coord_units
 
 

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -106,41 +106,6 @@ class WCS(wcs.WCS):
             newheader['CTYPE' + axis] = projection
         return newheader
 
-    def dependent_axes(self, axis):
-        # Given an axis number in numpy ordering, returns the axes whose
-        # WCS translations are dependent, including itself.  Again,
-        # returned axes are in numpy ordering convention.
-        # Copied from WCSCoordinates class in glue-viz/glue github repo.
-
-        # TODO: we should cache this
-
-        # if distorted, all bets are off
-        try:
-            if any([self.sip, self.det2im1, self.det2im2]):
-                return tuple(range(self.naxis))
-        except AttributeError:
-            pass
-
-        # here, axis is the index number in numpy convention
-        # we flip with [::-1] because WCS and numpy index
-        # conventions are reversed
-        pc = np.array(self.wcs.get_pc()[::-1, ::-1])
-        ndim = pc.shape[0]
-        pc[np.eye(ndim, dtype=np.bool)] = 0
-        axes = self.get_axis_types()[::-1]
-
-        # axes rotated
-        if pc[axis, :].any() or pc[:, axis].any():
-            return tuple(range(ndim))
-
-        # XXX can spectral still couple with other axes by this point??
-        if axes[axis].get('coordinate_type') != 'celestial':
-            return (axis,)
-
-        # in some cases, even the celestial coordinates are
-        # independent. We don't catch that here.
-        return tuple(i for i, a in enumerate(axes) if a.get('coordinate_type') == 'celestial')
-
 
 def _wcs_slicer(wcs, missing_axis, item):
     """
@@ -317,3 +282,39 @@ def reindex_wcs(wcs, inds):
     outwcs._naxis = [wcs._naxis[i] for i in inds]
 
     return outwcs
+
+
+def dependent_axes(wcs_object, axis):
+    # Given an axis number in numpy ordering, returns the axes whose
+    # WCS translations are dependent, including itself.  Again,
+    # returned axes are in numpy ordering convention.
+    # Copied from WCSCoordinates class in glue-viz/glue github repo.
+
+    # TODO: we should cache this
+
+    # if distorted, all bets are off
+    try:
+        if any([wcs_object.sip, wcs_object.det2im1, wcs_object.det2im2]):
+            return tuple(range(wcs_object.naxis))
+    except AttributeError:
+        pass
+
+    # here, axis is the index number in numpy convention
+    # we flip with [::-1] because WCS and numpy index
+    # conventions are reversed
+    pc = np.array(wcs_object.wcs.get_pc()[::-1, ::-1])
+    ndim = pc.shape[0]
+    pc[np.eye(ndim, dtype=np.bool)] = 0
+    axes = wcs_object.get_axis_types()[::-1]
+
+    # axes rotated
+    if pc[axis, :].any() or pc[:, axis].any():
+        return tuple(range(ndim))
+
+    # XXX can spectral still couple with other axes by this point??
+    if axes[axis].get('coordinate_type') != 'celestial':
+        return (axis,)
+
+    # in some cases, even the celestial coordinates are
+    # independent. We don't catch that here.
+    return tuple(i for i, a in enumerate(axes) if a.get('coordinate_type') == 'celestial')

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy import wcs
 from astropy.wcs._wcs import InconsistentAxisTypesError
 
-__all__ = ['WCS', 'reindex_wcs', 'wcs_ivoa_mapping']
+__all__ = ['WCS', 'reindex_wcs', 'wcs_ivoa_mapping', 'get_dependent_axes']
 
 
 class TwoWayDict(UserDict):
@@ -284,7 +284,7 @@ def reindex_wcs(wcs, inds):
     return outwcs
 
 
-def dependent_axes(wcs_object, axis):
+def get_dependent_axes(wcs_object, axis):
     # Given an axis number in numpy ordering, returns the axes whose
     # WCS translations are dependent, including itself.  Again,
     # returned axes are in numpy ordering convention.


### PR DESCRIPTION
This PR introduces a new method/property, ```NDCube.all_world_coords``` which returns the world coordinates of all pixels along each axis in the ```NDCube``` instance.  It handles cases of dependent axes as well as independent ones.