### PR TITLE
Bug fix for get_dependent_axes

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -330,7 +330,7 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
         axes_translated = np.zeros_like(int_axes, dtype=bool)
         # Determine which axes are dependent on others.
         # Ensure the axes are in numerical order.
-        dependent_axes = [list(utils.wcs.get_dependent_axes(self.wcs, axis))
+        dependent_axes = [list(utils.wcs.get_dependent_axes(self.wcs, axis, self.missing_axis))
                           for axis in int_axes]
         n_dependent_axes = [len(da) for da in dependent_axes]
         # Iterate through each axis and perform WCS translation.

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -862,7 +862,12 @@ def test_all_world_coords_with_input(test_input, expected):
                                  [1., 1., 1.]], unit=u.deg),
                      u.Quantity([[1.26915033e-05, 4.99987815e-01, 9.99962939e-01],
                                  [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]], unit=u.deg),
-                     u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)))
+                     u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m))),
+    ((cubem[:, :, 0]), (u.Quantity([[0.60002173, 0.59999127, 0.5999608],
+                                    [1., 1., 1.]], unit=u.deg),
+                        u.Quantity([[1.26915033e-05, 4.99987815e-01, 9.99962939e-01],
+                                    [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]],
+                                   unit=u.deg)))
     ])
 def test_axis_world_coords_without_input(test_input, expected):
     all_coords = test_input.axis_world_coords()

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -319,4 +319,4 @@ def get_dependent_axes(wcs_object, axis, missing_axis):
 
     # in some cases, even the celestial coordinates are
     # independent. We don't catch that here.
-    return tuple([i for i, a in enumerate(axes) if a.get('coordinate_type') == 'celestial'])
+    return tuple(i for i, a in enumerate(axes) if a.get('coordinate_type') == 'celestial')


### PR DESCRIPTION
This PR fixes a bug in ```utils.wcs.get_dependent_axes``` whereby missing axes were not being accounted for.  This used to cause ```NDCube.axis_world_coords``` to crash when missing axes were in certain orders.