### PR TITLE
Separate plotting from NDCube base class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,12 @@
 
 New Features
 ------------
-- Added installation instructions to docs. [#77]
+- Created a new `~ndcube.NDCubeBase` which has all the functionality
+  of `~ncube.NDCube` except the plotting.  The old ``NDCubeBase``
+  which outlined the ``NDCube`` API was renamed ``NDCubeABC``.
+  `~ndcube.NDCube` has all the same functionality as before except is
+  now simply inherits from `~ndcube.NDCubeBase` and
+  `~ndcube.mixins.plotting.NDCubePlotMixin`.
 
 API Changes
 -----------
@@ -18,8 +23,12 @@ Bug Fixes
 ---------
 
 
-1.0.1 (Unreleased)
+1.0.1
 ==================
+
+New Features
+------------
+- Added installation instructions to docs. [#77]
 
 Bug Fixes
 ---------

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -12,7 +12,7 @@ from ndcube.utils.wcs import wcs_ivoa_mapping
 from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
 
 
-__all__ = ['NDCubeBase', 'NDCube', 'NDCubeOrdered']
+__all__ = ['NDCubeABC', 'NDCubeBase', 'NDCube', 'NDCubeOrdered']
 
 
 class NDCubeMetaClass(abc.ABCMeta, InheritDocstrings):
@@ -21,7 +21,7 @@ class NDCubeMetaClass(abc.ABCMeta, InheritDocstrings):
     """
 
 
-class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
+class NDCubeABC(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
 
     @abc.abstractmethod
     def pixel_to_world(self, *quantity_axis_list):
@@ -109,7 +109,7 @@ class NDCubeBase(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
         """
 
 
-class NDCube(NDCubeSlicingMixin, NDCubePlotMixin, astropy.nddata.NDArithmeticMixin, NDCubeBase):
+class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
     """
     Class representing N dimensional cubes.
     Extra arguments are passed on to `~astropy.nddata.NDData`.
@@ -463,6 +463,10 @@ Length of NDCube: {lengthNDCube}
 Axis Types of NDCube: {axis_type}
 """.format(wcs=self.wcs.__repr__(), lengthNDCube=self.dimensions,
            axis_type=self.world_axis_physical_types))
+
+
+class NDCube(NDCubeBase, NDCubePlotMixin, astropy.nddata.NDArithmeticMixin):
+    pass
 
 
 class NDCubeOrdered(NDCube):


### PR DESCRIPTION
This PR creates a new ```NDCubeBase``` class that contains all the ```NDCube``` functionality except plotting.  This allows custom plotting mixin classes to be used with ```NDCube``` and stops the basic version of ```NDCube``` being dependent on ```sunpy```.  This was achieved by doing the following:
* Rename old ```NDCubeBase``` to ```NDCubeABC```
* Rename old ```NDCube``` class to ```NDCubeBase``` and remove the ```NDCubePlotMixin``` and ```astropy.nddata.NDArithmeticMixin``` mixin classes from its inheritence.
* Create new ```NDCube``` class which inherits from new ```NDCubeBase``` and the ```NDCubePlotMixin``` and ```astropy.nddata.NDArithmeticMixin``` mixin classes.