### PR TITLE
Support 1D plotting in NDCube using APE14

### DIFF
--- a/ndcube/mixins/ndslicing.py
+++ b/ndcube/mixins/ndslicing.py
@@ -57,7 +57,7 @@ class NDCubeSlicingMixin(NDSlicingMixin):
 
         item = tuple(sanitize_slices(item, len(self.dimensions)))
         kwargs = super()._slice(item)
-        
+
         # Store the original dimension of NDCube object before slicing
         prev_dim = len(self.dimensions)
 

--- a/ndcube/tests/test_plotting.py
+++ b/ndcube/tests/test_plotting.py
@@ -1,206 +1,211 @@
-# # -*- coding: utf-8 -*-
-# import pytest
-# import datetime
-# import copy
+# -*- coding: utf-8 -*-
+import pytest
+import datetime
+import copy
 
-# import numpy as np
-# import astropy.units as u
-# import matplotlib
-# try:
-#     from sunpy.visualization.animator import ImageAnimatorWCS, LineAnimator
-# except ImportError:
-#     from sunpy.visualization.imageanimator import ImageAnimatorWCS, LineAnimator
+import numpy as np
+import astropy.units as u
+import matplotlib
+try:
+    from sunpy.visualization.animator import ImageAnimatorWCS, LineAnimator
+except ImportError:
+    from sunpy.visualization.imageanimator import ImageAnimatorWCS, LineAnimator
 
-# from ndcube import NDCube
-# from ndcube.utils.wcs import WCS
-# from ndcube.mixins import plotting
-
-
-# # sample data for tests
-# # TODO: use a fixture reading from a test file. file TBD.
-# ht = {'CTYPE3': 'HPLT-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.5, 'CRPIX3': 0, 'CRVAL3': 0, 'NAXIS3': 2,
-#       'CTYPE2': 'WAVE    ', 'CUNIT2': 'Angstrom', 'CDELT2': 0.2, 'CRPIX2': 0, 'CRVAL2': 0,
-#       'NAXIS2': 3,
-#       'CTYPE1': 'TIME    ', 'CUNIT1': 'min', 'CDELT1': 0.4, 'CRPIX1': 0, 'CRVAL1': 0, 'NAXIS1': 4}
-# wt = WCS(header=ht, naxis=3)
-
-# hm = {'CTYPE1': 'WAVE    ', 'CUNIT1': 'Angstrom', 'CDELT1': 0.2, 'CRPIX1': 0, 'CRVAL1': 10,
-#       'NAXIS1': 4,
-#       'CTYPE2': 'HPLT-TAN', 'CUNIT2': 'deg', 'CDELT2': 0.5, 'CRPIX2': 2, 'CRVAL2': 0.5,
-#       'NAXIS2': 3,
-#       'CTYPE3': 'HPLN-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.4, 'CRPIX3': 2, 'CRVAL3': 1, 'NAXIS3': 2}
-# wm = WCS(header=hm, naxis=3)
-
-# data = np.array([[[1, 2, 3, 4], [2, 4, 5, 3], [0, -1, 2, 3]],
-#                  [[2, 4, 5, 1], [10, 5, 2, 2], [10, 3, 3, 0]]])
-# uncertainty = np.sqrt(data)
-# mask_cube = data < 0
-
-# cube = NDCube(
-#     data,
-#     wt,
-#     mask=mask_cube,
-#     uncertainty=uncertainty,
-#     missing_axes=[False, False, False, True],
-#     extra_coords=[('time', 0, u.Quantity(range(data.shape[0]), unit=u.s)),
-#                   ('hello', 1, u.Quantity(range(data.shape[1]), unit=u.W)),
-#                   ('bye', 2, u.Quantity(range(data.shape[2]), unit=u.m)),
-#                   ('another time', 2, np.array(
-#                       [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
-#                        for i in range(data.shape[2])])),
-#                   ('array coord', 2, np.arange(100, 100+data.shape[2]))
-#                   ])
-
-# cube_unit = NDCube(
-#     data,
-#     wt,
-#     mask=mask_cube,
-#     unit=u.J,
-#     uncertainty=uncertainty,
-#     missing_axes=[False, False, False, True],
-#     extra_coords=[('time', 0, u.Quantity(range(data.shape[0]), unit=u.s)),
-#                   ('hello', 1, u.Quantity(range(data.shape[1]), unit=u.W)),
-#                   ('bye', 2, u.Quantity(range(data.shape[2]), unit=u.m)),
-#                   ('another time', 2, np.array(
-#                       [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
-#                        for i in range(data.shape[2])]))
-#                   ])
-
-# cube_no_uncertainty = NDCube(
-#     data,
-#     wt,
-#     mask=mask_cube,
-#     missing_axes=[False, False, False, True],
-#     extra_coords=[('time', 0, u.Quantity(range(data.shape[0]), unit=u.s)),
-#                   ('hello', 1, u.Quantity(range(data.shape[1]), unit=u.W)),
-#                   ('bye', 2, u.Quantity(range(data.shape[2]), unit=u.m)),
-#                   ('another time', 2, np.array(
-#                       [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
-#                        for i in range(data.shape[2])]))
-#                   ])
-
-# cube_unit_no_uncertainty = NDCube(
-#     data,
-#     wt,
-#     mask=mask_cube,
-#     unit=u.J,
-#     missing_axes=[False, False, False, True],
-#     extra_coords=[('time', 0, u.Quantity(range(data.shape[0]), unit=u.s)),
-#                   ('hello', 1, u.Quantity(range(data.shape[1]), unit=u.W)),
-#                   ('bye', 2, u.Quantity(range(data.shape[2]), unit=u.m)),
-#                   ('another time', 2, np.array(
-#                       [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
-#                        for i in range(data.shape[2])]))
-#                   ])
-
-# cubem = NDCube(
-#     data,
-#     wm,
-#     mask=mask_cube,
-#     uncertainty=uncertainty,
-#     extra_coords=[('time', 0, u.Quantity(range(data.shape[0]), unit=u.s)),
-#                   ('hello', 1, u.Quantity(range(data.shape[1]), unit=u.W)),
-#                   ('bye', 2, u.Quantity(range(data.shape[2]), unit=u.m)),
-#                   ('another time', 2, np.array(
-#                       [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
-#                        for i in range(data.shape[2])]))
-#                   ])
-
-# # Derive expected data values
-# cube_data = np.ma.masked_array(cube.data, cube.mask)
-
-# # Derive expected axis_ranges.
-# # Let False stand for ranges generated by SunPy classes and so not tested.
-# cube_none_axis_ranges_axis2 = [False, False, np.array([0.4, 0.8, 1.2, 1.6])]
-
-# cube_none_axis_ranges_axis2_s = copy.deepcopy(cube_none_axis_ranges_axis2)
-# cube_none_axis_ranges_axis2_s[2] = cube_none_axis_ranges_axis2[2] * 60.
-
-# cube_none_axis_ranges_axis2_bye = copy.deepcopy(cube_none_axis_ranges_axis2)
-# cube_none_axis_ranges_axis2_bye[2] = cube.extra_coords["bye"]["value"].value
-
-# cube_none_axis_ranges_axis2_array = copy.deepcopy(cube_none_axis_ranges_axis2)
-# cube_none_axis_ranges_axis2_array[2] = np.arange(10, 10+cube.data.shape[-1])
-
-# @pytest.mark.parametrize("test_input, test_kwargs, expected_values", [
-#     (cube[0, 0], {},
-#      (np.ma.masked_array([0.4, 0.8, 1.2, 1.6], cube[0, 0].mask),
-#       np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask),
-#       "time [min]", "Data [None]", (0.4, 1.6), (1, 4))),
-
-#     (cube_unit[0, 0], {"axes_coordinates": "bye", "axes_units": "km", "data_unit": u.erg},
-#      (np.ma.masked_array(cube_unit[0, 0].extra_coords["bye"]["value"].to(u.km).value,
-#                          cube_unit[0, 0].mask),
-#       np.ma.masked_array(u.Quantity(cube_unit[0, 0].data,
-#                                     unit=cube_unit[0, 0].unit).to(u.erg).value,
-#                          cube_unit[0, 0].mask),
-#       "bye [km]", "Data [erg]", (0, 0.003), (10000000, 40000000))),
-
-#     (cube_unit[0, 0], {"axes_coordinates": np.arange(10, 10+cube_unit[0, 0].data.shape[0])},
-#      (np.ma.masked_array(np.arange(10, 10+cube_unit[0, 0].data.shape[0]), cube_unit[0, 0].mask),
-#       np.ma.masked_array(cube_unit[0, 0].data, cube_unit[0, 0].mask),
-#       " [None]", "Data [J]", (10, 10+cube_unit[0, 0].data.shape[0]-1), (1, 4))),
-
-#     (cube_no_uncertainty[0, 0], {},
-#      (np.ma.masked_array([0.4, 0.8, 1.2, 1.6], cube_no_uncertainty[0, 0].mask),
-#       np.ma.masked_array(cube_no_uncertainty[0, 0].data, cube_no_uncertainty[0, 0].mask),
-#       "time [min]", "Data [None]", (0.4, 1.6), (1, 4))),
-
-#     (cube_unit_no_uncertainty[0, 0], {},
-#      (np.ma.masked_array([0.4, 0.8, 1.2, 1.6], cube_unit_no_uncertainty[0, 0].mask),
-#       np.ma.masked_array(cube_no_uncertainty[0, 0].data, cube_unit_no_uncertainty[0, 0].mask),
-#       "time [min]", "Data [J]", (0.4, 1.6), (1, 4))),
-
-#     (cube_unit_no_uncertainty[0, 0], {"data_unit": u.erg},
-#      (np.ma.masked_array([0.4, 0.8, 1.2, 1.6], cube_unit_no_uncertainty[0, 0].mask),
-#       np.ma.masked_array(u.Quantity(cube_unit[0, 0].data,
-#                                     unit=cube_unit[0, 0].unit).to(u.erg).value,
-#                          cube_unit[0, 0].mask),
-#       "time [min]", "Data [erg]", (0.4, 1.6), (10000000, 40000000)))
-#     ])
-# def test_cube_plot_1D(test_input, test_kwargs, expected_values):
-#     # Unpack expected properties.
-#     expected_xdata, expected_ydata, expected_xlabel, expected_ylabel, \
-#       expected_xlim, expected_ylim = expected_values
-#     # Run plot method.
-#     output = test_input.plot(**test_kwargs)
-#     # Check plot properties are correct.
-#     # Type
-#     assert isinstance(output, matplotlib.axes.Axes)
-#     # Check x axis data
-#     output_xdata = (output.axes.lines[0].get_xdata())
-#     assert np.allclose(output_xdata.data, expected_xdata.data)
-#     if isinstance(output_xdata.mask, np.ndarray):
-#         np.testing.assert_array_equal(output_xdata.mask, expected_xdata.mask)
-#     else:
-#         assert output_xdata.mask == expected_xdata.mask
-#     # Check y axis data
-#     output_ydata = (output.axes.lines[0].get_ydata())
-#     assert np.allclose(output_ydata.data, expected_ydata.data)
-#     if isinstance(output_ydata.mask, np.ndarray):
-#         np.testing.assert_array_equal(output_ydata.mask, expected_ydata.mask)
-#     else:
-#         assert output_ydata.mask == expected_ydata.mask
-#     # Check axis labels
-#     assert output.axes.get_xlabel() == expected_xlabel
-#     assert output.axes.get_ylabel() == expected_ylabel
-#     # Check axis limits
-#     output_xlim = output.axes.get_xlim()
-#     assert output_xlim[0] <= expected_xlim[0]
-#     assert output_xlim[1] >= expected_xlim[1]
-#     output_ylim = output.axes.get_ylim()
-#     assert output_ylim[0] <= expected_ylim[0]
-#     assert output_ylim[1] >= expected_ylim[1]
+from ndcube import NDCube
+from astropy.wcs import WCS
+from ndcube.mixins import plotting
 
 
-# @pytest.mark.parametrize("test_input, test_kwargs, expected_error", [
-#     (cube[0, 0], {"axes_coordinates": np.arange(10, 10+cube_unit[0, 0].data.shape[0]),
-#                   "axes_units": u.C}, TypeError),
-#     (cube[0, 0], {"data_unit": u.C}, TypeError)
-#     ])
-# def test_cube_plot_1D_errors(test_input, test_kwargs, expected_error):
-#     with pytest.raises(expected_error):
-#         output = test_input.plot(**test_kwargs)
+# sample data for tests
+# TODO: use a fixture reading from a test file. file TBD.
+ht = {'CTYPE4': 'HPLN-TAN', 'CUNIT4': 'deg', 'CDELT4': 0.4, 'CRPIX4': 2, 'CRVAL4': 1, 'NAXIS4': 5,
+      'CTYPE3': 'HPLT-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.5, 'CRPIX3': 0, 'CRVAL3': 0, 'NAXIS3': 2,
+      'CTYPE2': 'WAVE    ', 'CUNIT2': 'Angstrom', 'CDELT2': 0.2, 'CRPIX2': 0, 'CRVAL2': 0,
+      'NAXIS2': 3,
+      'CTYPE1': 'TIME    ', 'CUNIT1': 'min', 'CDELT1': 0.4, 'CRPIX1': 0, 'CRVAL1': 0, 'NAXIS1': 4}
+wt = WCS(header=ht)
+
+hm = {'CTYPE1': 'WAVE    ', 'CUNIT1': 'Angstrom', 'CDELT1': 0.2, 'CRPIX1': 0, 'CRVAL1': 10,
+      'NAXIS1': 4,
+      'CTYPE2': 'HPLT-TAN', 'CUNIT2': 'deg', 'CDELT2': 0.5, 'CRPIX2': 2, 'CRVAL2': 0.5,
+      'NAXIS2': 3,
+      'CTYPE3': 'HPLN-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.4, 'CRPIX3': 2, 'CRVAL3': 1, 'NAXIS3': 2}
+wm = WCS(header=hm)
+
+data = np.array([[[1, 2, 3, 4], [2, 4, 5, 3], [0, -1, 2, 3]],
+                 [[2, 4, 5, 1], [10, 5, 2, 2], [10, 3, 3, 0]]])
+
+data_cube = np.zeros((5, 2, 3, 4))
+data_cube = np.array([data for _ in range(5)])
+
+uncertaintyt = np.sqrt(data_cube)
+uncertainty = np.sqrt(data)
+
+mask = data < 0
+mask_cube = data_cube < 0
+
+cube = NDCube(
+    data_cube,
+    wt,
+    mask=mask_cube,
+    uncertainty=uncertaintyt,
+    extra_coords=[('time', 0, u.Quantity(range(data_cube.shape[0]), unit=u.s)),
+                  ('hello', 1, u.Quantity(range(data_cube.shape[1]), unit=u.W)),
+                  ('bye', 2, u.Quantity(range(data_cube.shape[2]), unit=u.m)),
+                  ('another time', 2, np.array(
+                      [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
+                       for i in range(data_cube.shape[2])])),
+                  ('array coord', 2, np.arange(100, 100+data_cube.shape[2]))
+                  ])
+
+cube_unit = NDCube(
+    data_cube,
+    wt,
+    mask=mask_cube,
+    unit=u.J,
+    uncertainty=uncertaintyt,
+    extra_coords=[('time', 0, u.Quantity(range(data_cube.shape[0]), unit=u.s)),
+                  ('hello', 1, u.Quantity(range(data_cube.shape[1]), unit=u.W)),
+                  ('bye', 2, u.Quantity(range(data_cube.shape[2]), unit=u.m)),
+                  ('another time', 2, np.array(
+                      [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
+                       for i in range(data_cube.shape[2])]))
+                  ])
+
+cube_no_uncertainty = NDCube(
+    data_cube,
+    wt,
+    mask=mask_cube,
+    extra_coords=[('time', 0, u.Quantity(range(data_cube.shape[0]), unit=u.s)),
+                  ('hello', 1, u.Quantity(range(data_cube.shape[1]), unit=u.W)),
+                  ('bye', 2, u.Quantity(range(data_cube.shape[2]), unit=u.m)),
+                  ('another time', 2, np.array(
+                      [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
+                       for i in range(data_cube.shape[2])]))
+                  ])
+
+cube_unit_no_uncertainty = NDCube(
+    data_cube,
+    wt,
+    mask=mask_cube,
+    unit=u.J,
+    extra_coords=[('time', 0, u.Quantity(range(data_cube.shape[0]), unit=u.s)),
+                  ('hello', 1, u.Quantity(range(data_cube.shape[1]), unit=u.W)),
+                  ('bye', 2, u.Quantity(range(data_cube.shape[2]), unit=u.m)),
+                  ('another time', 2, np.array(
+                      [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
+                       for i in range(data_cube.shape[2])]))
+                  ])
+
+cubem = NDCube(
+    data,
+    wm,
+    mask=mask,
+    uncertainty=uncertainty,
+    extra_coords=[('time', 0, u.Quantity(range(data.shape[0]), unit=u.s)),
+                  ('hello', 1, u.Quantity(range(data.shape[1]), unit=u.W)),
+                  ('bye', 2, u.Quantity(range(data.shape[2]), unit=u.m)),
+                  ('another time', 2, np.array(
+                      [datetime.datetime(2000, 1, 1)+datetime.timedelta(minutes=i)
+                       for i in range(data.shape[2])]))
+                  ])
+
+# Derive expected data values
+cube_data_3 = np.ma.masked_array(cube.data, cube.mask)
+
+# Derive expected axis_ranges.
+# Let False stand for ranges generated by SunPy classes and so not tested.
+cube_none_axis_ranges_axis2 = [False, False, np.array([0.4, 0.8, 1.2, 1.6])]
+
+cube_none_axis_ranges_axis2_s = copy.deepcopy(cube_none_axis_ranges_axis2)
+cube_none_axis_ranges_axis2_s[2] = cube_none_axis_ranges_axis2[2] * 60.
+
+cube_none_axis_ranges_axis2_bye = copy.deepcopy(cube_none_axis_ranges_axis2)
+cube_none_axis_ranges_axis2_bye[2] = cube.extra_coords["bye"]["value"].value
+
+cube_none_axis_ranges_axis2_array = copy.deepcopy(cube_none_axis_ranges_axis2)
+cube_none_axis_ranges_axis2_array[2] = np.arange(10, 10+cube.data.shape[-1])
+
+@pytest.mark.parametrize("test_input, test_kwargs, expected_values", [
+    (cube[0, 0, 0], {},
+     (np.ma.masked_array([0.4, 0.8, 1.2, 1.6], cube[0, 0, 0].mask),
+      np.ma.masked_array(cube[0, 0, 0].data, cube[0, 0, 0].mask),
+      "time [min]", "Data [None]", (0.4, 1.6), (1, 4))),
+
+    (cube_unit[0, 0, :, 0], {"axes_coordinates": "bye", "axes_units": "km", "data_unit": u.erg},
+     (np.ma.masked_array(cube_unit[0, 0, :, 0].extra_coords["bye"]["value"].to(u.km).value,
+                         cube_unit[0, 0, :, 0].mask),
+      np.ma.masked_array(u.Quantity(cube_unit[0, 0, :, 0].data,
+                                    unit=cube_unit[0, 0, :, 0].unit).to(u.erg).value,
+                         cube_unit[0, 0, :, 0].mask),
+      "bye [km]", "Data [erg]", (0, 0.0021), (10000000, 20000000))),
+
+    (cube_unit[0, 0, 0], {"axes_coordinates": np.arange(10, 10+cube_unit[0, 0, 0].data.shape[0])},
+     (np.ma.masked_array(np.arange(10, 10+cube_unit[0, 0, 0].data.shape[0]), cube_unit[0, 0, 0].mask),
+      np.ma.masked_array(cube_unit[0, 0, 0].data, cube_unit[0, 0, 0].mask),
+      " [None]", "Data [J]", (10, 10+cube_unit[0, 0, 0].data.shape[0]-1), (1, 4))),
+
+    (cube_no_uncertainty[0, 0, 0], {},
+     (np.ma.masked_array([0.4, 0.8, 1.2, 1.6], cube_no_uncertainty[0, 0, 0].mask),
+      np.ma.masked_array(cube_no_uncertainty[0, 0, 0].data, cube_no_uncertainty[0, 0, 0].mask),
+      "time [min]", "Data [None]", (0.4, 1.6), (1, 4))),
+
+    (cube_unit_no_uncertainty[0, 0, 0], {},
+     (np.ma.masked_array([0.4, 0.8, 1.2, 1.6], cube_unit_no_uncertainty[0, 0, 0].mask),
+      np.ma.masked_array(cube_no_uncertainty[0, 0, 0].data, cube_unit_no_uncertainty[0, 0, 0].mask),
+      "time [min]", "Data [J]", (0.4, 1.6), (1, 4))),
+
+    (cube_unit_no_uncertainty[0, 0, 0], {"data_unit": u.erg},
+     (np.ma.masked_array([0.4, 0.8, 1.2, 1.6], cube_unit_no_uncertainty[0, 0, 0].mask),
+      np.ma.masked_array(u.Quantity(cube_unit[0, 0, 0].data,
+                                    unit=cube_unit[0, 0, 0].unit).to(u.erg).value,
+                         cube_unit[0, 0, 0].mask),
+      "time [min]", "Data [erg]", (0.4, 1.6), (10000000, 40000000))
+      )
+    ])
+def test_cube_plot_1D(test_input, test_kwargs, expected_values):
+    # Unpack expected properties.
+    expected_xdata, expected_ydata, expected_xlabel, expected_ylabel, \
+      expected_xlim, expected_ylim = expected_values
+    # Run plot method.
+    output = test_input.plot(**test_kwargs)
+    # Check plot properties are correct.
+    # Type
+    assert isinstance(output, matplotlib.axes.Axes)
+    # Check x axis data
+    output_xdata = (output.axes.lines[0].get_xdata())
+    assert np.allclose(output_xdata.data, expected_xdata.data)
+    if isinstance(output_xdata.mask, np.ndarray):
+        np.testing.assert_array_equal(output_xdata.mask, expected_xdata.mask)
+    else:
+        assert output_xdata.mask == expected_xdata.mask
+    # Check y axis data
+    output_ydata = (output.axes.lines[0].get_ydata())
+    assert np.allclose(output_ydata.data, expected_ydata.data)
+    if isinstance(output_ydata.mask, np.ndarray):
+        np.testing.assert_array_equal(output_ydata.mask, expected_ydata.mask)
+    else:
+        assert output_ydata.mask == expected_ydata.mask
+    # Check axis labels
+    assert output.axes.get_xlabel() == expected_xlabel
+    assert output.axes.get_ylabel() == expected_ylabel
+    # Check axis limits
+    output_xlim = output.axes.get_xlim()
+    assert output_xlim[0] <= expected_xlim[0]
+    assert output_xlim[1] >= expected_xlim[1]
+    output_ylim = output.axes.get_ylim()
+    assert output_ylim[0] <= expected_ylim[0]
+    assert output_ylim[1] >= expected_ylim[1]
+
+
+@pytest.mark.parametrize("test_input, test_kwargs, expected_error", [
+    (cube[0, 0, 0], {"axes_coordinates": np.arange(10, 10+cube_unit[0, 0, 0].data.shape[0]),
+                  "axes_units": u.C}, TypeError),
+    (cube[0, 0, 0], {"data_unit": u.C}, TypeError)
+    ])
+def test_cube_plot_1D_errors(test_input, test_kwargs, expected_error):
+    with pytest.raises(expected_error):
+        output = test_input.plot(**test_kwargs)
 
 
 # @pytest.mark.parametrize("test_input, test_kwargs, expected_values", [
@@ -319,16 +324,16 @@
 
 # @pytest.mark.parametrize("test_input, test_kwargs, expected_values", [
 #     (cube, {"plot_axis_indices": -1},
-#      (cube_data, cube_none_axis_ranges_axis2, "time [min]", "Data [None]")),
+#      (cube_data_3, cube_none_axis_ranges_axis2, "time [min]", "Data [None]")),
 
 #     (cube_unit, {"plot_axis_indices": -1, "axes_units": u.s, "data_unit": u.erg},
-#      (cube_data*1e7, cube_none_axis_ranges_axis2_s, "time [s]", "Data [erg]")),
+#      (cube_data_3*1e7, cube_none_axis_ranges_axis2_s, "time [s]", "Data [erg]")),
 
 #     (cube_unit, {"plot_axis_indices": -1, "axes_coordinates": "bye"},
-#      (cube_data, cube_none_axis_ranges_axis2_bye, "bye [m]", "Data [J]")),
+#      (cube_data_3, cube_none_axis_ranges_axis2_bye, "bye [m]", "Data [J]")),
 
 #     (cube, {"plot_axis_indices": -1, "axes_coordinates": np.arange(10, 10+cube.data.shape[-1])},
-#      (cube_data, cube_none_axis_ranges_axis2_array, " [None]", "Data [None]"))
+#      (cube_data_3, cube_none_axis_ranges_axis2_array, " [None]", "Data [None]"))
 #     ])
 # def test_cube_plot_ND_as_1DAnimation(test_input, test_kwargs, expected_values):
 #     # Unpack expected properties.


### PR DESCRIPTION
This PR adds support of APE14 in plotting for `NDCube`.
##
Currently, the features of plotting supported would be brought out using different Pull Requests, each of the PR fixing/supporting APE14 in plotting.
This removes the overhead of pushing all the changes in one single cranky PR. 
##
Note this PR only modifies the tests for 1D plotting instead of making code changes, as the plotting of 1D cube works as it was working earlier.

Ping @DanRyanIrish for the review.

Edit: Note this PR depends on #185 before getting merged.
##
Edit2:
The plotting of `NDCube` can be operated in 3 ways. The checklist denotes the feature which is working. 
- [x] Simple plotting - `NDCube.plot()` 
- [x] Plotting with `plot_axis_indices` argument. 
- [x] Plotting with `axes_coordinates` argument.