### PR TITLE
Travis changes

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,9 +1,14 @@
+scanner:
+    diff_only: True  # If True, errors caused by only the patch are shown
+
 pycodestyle:
-  max-line-length: 100 # Default is 79 in PEP8
+    max-line-length: 100  # Default is 79 in PEP8
 
 exclude:
-  - setup.py
-  - ez_setup.py
-  - ah_bootstrap.py
-  - astropy_helpers/
-  - docs/conf.py
+    - setup.py
+    - ez_setup.py
+    - ah_bootstrap.py
+    - astropy_helpers/
+    - docs/conf.py
+
+descending_issues_order: True # If True, PEP8 issues in message will be displayed in descending order of line numbers in the file

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ language: c
 os:
     - linux
 
+# Build Stage first step
+stage: Initial tests
+
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
-# The apt packages below are needed for sphinx builds. A full list of packages
-# that can be included can be found here:
-#
-# https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
+# The apt packages below are needed for sphinx builds.
 
 addons:
     apt:
@@ -23,42 +23,29 @@ addons:
 
 env:
     global:
-
-        # The following versions are the 'default' for tests, unless
-        # overridden underneath. They are defined here in order to save having
-        # to repeat them for all configurations.
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - SUNPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
-        - EVENT_TYPE='pull_request push'
-
-        
-        # List other runtime dependencies for the package that are available as
-        # conda packages here.
-        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock pandas nomkl pytest-cov coverage glymur suds-jurko sphinx<1.7'
-        
-        # List other runtime dependencies for the package that are available as
-        # pip packages here.
+        - EVENT_TYPE='pull_request push cron'
+        - CONDA_DEPENDENCIES='openjpeg Cython jinja2 scipy matplotlib mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock pandas nomkl pytest-cov coverage glymur suds-jurko sphinx'
         - PIP_DEPENDENCIES='sunpy-sphinx-theme pytest-astropy'
-
-        # Conda packages for affiliated packages are hosted in channel
-        # "astropy" while builds for astropy LTS with recent numpy versions
-        # are in astropy-ci-extras. If your package uses either of these,
-        # add the channels to CONDA_CHANNELS along with any other channels
-        # you want to use.
-        - CONDA_CHANNELS='sunpy'
-
-        # If there are matplotlib or other GUI tests, uncomment the following
-        # line to use the X virtual framebuffer.
-        # - SETUP_XVFB=True
-
+        - CONDA_CHANNELS='sunpy astropy-ci-extras'
     matrix:
         # Make sure that egg_info works without dependencies
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+
+stages:
+   # Do the install jobs and one offline test, it will not proceed if any fail
+   - name: Initial tests
+   # Cron only tests
+   - name: Cron tests
+     if: type = cron
+   # Do the rest of the tests
+   - name: Comprehensive tests
 
 matrix:
 
@@ -66,60 +53,51 @@ matrix:
     fast_finish: true
 
     include:
-        # Try MacOS X
-        # - os: osx
-        #   env: SETUP_CMD='test'
+
+        # Do a basic test.
+        - os: linux
+          stage: Initial tests
+          env: SETUP_CMD='test'
+
+        # Do a PEP8 test with pycodestyle
+        - os: linux
+          stage: Initial tests
+          env: MAIN_CMD='pycodestyle ndcube --count' SETUP_CMD=''
 
         # Do a coverage test.
         - os: linux
+          stage: Comprehensive tests
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - os: linux
+          stage: Comprehensive tests
           env: SETUP_CMD='build_docs -w'
 
-        # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
+        # Astropy LTS
         - os: linux
-          env: ASTROPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
-        - os: linux
-          env: SUNPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
+          stage: Comprehensive tests
+          env: ASTROPY_VERSION=lts
 
-        # Do a PEP8 test with pycodestyle
+        # Astropy Master (CRON)
         - os: linux
-          env: MAIN_CMD='pycodestyle ndcube --count' SETUP_CMD=''
+          stage: Cron tests
+          env: ASTROPY_VERSION=development
+
+        # SunPy Master (CRON)
+        - os: linux
+          stage: Cron tests
+          env: SUNPY_VERSION=development
+
+        # Mac OS (CRON)
+        - os: osx
+          stage: Cron tests
+          env: SETUP_CMD='test'
 
 install:
-
-    # We now use the ci-helpers package to set up our testing environment.
-    # This is done by using Miniconda and then using conda and pip to install
-    # dependencies. Which dependencies are installed using conda and pip is
-    # determined by the CONDA_DEPENDENCIES and PIP_DEPENDENCIES variables,
-    # which should be space-delimited lists of package names. See the README
-    # in https://github.com/astropy/ci-helpers for information about the full
-    # list of environment variables that can be used to customize your
-    # environment. In some cases, ci-helpers may not offer enough flexibility
-    # in how to install a package, in which case you can have additional
-    # commands in the install: section below.
-
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
 
-    # As described above, using ci-helpers, you should be able to set up an
-    # environment with dependencies installed using conda and pip, but in some
-    # cases this may not provide enough flexibility in how to install a
-    # specific dependency (and it will not be able to install non-Python
-    # dependencies). Therefore, you can also include commands below (as
-    # well as at the start of the install section or in the before_install
-    # section if they are needed before setting up conda) to install any
-    # other dependencies.
-
 script:
    - $MAIN_CMD $SETUP_CMD
-
-after_success:
-    # If coveralls.io is set up for this package, uncomment the line below.
-    # The coveragerc file may be customized as needed for your package.
-    # - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='ndcube/tests/coveragerc'; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,25 +10,13 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-
-      # For this package-template, we include examples of Cython modules,
-      # so Cython is required for testing. If your package does not include
-      # Cython code, you can set CONDA_DEPENDENCIES=''
-      CONDA_DEPENDENCIES: "Cython"
-
-      # Conda packages for affiliated packages are hosted in channel
-      # "astropy" while builds for astropy LTS with recent numpy versions
-      # are in astropy-ci-extras. If your package uses either of these,
-      # add the channels to CONDA_CHANNELS along with any other channels
-      # you want to use.
-      # CONDA_CHANNELS: "astropy-ci-extras astropy"
+      CONDA_CHANNELS: "astropy-ci-extras sunpy"
+      CONDA_DEPENDENCIES: "Cython jinja2 scipy matplotlib mock requests beautifulsoup4 sqlalchemy scikit-image pytest-mock pandas pytest-cov coverage glymur suds-jurko sphinx sunpy"
+      PIP_DEPENDENCIES: "sunpy-sphinx-theme pytest-astropy"
 
   matrix:
 
-      # We test Python 2.7 and 3.6 because 2.7 is the supported Python 2
-      # release of Astropy and Python 3.6 is the latest Python 3 release.
-
-      - PYTHON_VERSION: "2.7"
+      - PYTHON_VERSION: "3.5"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,4 +180,3 @@ if eval(setup_cfg.get('edit_on_github')):
 
 # -- Resolving issue number to links in changelog -----------------------------
 github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_project'])
-


### PR DESCRIPTION
Main "Work"

Stage Builds: First tests are to install package and run PEP8 and test suite
Second round are to build vs LTS Astropy, Run coverage and build docs
3 CronJobs: Astropy Dev, SunPy Dev, Mac OS X

Also made pep8speaks only show diff for PR. We might want to discuss this one. I want this on sunpy main.  Also wondering if we can get it to ignore the files which it seems to ignore in the wrong way. 