### PR TITLE
Converting between negative data and wcs axes.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,4 +21,6 @@ Bug Fixes
   scalar ``.data``. [#79]
 - Fixed ``NDCube.world_axis_physical_types`` in cases where there is a
   ``missing`` WCS axis. [#80]
+- Fixed bugs in converting between negative data and WCS axis
+  numbers. [#91]
 

--- a/ndcube/tests/test_utils_cube.py
+++ b/ndcube/tests/test_utils_cube.py
@@ -28,9 +28,18 @@ extra_coords_dict_wcs = {"time": {"wcs axis": 0,
      ((0, missing_axis_none), 2),
      ((1, missing_axis_none), 1),
      ((0, missing_axis_0_2), 1),
-     ((1, missing_axis_1), 0)])
+     ((1, missing_axis_1), 0),
+     ((-1, missing_axis_0_2), 1),
+     ((-2, missing_axis_1), 2),
+     ((-1, missing_axis_none), 0)])
 def test_data_axis_to_wcs_axis(test_input, expected):
     assert utils.cube.data_axis_to_wcs_axis(*test_input) == expected
+
+
+@pytest.mark.parametrize("test_input", [(-2, missing_axis_0_2), (1, missing_axis_0_2)])
+def test_data_axis_to_wcs_axis_error(test_input):
+    with pytest.raises(IndexError):
+        utils.cube.data_axis_to_wcs_axis(*test_input)
 
 
 @pytest.mark.parametrize(
@@ -39,9 +48,20 @@ def test_data_axis_to_wcs_axis(test_input, expected):
      ((0, missing_axis_none), 2),
      ((1, missing_axis_none), 1),
      ((1, missing_axis_0_2), 0),
-     ((0, missing_axis_1), 1)])
+     ((0, missing_axis_1), 1),
+     ((-1, missing_axis_0_2), None),
+     ((-2, missing_axis_0_2), 0),
+     ((-2, missing_axis_1), None),
+     ((-3, missing_axis_1), 1),
+     ((-1, missing_axis_none), 0)])
 def test_wcs_axis_to_data_axis(test_input, expected):
     assert utils.cube.wcs_axis_to_data_axis(*test_input) == expected
+
+
+@pytest.mark.parametrize("test_input", [(-10, missing_axis_0_2), (10, missing_axis_0_2)])
+def test_wcs_axis_to_data_axis_error(test_input):
+    with pytest.raises(IndexError):
+        utils.cube.data_axis_to_wcs_axis(*test_input)
 
 
 def test_select_order():

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -17,6 +17,9 @@ def data_axis_to_wcs_axis(data_axis, missing_axis):
     else:
         if data_axis < 0:
             data_axis = np.invert(missing_axis).sum() + data_axis
+        if data_axis > np.invert(missing_axis).sum()-1 or data_axis < 0:
+            raise IndexError("Data axis out of range.  Number data axes = {0}".format(
+                np.invert(missing_axis).sum()))
         result = len(missing_axis)-np.where(np.cumsum(
             [b is False for b in missing_axis][::-1]) == data_axis+1)[0][0]-1
     return result
@@ -29,6 +32,9 @@ def wcs_axis_to_data_axis(wcs_axis, missing_axis):
     else:
         if wcs_axis < 0:
             wcs_axis = len(missing_axis) + wcs_axis
+        if wcs_axis > len(missing_axis)-1 or wcs_axis < 0:
+            raise IndexError("WCS axis out of range.  Number WCS axes = {0}".format(
+                len(missing_axis)))
         if missing_axis[wcs_axis]:
             result = None
         else:

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -15,6 +15,8 @@ def data_axis_to_wcs_axis(data_axis, missing_axis):
     if data_axis is None:
         result = None
     else:
+        if data_axis < 0:
+            data_axis = np.invert(missing_axis).sum() + data_axis
         result = len(missing_axis)-np.where(np.cumsum(
             [b is False for b in missing_axis][::-1]) == data_axis+1)[0][0]-1
     return result
@@ -25,6 +27,8 @@ def wcs_axis_to_data_axis(wcs_axis, missing_axis):
     if wcs_axis is None:
         result = None
     else:
+        if wcs_axis < 0:
+            wcs_axis = len(missing_axis) + wcs_axis
         if missing_axis[wcs_axis]:
             result = None
         else:


### PR DESCRIPTION
This PR addresses bugs highlighted by Issue #85 in converting between data and wcs axis numbers on an ```NDCube``` when the axis number is negative.  This is fixed by first converting the negative axis number to the corresponding positive one and then performing the conversion.