### PR TITLE
Solve a plotting bug when NDCubeSequence is used as a Cube-like

### DIFF
--- a/ndcube/mixins/sequence_plotting.py
+++ b/ndcube/mixins/sequence_plotting.py
@@ -809,7 +809,7 @@ class ImageAnimatorCubeLikeNDCubeSequence(ImageAnimatorWCS):
             [c.dimensions[0].value for c in seq.data], dtype=int))
         # Add dimensions of length 1 of concatenated data array
         # shape for an missing axes.
-        if seq[0].wcs.naxis != len(seq.dimensions) - 1:
+        if seq[0].wcs.naxis != len(seq._dimensions) - 1:
             new_shape = list(data_concat.shape)
             for i in np.arange(seq[0].wcs.naxis)[seq[0].missing_axis[::-1]]:
                 new_shape.insert(i, 1)


### PR DESCRIPTION
Here I changed `dimensions` to `_dimensions` as we modified it in `ndcube.ndcube_sequence.py` (L 41-59) see PR #121 

Must be merged before PR[#87](https://github.com/sunpy/irispy/pull/87) in irispy.
