### PR TITLE
Prevent NDCube.world_axis_physical_types crashing if WCS CTYPE not supported by IVOA mapping dict

### DIFF
--- a/changelog/164.bugfix.rst
+++ b/changelog/164.bugfix.rst
@@ -1,0 +1,1 @@
+`ndcube.NDCube.world_axis_physical_types` now sets the axis label to the WCS CTYPE if no corresponding IVOA name can be found.

--- a/docs/ndcube.rst
+++ b/docs/ndcube.rst
@@ -351,7 +351,7 @@ is a list of `~astropy.units.Quantity` objects in pixel unit.::
   >>> pixel_coords = my_cube.world_to_pixel(
   ... 1.400069678 * u.deg, 1.49986193 * u.deg, 1.10000000e-09 * u.m)
   >>> pixel_coords
-  [<Quantity 2.00000001 pix>, <Quantity 3. pix>, <Quantity 4. pix>]
+  [<Quantity 2.00000003 pix>, <Quantity 3. pix>, <Quantity 4. pix>]
 
 Note that both `~ndcube.NDCube.pixel_to_pixel` and
 `~ndcube.NDCube.world_to_pixel` can handle non-integer pixels.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -233,15 +233,23 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                 # Find keys in wcs_ivoa_mapping dict that represent start of CTYPE.
                 # Ensure CTYPE is capitalized.
                 keys = list(filter(lambda key: ctype[i].upper().startswith(key), wcs_ivoa_mapping))
+                # Assuming CTYPE is supported by wcs_ivoa_mapping, use its corresponding axis name.
+                if len(keys) == 1:
+                    key = key[0]
+                # If CTYPE not supported, raise a warning and set the axis name to CTYPE.
+                elif len(keys) == 0:
+                    warnings.warn("CTYPE not recognized by ndcube. "
+                                  "Please raise an issue at "
+                                  "https://github.com/sunpy/ndcube/issues citing the "
+                                  "unsupported CTYPE as we'll include it: "
+                                  "CTYPE = {0}".format(ctype[i]))
                 # If there are multiple valid keys, raise an error.
-                if len(keys) != 1:
+                else:
                     raise ValueError("Non-unique CTYPE key.  Please raise an issue at "
-                                     "https://github.com/sunpy/ndcube/issues citing the"
+                                     "https://github.com/sunpy/ndcube/issues citing the "
                                      "following  CTYPE and non-unique keys: "
                                      "CTYPE = {0}; keys = {1}".format(ctype[i], keys))
-                else:
-                    key = keys[0]
-                axes_ctype.append(wcs_ivoa_mapping.get(key, default=None))
+                axes_ctype.append(wcs_ivoa_mapping.get(key, default=ctype[i]))
         return tuple(axes_ctype[::-1])
 
     def pixel_to_world(self, *quantity_axis_list):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -235,7 +235,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                 keys = list(filter(lambda key: ctype[i].upper().startswith(key), wcs_ivoa_mapping))
                 # Assuming CTYPE is supported by wcs_ivoa_mapping, use its corresponding axis name.
                 if len(keys) == 1:
-                    key = key[0]
+                    axis_name = wcs_ivoa_mapping.get(keys[0])
                 # If CTYPE not supported, raise a warning and set the axis name to CTYPE.
                 elif len(keys) == 0:
                     warnings.warn("CTYPE not recognized by ndcube. "
@@ -243,13 +243,14 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                                   "https://github.com/sunpy/ndcube/issues citing the "
                                   "unsupported CTYPE as we'll include it: "
                                   "CTYPE = {0}".format(ctype[i]))
+                    axis_name = ctype[i]
                 # If there are multiple valid keys, raise an error.
                 else:
                     raise ValueError("Non-unique CTYPE key.  Please raise an issue at "
                                      "https://github.com/sunpy/ndcube/issues citing the "
                                      "following  CTYPE and non-unique keys: "
                                      "CTYPE = {0}; keys = {1}".format(ctype[i], keys))
-                axes_ctype.append(wcs_ivoa_mapping.get(key, default=ctype[i]))
+                axes_ctype.append(axis_name)
         return tuple(axes_ctype[::-1])
 
     def pixel_to_world(self, *quantity_axis_list):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -243,7 +243,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                                   "https://github.com/sunpy/ndcube/issues citing the "
                                   "unsupported CTYPE as we'll include it: "
                                   "CTYPE = {0}".format(ctype[i]))
-                    axis_name = ctype[i]
+                    axis_name = "custom:{0}".format(ctype[i])
                 # If there are multiple valid keys, raise an error.
                 else:
                     raise ValueError("Non-unique CTYPE key.  Please raise an issue at "

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -38,7 +38,8 @@ wcs_to_ivoa = {
     "RA--": "pos.eq.ra",
     "DEC-": "pos.eq.dec",
     "FREQ": "em.freq",
-    "STOKES": "phys.polarization.stokes "
+    "STOKES": "phys.polarization.stokes",
+    "PIXEL": "instr.pixel"
     }
 wcs_ivoa_mapping = TwoWayDict()
 for key in wcs_to_ivoa.keys():

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -39,7 +39,10 @@ wcs_to_ivoa = {
     "DEC-": "pos.eq.dec",
     "FREQ": "em.freq",
     "STOKES": "phys.polarization.stokes",
-    "PIXEL": "instr.pixel"
+    "PIXEL": "instr.pixel",
+    "XPIXEL": "custom:instr.pixel.x",
+    "YPIXEL": "custom:instr.pixel.y",
+    "ZPIXEL": "custom:instr.pixel.z"
     }
 wcs_ivoa_mapping = TwoWayDict()
 for key in wcs_to_ivoa.keys():


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR:
* Adds ```PIXEL``` as a WCS CTYPE supported the IVOA mapping dictionary.
* Prevents ```NDCube.world_axis_physical_type``` from crashing if unsupported CTYPE is used.  Instead the axis name is set to the CTYPE and the used is invited to post a issue so the CTYPE can be supported.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
