### PR TITLE
Fix bug in 2D plotting.

### DIFF
--- a/changelog/182.bugfix.rst
+++ b/changelog/182.bugfix.rst
@@ -1,0 +1,1 @@
+Fix 2D plotting from crashing when both data and WCS are 2D.

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -201,23 +201,25 @@ class NDCubePlotMixin:
         data = np.ma.masked_array(data, self.mask)
         if axes is None:
             try:
-                axes_coord_check == [None, None]
+                axes_coord_check = axes_coordinates == [None, None]
             except:
                 axes_coord_check = False
             if axes_coord_check:
                 # Build slice list for WCS for initializing WCSAxes object.
-                if self.wcs.naxis is not 2:
+                if self.wcs.naxis != 2:
                     slice_list = []
                     index = 0
-                    for i, bool_ in enumerate(self.missing_axes):
+                    for bool_ in self.missing_axes:
                         if not bool_:
                             slice_list.append(axis_data[index])
                             index += 1
                         else:
                             slice_list.append(1)
-                    if index is not 2:
+                    if index != 2:
                         raise ValueError("Dimensions of WCS and data don't match")
-                ax = wcsaxes_compat.gca_wcs(self.wcs, slices=slice_list)
+                    ax = wcsaxes_compat.gca_wcs(self.wcs, slices=tuple(slice_list))
+                else:
+                    ax = wcsaxes_compat.gca_wcs(self.wcs)
                 # Set axis labels
                 x_wcs_axis = utils.cube.data_axis_to_wcs_axis(plot_axis_indices[0],
                                                               self.missing_axes)


### PR DESCRIPTION
Bug was caused when both data and WCS were 2D. In this case a slice list
was being called, even though that list was only created when the data
was 2D with a >2D WCS with missing axes.

<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
The bug is fixed by only entering the ```slice_list``` to the ```gca_wcs``` method if the ```wcs``` is greater than 2 when the data is 2D.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
