### PR TITLE
Remove dependence of NDCube.cube_like_dimensions on NDCube.dimensions

### DIFF
--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -40,6 +40,10 @@ class NDCubeSequenceBase:
 
     @property
     def dimensions(self):
+        return self._dimensions
+
+    @property
+    def _dimensions(self):
         dimensions = [len(self.data) * u.pix] + list(self.data[0].dimensions)
         if len(dimensions) > 1:
             # If there is a common axis, length of cube's along it may not
@@ -62,8 +66,8 @@ class NDCubeSequenceBase:
     def cube_like_dimensions(self):
         if type(self._common_axis) is not int:
             raise TypeError("Common axis must be set.")
-        dimensions = list(self.dimensions)
-        cube_like_dimensions = list(self.dimensions[1:])
+        dimensions = list(self._dimensions)
+        cube_like_dimensions = list(self._dimensions[1:])
         if dimensions[self._common_axis+1].isscalar:
             cube_like_dimensions[self._common_axis] = \
               u.Quantity(dimensions[0].value * dimensions[self._common_axis+1].value, unit=u.pix)
@@ -72,6 +76,7 @@ class NDCubeSequenceBase:
         # Combine into single Quantity
         cube_like_dimensions = u.Quantity(cube_like_dimensions, unit=u.pix)
         return cube_like_dimensions
+
 
     @property
     def cube_like_world_axis_physical_types(self):

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -77,7 +77,6 @@ class NDCubeSequenceBase:
         cube_like_dimensions = u.Quantity(cube_like_dimensions, unit=u.pix)
         return cube_like_dimensions
 
-
     @property
     def cube_like_world_axis_physical_types(self):
         return self.data[0].world_axis_physical_types


### PR DESCRIPTION
Some lines to avoid a cycling call when dimensions is over-writing. See [PR 83](https://github.com/sunpy/irispy/pull/83#pullrequestreview-119811642) in irispy for more information.