### PR TITLE
Attempt 2: If the user does not specify a wcs object, makes a default wcs.

### DIFF
--- a/changelog/175.feature.rst
+++ b/changelog/175.feature.rst
@@ -1,0 +1,1 @@
+- Make supplying a WCS object optional and supply a default if one is not.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -179,11 +179,8 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
     def __init__(self, data, wcs=None, uncertainty=None, mask=None, meta=None,
                  unit=None, extra_coords=None, copy=False, **kwargs):
+        # If wcs not supplied, generate default wcs.
         if wcs is None:
-            # If missing_axes supplied without a wcs, raise an error.
-            if missing_axes is not None:
-                raise ValueError("Cannot set missing_axes without supplyinga WCS.")
-            # If wcs not supplied, generate default wcs.
             wcs = _generate_default_wcs(data.shape)
 
         super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -180,6 +180,10 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
     def __init__(self, data, wcs=None, uncertainty=None, mask=None, meta=None,
                  unit=None, extra_coords=None, copy=False, **kwargs):
         if wcs is None:
+            # If missing_axes supplied without a wcs, raise an error.
+            if missing_axes is not None:
+                raise ValueError("Cannot set missing_axes without supplyinga WCS.")
+            # If wcs not supplied, generate default wcs.
             wcs = _generate_default_wcs(data.shape)
 
         super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -13,7 +13,7 @@ import sunpy.coordinates
 
 from ndcube import utils
 from ndcube.ndcube_sequence import NDCubeSequence
-from ndcube.utils.wcs import wcs_ivoa_mapping, _pixel_keep
+from ndcube.utils.wcs import wcs_ivoa_mapping, _pixel_keep, _generate_default_wcs
 from ndcube.utils.cube import _pixel_centers_or_edges, _get_dimension_for_pixel, unique_data_axis
 from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
 
@@ -179,6 +179,8 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
     def __init__(self, data, wcs=None, uncertainty=None, mask=None, meta=None,
                  unit=None, extra_coords=None, copy=False, **kwargs):
+        if wcs is None:
+            wcs = _generate_default_wcs(data.shape)
 
         super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,
                          meta=meta, unit=unit, copy=copy, **kwargs)

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -13,8 +13,7 @@ from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 
 from ndcube import NDCube, NDCubeOrdered
-from astropy.wcs import WCS
-
+from ndcube.utils.wcs import WCS, _wcs_slicer, _generate_default_wcs
 from ndcube.tests import helpers
 from ndcube.tests.helpers import create_sliced_wcs
 from ndcube.ndcube_sequence import NDCubeSequence
@@ -80,6 +79,8 @@ w_rotated = WCS(header=h_rotated)
 
 data_rotated = np.array([[[1, 2, 3, 4, 6], [2, 4, 5, 3, 1], [0, -1, 2, 4, 2], [3, 5, 1, 2, 0]],
                          [[2, 4, 5, 1, 3], [1, 5, 2, 2, 4], [2, 3, 4, 0, 5], [0, 1, 2, 3, 4]]])
+
+default_wcs = _generate_default_wcs((data.shape))
 
 mask_cubem = data > 0
 mask_cube = data_cube >= 0
@@ -160,6 +161,13 @@ cube_rotated = NDCube(
 def test_wcs_object(nd_cube):
     assert isinstance(nd_cube.wcs, BaseLowLevelWCS)
     assert isinstance(nd_cube.high_level_wcs, BaseHighLevelWCS)
+
+
+def test_ndcube_default_wcs_input():
+    data = np.ones((2, 3, 4))
+    expected_wcs = _generate_default_wcs((data.shape))
+    output = NDCube(data)
+    helpers.assert_wcs_are_equal(output.wcs, expected_wcs)
 
 
 @pytest.mark.parametrize(

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -101,7 +101,7 @@ def test_axis_correlation_matrix(test_input, expected):
 
 def test_generate_default_wcs():
     data_shape = (2,3,4)
-    output = _generate_default_wcs(data_shape)
+    output = utils.wcs._generate_default_wcs(data_shape)
     wcs_dict = {'CTYPE1': 'PIXEL', 'CDELT1': 1, 'CRPIX1': 0, 'CRVAL1': 0, 'NAXIS1': 2,
                 'CTYPE2': 'PIXEL', 'CDELT2': 1, 'CRPIX2': 0, 'CRVAL2': 0, 'NAXIS2': 3,
                 'CTYPE3': 'PIXEL', 'CDELT3': 1, 'CRPIX3': 0, 'CRVAL3': 0, 'NAXIS3': 4}
@@ -109,6 +109,6 @@ def test_generate_default_wcs():
     for i in range(3):
         assert output.wcs.ctype[i] == expected.wcs.ctype[i]
         assert output._naxis[i] == expected._naxis[i]
-    numpy.testing.assert_array_equal(output.wcs.cdelt, expected.wcs.cdelt)
-    numpy.testing.assert_array_equal(output.wcs.crpix, expected.wcs.crpix)
-    numpy.testing.assert_array_equal(output.wcs.crval, expected.wcs.crval)
+    np.testing.assert_array_equal(output.wcs.cdelt, expected.wcs.cdelt)
+    np.testing.assert_array_equal(output.wcs.crpix, expected.wcs.crpix)
+    np.testing.assert_array_equal(output.wcs.crval, expected.wcs.crval)

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -87,3 +87,28 @@ def test_get_dependent_data_axes(test_input, expected):
 def test_get_dependent_wcs_axes(test_input, expected):
     output = utils.wcs.get_dependent_wcs_axes(*test_input)
     assert output == expected
+
+
+@pytest.mark.parametrize("test_input,expected", [
+    (wm, np.array([[True, False, False], [False, True, True], [False, True, True]])),
+    (wt, np.array([[True, False, False, False], [False, True, False, False],
+                   [False, False, True, True], [False, False, True, True]])),
+    (wm_reindexed_102, np.array([[True, False, True], [False, True, False],
+                                 [True, False, True]]))
+    ])
+def test_axis_correlation_matrix(test_input, expected):
+    assert (utils.wcs.axis_correlation_matrix(test_input) == expected).all()
+
+def test_generate_default_wcs():
+    data_shape = (2,3,4)
+    output = _generate_default_wcs(data_shape)
+    wcs_dict = {'CTYPE1': 'PIXEL', 'CDELT1': 1, 'CRPIX1': 0, 'CRVAL1': 0, 'NAXIS1': 2,
+                'CTYPE2': 'PIXEL', 'CDELT2': 1, 'CRPIX2': 0, 'CRVAL2': 0, 'NAXIS2': 3,
+                'CTYPE3': 'PIXEL', 'CDELT3': 1, 'CRPIX3': 0, 'CRVAL3': 0, 'NAXIS3': 4}
+    expected = astropy.wcs.WCS(header=wcs_dict, naxis=len(data_shape))
+    for i in range(3):
+        assert output.wcs.ctype[i] == expected.wcs.ctype[i]
+        assert output._naxis[i] == expected._naxis[i]
+    numpy.testing.assert_array_equal(output.wcs.cdelt, expected.wcs.cdelt)
+    numpy.testing.assert_array_equal(output.wcs.crpix, expected.wcs.crpix)
+    numpy.testing.assert_array_equal(output.wcs.crval, expected.wcs.crval)

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -99,16 +99,3 @@ def test_get_dependent_wcs_axes(test_input, expected):
 def test_axis_correlation_matrix(test_input, expected):
     assert (utils.wcs.axis_correlation_matrix(test_input) == expected).all()
 
-def test_generate_default_wcs():
-    data_shape = (2,3,4)
-    output = utils.wcs._generate_default_wcs(data_shape)
-    wcs_dict = {'CTYPE1': 'PIXEL', 'CDELT1': 1, 'CRPIX1': 0, 'CRVAL1': 0, 'NAXIS1': 2,
-                'CTYPE2': 'PIXEL', 'CDELT2': 1, 'CRPIX2': 0, 'CRVAL2': 0, 'NAXIS2': 3,
-                'CTYPE3': 'PIXEL', 'CDELT3': 1, 'CRPIX3': 0, 'CRVAL3': 0, 'NAXIS3': 4}
-    expected = astropy.wcs.WCS(header=wcs_dict, naxis=len(data_shape))
-    for i in range(3):
-        assert output.wcs.ctype[i] == expected.wcs.ctype[i]
-        assert output._naxis[i] == expected._naxis[i]
-    np.testing.assert_array_equal(output.wcs.cdelt, expected.wcs.cdelt)
-    np.testing.assert_array_equal(output.wcs.crpix, expected.wcs.crpix)
-    np.testing.assert_array_equal(output.wcs.crval, expected.wcs.crval)

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -98,4 +98,3 @@ def test_get_dependent_wcs_axes(test_input, expected):
     ])
 def test_axis_correlation_matrix(test_input, expected):
     assert (utils.wcs.axis_correlation_matrix(test_input) == expected).all()
-

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -402,3 +402,15 @@ def _pixel_keep(wcs_object):
     if hasattr(wcs_object, "_pixel_keep"):
         return wcs_object._pixel_keep
     return np.arange(wcs_object.pixel_n_dim)
+
+
+def _generate_default_wcs(data_shape):
+    hm = {}
+    for i in range(1, len(data_shape)+1):
+        hm["CTYPE{}".format(i)] = 'PIXEL'
+        hm["CDELT{}".format(i)] = 1
+        hm["CRPIX{}".format(i)] = 0
+        hm["CRVAL{}".format(i)] = 0
+        hm["NAXIS{}".format(i)] = data_shape[i-1]
+    default_wcs = wcs.WCS(header=hm, naxis=len(data_shape))
+    return default_wcs

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -405,12 +405,13 @@ def _pixel_keep(wcs_object):
 
 
 def _generate_default_wcs(data_shape):
+    wcs_shape = data_shape[::-1]
     hm = {}
-    for i in range(1, len(data_shape)+1):
+    for i in range(1, len(wcs_shape)+1):
         hm["CTYPE{}".format(i)] = 'PIXEL'
         hm["CDELT{}".format(i)] = 1
         hm["CRPIX{}".format(i)] = 0
         hm["CRVAL{}".format(i)] = 0
-        hm["NAXIS{}".format(i)] = data_shape[i-1]
-    default_wcs = wcs.WCS(header=hm, naxis=len(data_shape))
+        hm["NAXIS{}".format(i)] = wcs_shape[i-1]
+    default_wcs = wcs.WCS(header=hm, naxis=len(wcs_shape))
     return default_wcs


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This is the same as PR #170 with some updated merges.  It relaxes requirement that user must input wcs object. If user does not provide one, a default object is created from the dataset.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #156 
