### PR TITLE
Plotting lower dimension NDCubeSequences

### DIFF
--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -172,11 +172,20 @@ class NDCubeSequence:
         return sequence_extra_coords
 
     def plot(self, *args, **kwargs):
-        if self._common_axis is None:
-            i = ani.ImageAnimatorNDCubeSequence(self, *args, **kwargs)
+        naxis = len(self.dimensions)
+        if naxis == 1:
+            plot = ani._plot_1D_sequence(self, *args, **kwargs)
+        elif naxis == 2:
+            if self._common_axis == 0:
+                plot = ani._plot_2D_sequence_with_common_axis(self, *args, **kwargs)
+            else:
+                plot = ani._plot_2D_sequence_without_common_axis(self, *args, **kwargs)
         else:
-            i = ani.ImageAnimatorCommonAxisNDCubeSequence(self, *args, **kwargs)
-        return i
+            if self._common_axis is None:
+                plot = ani.ImageAnimatorNDCubeSequence(self, *args, **kwargs)
+            else:
+                plot = ani.ImageAnimatorCommonAxisNDCubeSequence(self, *args, **kwargs)
+        return plot
 
     def explode_along_axis(self, axis):
         """

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -10,7 +10,7 @@ from ndcube.visualization import animation as ani
 __all__ = ['NDCubeSequence']
 
 
-class NDCubeSequence:
+class NDCubeSequence(object):
     """
     Class representing list of cubes.
 
@@ -171,13 +171,19 @@ class NDCubeSequence:
             sequence_extra_coords = None
         return sequence_extra_coords
 
-    def plot(self, *args, **kwargs):
+    def plot(self, axis_ranges=None, plot_as_cube=False, *args, **kwargs):
+        # axis_ranges is list of same length as number of dimensions
         naxis = len(self.dimensions)
         if naxis == 1:
             plot = ani._plot_1D_sequence(self, *args, **kwargs)
         elif naxis == 2:
-            if self._common_axis == 0:
-                plot = ani._plot_2D_sequence_with_common_axis(self, *args, **kwargs)
+            if (self._common_axis is not None) and (plot_as_cube is True):
+                if (axis_ranges is not None) and isinstance(axis_ranges[self._common_axis], str):
+                    x_axis_extra_coord = axis_ranges[self._common_axis]
+                else:
+                    x_axis_extra_coord = None
+                plot = ani._plot_2D_sequence_with_common_axis(
+                    self, x_axis_extra_coord=x_axis_extra_coord, *args, **kwargs)
             else:
                 plot = ani._plot_2D_sequence_without_common_axis(self, *args, **kwargs)
         else:

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -171,11 +171,18 @@ class NDCubeSequence(object):
             sequence_extra_coords = None
         return sequence_extra_coords
 
-    def plot(self, axis_ranges=None, plot_as_cube=False, *args, **kwargs):
+    def plot(self, axis_ranges=None, plot_as_cube=False, unit_x_axis=None, unit_y_axis=None,
+             *args, **kwargs):
         # axis_ranges is list of same length as number of dimensions
         naxis = len(self.dimensions)
         if naxis == 1:
-            plot = ani._plot_1D_sequence(self, *args, **kwargs)
+            if (axis_ranges is not None) and isinstance(axis_ranges[0], str):
+                x_axis_extra_coord = axis_ranges[0]
+            else:
+                x_axis_extra_coord = None
+            plot = ani._plot_1D_sequence(self, x_axis_extra_coord=x_axis_extra_coord,
+                                         unit_x_axis=unit_x_axis, unit_y_axis=unit_y_axis,
+                                         *args, **kwargs)
         elif naxis == 2:
             if (self._common_axis is not None) and (plot_as_cube is True):
                 if (axis_ranges is not None) and isinstance(axis_ranges[self._common_axis], str):

--- a/ndcube/utils/sequence.py
+++ b/ndcube/utils/sequence.py
@@ -671,3 +671,28 @@ def _get_int_axis_extra_coords(cube_list, axis_coord_names, axis_coord_units, ax
         else:
             axis_extra_coords[coord_key] = np.asarray(coord_values)
     return axis_extra_coords
+
+
+def _get_all_cube_units(sequence_data):
+    """
+    Return units of a sequence of NDCubes.
+
+    Raises an error if any of the cube's don't have the unit attribute set.
+
+    Parameters
+    ----------
+    sequence_data: iterable of `ndcube.NDCube` of `astropy.nddata.NDData`.
+
+    Returns
+    -------
+    sequence_units: `list` of `astropy.units.Unit`
+       The unit of each cube in the sequence.
+
+    """
+    sequence_units = []
+    for i, cube in enumerate(sequence_data):
+        if cube.unit is None:
+            raise ValueError("{0}th cube in sequence does not have unit set.".format(i))
+        else:
+            sequence_units.append(cube.unit)
+    return sequence_units

--- a/ndcube/visualization/animation.py
+++ b/ndcube/visualization/animation.py
@@ -197,7 +197,18 @@ def _plot_2D_sequence_without_common_axis(cubesequence, image_axes=[-1, -2], uni
         Default: ['x', 'y']
 
     """
-    pass
+    # Check that the unit attribute is set of all cubes and
+    # derive unit_y_axis if not set.
+    sequence_units, unit = _determine_sequence_units(cubesequence.data, unit)
+    # If all cubes have unit set, create a y data quantity from cube's data.
+    if sequence_units is not None:
+        data = np.stack([(cube.data * sequence_units[i]).to(unit).value
+                         for i, cube in enumerate(cubesequence.data)])
+    else:
+        data = np.stack([cube.data for i, cube in enumerate(cubesequence.data)])
+    # Plot image.  !!!!This implementation does not plot real world axes!!!!!
+    plot = plt.imshow(data, **kwargs)
+    return plot
 
 
 def _plot_2D_sequence_with_common_axis(cubesequence, unit_x_axis=None, unit_y_axis=None,

--- a/ndcube/visualization/animation.py
+++ b/ndcube/visualization/animation.py
@@ -286,6 +286,8 @@ def _determine_sequence_units(cubesequence_data, unit=None):
     """
     Returns units of cubes in sequence and derives data unit if not set.
 
+    If not all cubes have their unit attribute set, an error is raised.
+
     Parameters
     ----------
     cubesequence_data: `list` of `ndcube.NDCube`
@@ -293,6 +295,15 @@ def _determine_sequence_units(cubesequence_data, unit=None):
 
     unit: `astropy.units.Unit` or `None`
         If None, an appropriate unit is derived from first cube in sequence.
+
+    Returns
+    -------
+    sequence_units: `list` of `astropy.units.Unit`
+        Unit of each cube.
+
+    unit: `astropy.units.Unit`
+        If input unit is not None, then the same as input.  Otherwise it is
+        the unit of the first cube in the sequence.
 
     """
     # Check that the unit attribute is set of all cubes.  If not, unit_y_axis
@@ -303,7 +314,7 @@ def _determine_sequence_units(cubesequence_data, unit=None):
     # If all cubes have unit set, create a data quantity from cube's data.
     if sequence_units is not None:
         if unit is None:
-           unit = sequence_units[0]
+            unit = sequence_units[0]
     else:
         unit = None
     return sequence_units, unit

--- a/ndcube/visualization/animation.py
+++ b/ndcube/visualization/animation.py
@@ -1,4 +1,5 @@
 import numpy as np
+import matplotlib.pyplot as plt
 from sunpy.visualization.imageanimator import ImageAnimatorWCS
 
 from ndcube import utils
@@ -177,3 +178,83 @@ class ImageAnimatorCommonAxisNDCubeSequence(ImageAnimatorWCS):
             self._set_unit_in_axis(self.axes)
             im.set_array(self.data[self.frame_slice])
             slider.cval = val
+
+
+def _plot_2D_sequence_without_common_axis(cubesequence, image_axes=[-1, -2], **kwargs):
+    """
+    Plots an NDCubeSequence of 1D NDCubes without a common axis as an image.
+
+    Parameters
+    ----------
+    cubesequence: `ndcube.NDCubeSequence`
+       NDCubeSequence instance to be plotted.
+
+    image_axes: `list`
+        The first axis in WCS object will become the first axis of image_axes and
+        second axis in WCS object will become the second axis of image_axes.
+        Default: ['x', 'y']
+
+    """
+    pass
+
+
+def _plot_2D_sequence_with_common_axis(cubesequence, unit_x_axis=None, unit_y_axis=None,
+                                       **kwargs):
+    """
+    Plots an NDCubeSequence of 1D NDCubes with a common axis as line plot.
+
+    Parameters
+    ----------
+    cubesequence: `ndcube.NDCubeSequence`
+       NDCubeSequence instance to be plotted.
+
+    unit_x_axis: `astropy.units.unit` or valid unit `str`
+        The units into which the x-axis should be displayed.
+
+    unit_y_axis: `astropy.units.unit` or valid unit `str`
+        The units into which the y-axis should be displayed.  The unit attribute of all
+        the sub-cubes must be set to a compatible unit to set this kwarg.
+
+    """
+    pass
+
+
+def _plot_1D_sequence(cubesequence, unit_y_axis=None, **kwargs):
+    """
+    Plots an NDCubeSequence of scalar NDCubes as line plot.
+
+    A scalar NDCube is one whose NDCube.data is a scalar rather than an array.
+
+    Parameters
+    ----------
+    cubesequence: `ndcube.NDCubeSequence`
+       NDCubeSequence instance to be plotted.
+
+    unit_x_axis: `astropy.units.unit` or valid unit `str`
+        The units into which the x-axis should be displayed.
+
+    unit_y_axis: `astropy.units.unit` or valid unit `str`
+        The units into which the y-axis should be displayed.  The unit attribute of all
+        the sub-cubes must be set to a compatible unit to set this kwarg.
+
+    """
+    # Check that the unit attribute is set of all cubes.  If not, unit_y_axis
+    try:
+        sequence_units = np.array(utils.sequence._get_all_cube_units(cubesequence.data))
+    except ValueError:
+        sequence_units = None
+    # If all cubes have unit set, create a data quantity from cube's data.
+    if sequence_units is not None:
+        if unit_y_axis is None:
+           unit_y_axis = sequence_units[0]
+        ydata = u.Quantity([cube.data * sequence_units[i]
+                            for i, cube in enumerate(cubesequence.data)], unit=unit_y_axis)
+    # If not all cubes have their unit set, create a data array from cube's data.
+    else:
+        unit_y_axis = None
+        ydata = np.array([cube.data for cube in cubesequence.data])
+    # Define xdata
+    xdata = np.arange(ydata.size)
+    # Plot data
+    plot = plt.plot(xdata, ydata, **kwargs)
+    return plot


### PR DESCRIPTION
This PR enhances the plotting functionality of ```NDCubeSequence.plot``` when the sub-cubes are scalar (NDCube.data is scalar) or 1D.

If the sub-cubes are scalar, a line plot is returned.  If the sub-cubes are 1D and have a common axis, a line plot is also returned.  If the sub-cubes are 1D and there is no common axis, a 2D image is returned.