### PR TITLE
Fixed the failing `axis_world_coords` after a NDCube is sliced

### DIFF
--- a/ndcube/mixins/ndslicing.py
+++ b/ndcube/mixins/ndslicing.py
@@ -57,7 +57,7 @@ class NDCubeSlicingMixin(NDSlicingMixin):
 
         item = tuple(sanitize_slices(item, len(self.dimensions)))
         kwargs = super()._slice(item)
-        
+
         # Store the original dimension of NDCube object before slicing
         prev_dim = len(self.dimensions)
 

--- a/ndcube/mixins/ndslicing.py
+++ b/ndcube/mixins/ndslicing.py
@@ -57,9 +57,9 @@ class NDCubeSlicingMixin(NDSlicingMixin):
 
         item = tuple(sanitize_slices(item, len(self.dimensions)))
         kwargs = super()._slice(item)
-
-        # Store the original dimension of the wcs object before slicing
-        prev_dim = self.wcs.world_n_dim
+        
+        # Store the original dimension of NDCube object before slicing
+        prev_dim = len(self.dimensions)
 
         # Sanitize the input arguments
         wcs = self._slice_wcs(item)

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -187,7 +187,6 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
             # If the WCS object is low_level_wcs object, convert it into SlicedLowLevelWCS object for sanity
             # Convert the WCS object into a SlicedLowLevelWCS
             if not isinstance(wcs, SlicedLowLevelWCS):
-                print('SLICIFIED!')
                 wcs = SlicedLowLevelWCS(wcs, [])
 
         # Format extra coords.
@@ -201,7 +200,6 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         # Initialize NDCube.
         super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,
                          meta=meta, unit=unit, copy=copy, **kwargs)
-
 
     @property
     def high_level_wcs(self):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -15,7 +15,7 @@ import sunpy.coordinates
 from ndcube import utils
 from ndcube.ndcube_sequence import NDCubeSequence
 from ndcube.utils.wcs import wcs_ivoa_mapping, _pixel_keep
-from ndcube.utils.cube import _pixel_centers_or_edges, _get_dimension_for_pixel, ape14_axes
+from ndcube.utils.cube import _pixel_centers_or_edges, _get_dimension_for_pixel, unique_data_axis
 from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
 
 
@@ -186,7 +186,9 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         else:
             # If the WCS object is low_level_wcs object, convert it into SlicedLowLevelWCS object for sanity
             # Convert the WCS object into a SlicedLowLevelWCS
-            wcs = SlicedLowLevelWCS(wcs, [])
+            if not isinstance(wcs, SlicedLowLevelWCS):
+                print('SLICIFIED!')
+                wcs = SlicedLowLevelWCS(wcs, [])
 
         # Format extra coords.
         if extra_coords:
@@ -199,6 +201,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         # Initialize NDCube.
         super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,
                          meta=meta, unit=unit, copy=copy, **kwargs)
+
 
     @property
     def high_level_wcs(self):
@@ -316,9 +319,8 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
             raise ValueError("The following axes were specified more than once: {}".format(
                 ' '.join(map(str, repeats))))
 
-        n_axes = len(int_axes)
         new_int_axes = np.arange(len(self.dimensions))
-        axes_coords = np.array([None] * len(ape14_axes(self.wcs, new_int_axes)))
+        axes_coords = np.array([None] * len(unique_data_axis(self.wcs, new_int_axes)[1]))
         axes_translated = np.array([False if entry in int_axes else True for entry in range(len(self.dimensions))])
 
         # Determine which axes are dependent on others.
@@ -362,10 +364,9 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                     if dependent_axis in int_axes:
                         # Due to error check above we know dependent
                         # axis can appear in int_axes at most once.
-                        j = ape14_axes(self.wcs, dependent_axis)[0]
-
+                        j = unique_data_axis(self.wcs, dependent_axis)[0]
                         # Since the dependent_axes_coords contains reduced number of results, adjust the index
-                        axes_coords[j] = dependent_axes_coords[ape14_axes(self.wcs, dependent_axis)[0]]
+                        axes_coords[j] = dependent_axes_coords[j]
                         # Remove axis from list that have now been translated.
                         axes_translated[dependent_axes[i]] = True
 

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -9,7 +9,7 @@ import numpy as np
 from ndcube.utils.wcs import _pixel_keep, get_dependent_wcs_axes
 
 __all__ = ['wcs_axis_to_data_axis', 'data_axis_to_wcs_axis', 'select_order','_pixel_centers_or_edges','_get_dimension_for_pixel',
-           'convert_extra_coords_dict_to_input_format', 'get_axis_number_from_axis_name','wcs_axis_to_data_ape14']
+           'convert_extra_coords_dict_to_input_format', 'get_axis_number_from_axis_name','wcs_axis_to_data_ape14','unique_data_axis']
 
 
 

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -350,14 +350,14 @@ def unique_data_axis(wcs_object, input_axis):
         The WCS object
     input_axis : `int` or `list`
         The list of wcs axes
-    
+
     Examples
     --------
-    Suppose, we have a wcs object with such entries - 
-    Below here is a Numpy ordering 
+    Suppose, we have a wcs object with such entries:
+    Below here is a Numpy ordering
     ['lat','lon','time','wave']
     then the corresponding data entries after adjusting the axis of
-    dependent axis as same - 
+    dependent axis as same :
     np.array([0, 0, 1, 2]).
 
     As the lat and lon are dependent axes, so they get assigned the same data axis.
@@ -382,21 +382,20 @@ def unique_data_axis(wcs_object, input_axis):
         distinct_element_index.append(idx)
         if element not in distinct_element:
             distinct_element.append(element)
-            
+
         prev_el = element
 
     # Convert to numpy array for array indexing
     distinct_element_index = np.array(distinct_element_index)
 
     if(wcs_object.pixel_n_dim == wcs_object.world_n_dim):
-        # If the pixel_dim and world_dim are same, then return the 
+        # If the pixel_dim and world_dim are same, then return the
         # distinct_element_index as it is
         return distinct_element_index[input_axis], np.unique(distinct_element_index)
     else:
         sliced_axis = np.setdiff1d(wcs_object._world_keep, wcs_object._pixel_keep)
         index_sliced_axis = np.where(sliced_axis == wcs_object._world_keep)[0]
         distinct_element_index = np.delete(distinct_element_index[::-1], index_sliced_axis[0])[::-1]
-        
+
         # Return the corresponding axis/axes after denoting same axis to dependent axis
         return distinct_element_index[input_axis], np.unique(distinct_element_index)
-

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -6,6 +6,8 @@ Utilities for ndcube.
 
 import numpy as np
 
+from ndcube.utils.wcs import _pixel_keep, get_dependent_wcs_axes
+
 __all__ = ['wcs_axis_to_data_axis', 'data_axis_to_wcs_axis', 'select_order','_pixel_centers_or_edges','_get_dimension_for_pixel',
            'convert_extra_coords_dict_to_input_format', 'get_axis_number_from_axis_name','wcs_axis_to_data_ape14']
 
@@ -25,8 +27,12 @@ def data_axis_to_wcs_axis(data_axis, missing_axes):
     return result
 
 
-def data_axis_to_wcs_ape14(data_axis, pixel_keep, naxes):
+def data_axis_to_wcs_ape14(data_axis, pixel_keep, naxes, old_order=False):
     """Converts a data axis number to wcs axis number taking care of the missing axes"""
+
+    # old_order tells us whether data_axis is an axis of before
+    # slicing or after slicing
+    # old_order=True tells us that data_axis is an axis before slicing
 
     # Make sure that data_axis is a scalar item
     if data_axis is not None:
@@ -47,36 +53,35 @@ def data_axis_to_wcs_ape14(data_axis, pixel_keep, naxes):
         if data_axis > naxes -1 or data_axis < 0:
             raise IndexError("Data axis out of range.  Number Data axes = {0} and the value requested is {1}".format(
                 naxes, data_axis))
-
-    # Try to convert the data_axis to its corresponding wcs_axis if present
-    # If not present, return None
-
-    # pixel_keep is the old order of all wcs
-    # Get the old order of all data axes
-    old_data_order = naxes - 1 - pixel_keep
-
-    # Get a mapping of the old order and new order of all data axes
-    new_wcs_order = np.unique(pixel_keep, return_inverse=True)[1]
-
-    # Mapping of the order of new wcs axes
-    new_data_order = new_wcs_order[::-1]
-
-    # First we check if the data_axis whose wcs_axis we want to calculate
-    # is present in the old_data_order
-    index = np.where(data_axis == old_data_order)[0]
-    if index.size != 0:
-        index = index.item()
+    if not old_order:
+        return naxes - 1 - data_axis
     else:
-        index = None
+        # pixel_keep is the old order of all wcs
+        # Get the old order of all data axes
+        old_data_order = naxes - 1 - pixel_keep
 
-    if index is None:
-        # As we have performed the check for bound,
-        # so the data_axis must have been missing if
-        # index is None
-        return None
+        # Get a mapping of the old order and new order of all data axes
+        new_wcs_order = np.unique(pixel_keep, return_inverse=True)[1]
 
-    # Return the corresponding wcs_axis for the data axis
-    return new_wcs_order[index]
+        # Mapping of the order of new wcs axes
+        new_data_order = new_wcs_order[::-1]
+
+        # First we check if the data_axis whose wcs_axis we want to calculate
+        # is present in the old_data_order
+        index = np.where(data_axis == old_data_order)[0]
+        if index.size != 0:
+            index = index.item()
+        else:
+            index = None
+
+        if index is None:
+            # As we have performed the check for bound,
+            # so the data_axis must have been missing if
+            # index is None
+            return None
+
+        # Return the corresponding wcs_axis for the data axis
+        return new_wcs_order[index]
 
 
 def wcs_axis_to_data_axis(wcs_axis, missing_axes):
@@ -97,8 +102,12 @@ def wcs_axis_to_data_axis(wcs_axis, missing_axes):
     return result
 
 
-def wcs_axis_to_data_ape14(wcs_axis, pixel_keep, naxes):
+def wcs_axis_to_data_ape14(wcs_axis, pixel_keep, naxes, old_order=False):
     """Converts a wcs axis number to data axis number taking care of the missing axes"""
+
+    # old_order tells us whether wcs_axis is an axis of before
+    # slicing or after slicing
+    # old_order=True tells us that wcs_axis is an axis before slicing
 
     # Make sure that wcs_axis is a scalar item
     if wcs_axis is not None:
@@ -120,35 +129,38 @@ def wcs_axis_to_data_ape14(wcs_axis, pixel_keep, naxes):
             raise IndexError("WCS axis out of range.  Number WCS axes = {0} and the value requested is {1}".format(
                 naxes, wcs_axis))
 
-    # Try to convert the wcs_axis to its corresponding data axis if present
-    # If not present, return None
-
-    # pixel_keep is the old order of all wcs axes
-    # Get the old order of all data axes
-    old_data_order = naxes - 1 - pixel_keep
-
-    # Get a mapping of the old order and new order of all data axes
-    new_wcs_order = np.unique(pixel_keep, return_inverse=True)[1]
-
-    # Mapping of the order of new wcs_axes
-    new_data_order = new_wcs_order[::-1]
-
-    # First we check if the wcs axis whose data_axis we want to calculate
-    # is present in the old_wcs_order
-
-    index = np.where(wcs_axis == pixel_keep)[0]
-    if index.size != 0:
-        index = index.item()
+    if not old_order:
+        return naxes - 1 - wcs_axis
     else:
-        index = None
-    if index is None:
-        # As we have performed the check for bound,
-        # so the wcs_axis must have been missing if
-        # index is None
-        return None
+        # Try to convert the wcs_axis to its corresponding data axis if present
+        # If not present, return None
 
-    # Return the corresponding data_axis for the wcs_axis
-    return new_data_order[index]
+        # pixel_keep is the old order of all wcs axes
+        # Get the old order of all data axes
+        old_data_order = naxes - 1 - pixel_keep
+
+        # Get a mapping of the old order and new order of all data axes
+        new_wcs_order = np.unique(pixel_keep, return_inverse=True)[1]
+
+        # Mapping of the order of new wcs_axes
+        new_data_order = new_wcs_order[::-1]
+
+        # First we check if the wcs axis whose data_axis we want to calculate
+        # is present in the old_wcs_order
+
+        index = np.where(wcs_axis == pixel_keep)[0]
+        if index.size != 0:
+            index = index.item()
+        else:
+            index = None
+        if index is None:
+            # As we have performed the check for bound,
+            # so the wcs_axis must have been missing if
+            # index is None
+            return None
+
+        # Return the corresponding data_axis for the wcs_axis
+        return new_data_order[index]
 
 
 def select_order(axtypes):
@@ -226,7 +238,7 @@ def convert_extra_coords_dict_to_input_format(extra_coords, pixel_keep, naxes):
 
             coord_keys = list(extra_coords[name].keys())
             if "wcs axis" in coord_keys and "axis" not in coord_keys:
-                axis = wcs_axis_to_data_ape14(extra_coords[name]["wcs axis"], pixel_keep, naxes)
+                axis = wcs_axis_to_data_ape14(extra_coords[name]["wcs axis"], pixel_keep, naxes, old_order=True)
             elif "axis" in coord_keys and "wcs axis" not in coord_keys:
                 axis = extra_coords[name]["axis"]
             else:
@@ -326,3 +338,65 @@ def ape14_axes(wcs_object, input_axis):
     n_rep_ape14_axes = np.unique(ape14_axes[input_axis])
 
     return n_rep_ape14_axes[::-1]
+
+
+def unique_data_axis(wcs_object, input_axis):
+    """This function helps in returning the corresponding data axis
+    after the assigning same data axis to a list of given dependent axis.
+
+    Parameters
+    ----------
+    wcs_object : `astropy.wcs.WCS` or similar object
+        The WCS object
+    input_axis : `int` or `list`
+        The list of wcs axes
+    
+    Examples
+    --------
+    Suppose, we have a wcs object with such entries - 
+    Below here is a Numpy ordering 
+    ['lat','lon','time','wave']
+    then the corresponding data entries after adjusting the axis of
+    dependent axis as same - 
+    np.array([0, 0, 1, 2]).
+
+    As the lat and lon are dependent axes, so they get assigned the same data axis.
+    """
+
+    wcomp = wcs_object.world_axis_object_components
+    axis_type = np.array([item[0] for item in wcomp])
+
+    # Numpy ordering
+    axis_type = axis_type[::-1]
+
+    distinct_element = list()
+    distinct_element_index = list()
+
+    # Pointer to each non-dependent axis
+    # gets incremented after each non-dependent axis
+    idx = 0
+    prev_el = axis_type[0]
+    for element in axis_type:
+        if element != prev_el:
+            idx += 1
+        distinct_element_index.append(idx)
+        if element not in distinct_element:
+            distinct_element.append(element)
+            
+        prev_el = element
+
+    # Convert to numpy array for array indexing
+    distinct_element_index = np.array(distinct_element_index)
+
+    if(wcs_object.pixel_n_dim == wcs_object.world_n_dim):
+        # If the pixel_dim and world_dim are same, then return the 
+        # distinct_element_index as it is
+        return distinct_element_index[input_axis], np.unique(distinct_element_index)
+    else:
+        sliced_axis = np.setdiff1d(wcs_object._world_keep, wcs_object._pixel_keep)
+        index_sliced_axis = np.where(sliced_axis == wcs_object._world_keep)[0]
+        distinct_element_index = np.delete(distinct_element_index[::-1], index_sliced_axis[0])[::-1]
+        
+        # Return the corresponding axis/axes after denoting same axis to dependent axis
+        return distinct_element_index[input_axis], np.unique(distinct_element_index)
+

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -326,12 +326,12 @@ def get_dependent_data_axes(wcs_object, data_axis, missing_axis=None):
     # This can be done by dropping missing_axes parameter of functions calling it
 
     # Convert input data axis index to WCS axis index.
-    wcs_axis = utils_cube.data_axis_to_wcs_ape14(data_axis,_pixel_keep(wcs_object), wcs_object.world_n_dim)
+    wcs_axis = utils_cube.data_axis_to_wcs_ape14(data_axis,_pixel_keep(wcs_object), wcs_object.pixel_n_dim)
     # Determine dependent axes, using WCS ordering.
     wcs_dependent_axes = np.asarray(get_dependent_wcs_axes(wcs_object, wcs_axis))
 
     # Convert dependent axes back to numpy/data ordering.
-    dependent_data_axes = tuple(np.sort([utils_cube.wcs_axis_to_data_ape14(i, _pixel_keep(wcs_object), wcs_object.world_n_dim)
+    dependent_data_axes = tuple(np.sort([utils_cube.wcs_axis_to_data_ape14(i, _pixel_keep(wcs_object), wcs_object.pixel_n_dim)
                                          for i in wcs_dependent_axes]))
     return dependent_data_axes
 


### PR DESCRIPTION
This PR addresses a bug fix after `axis_world_coords` wasn't working/raising an error after being used on a sliced NDCube object.
Ping @Cadair !