### PR TITLE
Give NDCube a False mask on instantiation if one not provided by user.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ API Changes
   implementation in ``glue-viz`` which is intended to be merged into
   ``astropy`` in the future.  This API change helped fix the
   ``NDCube.world_axis_physical_type`` bug listed below. [#80]
+- ``NDCube`` generates a False mask (all pixels unmasked) on
+  instantiation if one is not provided by the user. [#89]
 
 Bug Fixes
 ---------

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -166,6 +166,8 @@ class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMix
 
     def __init__(self, data, wcs, uncertainty=None, mask=None, meta=None,
                  unit=None, extra_coords=None, copy=False, missing_axis=None, **kwargs):
+        if mask is None:
+            mask = np.zeros_like(data, dtype=bool)
         if missing_axis is None:
             self.missing_axis = [False]*wcs.naxis
         else:


### PR DESCRIPTION
This PR addresses issue #88.