### PR TITLE
Support 2D plotting in NDCube using APE14

### DIFF
--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -165,6 +165,7 @@ class NDCubePlotMixin:
         if yerror is not None:
             yerror = np.ma.masked_array(yerror, self.mask)
         # Create plot
+        # print(f'{xdata, ydata, yerror,data_unit, default_xlabel, kwargs}')
         fig, ax = sequence_plotting._make_1D_sequence_plot(xdata, ydata, yerror,
                                                            data_unit, default_xlabel, kwargs)
         return ax
@@ -187,6 +188,7 @@ class NDCubePlotMixin:
 
         """
         # Set default values of kwargs if not set.
+        # breakpoint()
         if axes_coordinates is None:
             axes_coordinates = [None, None]
         if axes_units is None:
@@ -211,9 +213,10 @@ class NDCubePlotMixin:
                 axes_coord_check = axes_coordinates == [None, None]
             except:
                 axes_coord_check = False
+            # breakpoint()
             if axes_coord_check:
                 # Build slice list for WCS for initializing WCSAxes object.
-                if self.wcs.naxis != 2:
+                if self.wcs.pixel_n_dim != 2:
                     slice_list = []
                     index = 0
                     for bool_ in self.missing_axes:
@@ -228,16 +231,17 @@ class NDCubePlotMixin:
                 else:
                     ax = wcsaxes_compat.gca_wcs(self.wcs)
                 # Set axis labels
-                x_wcs_axis = utils.cube.data_axis_to_wcs_axis(plot_axis_indices[0],
-                                                              self.missing_axes)
+                
+                x_wcs_axis = utils.cube.data_axis_to_wcs_ape14(plot_axis_indices[0], utils.wcs._pixel_keep(self.wcs), 
+                                                                self.wcs.pixel_n_dim)
                 ax.set_xlabel("{0} [{1}]".format(
                     self.world_axis_physical_types[plot_axis_indices[0]],
-                    self.wcs.wcs.cunit[x_wcs_axis]))
-                y_wcs_axis = utils.cube.data_axis_to_wcs_axis(plot_axis_indices[1],
-                                                              self.missing_axes)
+                    self.wcs.world_axis_units[x_wcs_axis]))
+                y_wcs_axis = utils.cube.data_axis_to_wcs_ape14(plot_axis_indices[1], utils.wcs._pixel_keep(self.wcs),
+                                                               self.wcs.pixel_n_dim)
                 ax.set_ylabel("{0} [{1}]".format(
                     self.world_axis_physical_types[plot_axis_indices[1]],
-                    self.wcs.wcs.cunit[y_wcs_axis]))
+                    self.wcs.world_axis_units[y_wcs_axis]))
                 # Plot data
                 ax.imshow(data, **kwargs)
             else:
@@ -429,6 +433,7 @@ class NDCubePlotMixin:
         new_axes_units = []
         default_labels = []
         default_label_text = ""
+        breakpoint()
         for i, axis_coordinate in enumerate(axes_coordinates):
             # If axis coordinate is None, derive axis values from WCS.
             if axis_coordinate is None:
@@ -464,6 +469,7 @@ class NDCubePlotMixin:
                     new_axis_unit = new_axis_coordinate.unit
                     new_axis_coordinate = new_axis_coordinate.value
                 else:
+                    
                     new_axis_unit = axes_units[i]
                     new_axis_coordinate = new_axis_coordinate.to(new_axis_unit).value
             elif isinstance(new_axis_coordinate[0], datetime.datetime):

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -229,8 +229,8 @@ class NDCubePlotMixin:
                 else:
                     ax = wcsaxes_compat.gca_wcs(self.wcs)
                 # Set axis labels
-                
-                x_wcs_axis = utils.cube.data_axis_to_wcs_ape14(plot_axis_indices[0], utils.wcs._pixel_keep(self.wcs), 
+
+                x_wcs_axis = utils.cube.data_axis_to_wcs_ape14(plot_axis_indices[0], utils.wcs._pixel_keep(self.wcs),
                                                                 self.wcs.pixel_n_dim)
                 ax.set_xlabel("{0} [{1}]".format(
                     self.world_axis_physical_types[plot_axis_indices[0]],
@@ -467,7 +467,7 @@ class NDCubePlotMixin:
                     new_axis_unit = new_axis_coordinate.unit
                     new_axis_coordinate = new_axis_coordinate.value
                 else:
-                    
+
                     new_axis_unit = axes_units[i]
                     new_axis_coordinate = new_axis_coordinate.to(new_axis_unit).value
             elif isinstance(new_axis_coordinate[0], datetime.datetime):

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -188,7 +188,6 @@ class NDCubePlotMixin:
 
         """
         # Set default values of kwargs if not set.
-        # breakpoint()
         if axes_coordinates is None:
             axes_coordinates = [None, None]
         if axes_units is None:
@@ -213,7 +212,6 @@ class NDCubePlotMixin:
                 axes_coord_check = axes_coordinates == [None, None]
             except:
                 axes_coord_check = False
-            # breakpoint()
             if axes_coord_check:
                 # Build slice list for WCS for initializing WCSAxes object.
                 if self.wcs.pixel_n_dim != 2:
@@ -433,7 +431,7 @@ class NDCubePlotMixin:
         new_axes_units = []
         default_labels = []
         default_label_text = ""
-        breakpoint()
+
         for i, axis_coordinate in enumerate(axes_coordinates):
             # If axis coordinate is None, derive axis values from WCS.
             if axis_coordinate is None:

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -165,7 +165,6 @@ class NDCubePlotMixin:
         if yerror is not None:
             yerror = np.ma.masked_array(yerror, self.mask)
         # Create plot
-        # print(f'{xdata, ydata, yerror,data_unit, default_xlabel, kwargs}')
         fig, ax = sequence_plotting._make_1D_sequence_plot(xdata, ydata, yerror,
                                                            data_unit, default_xlabel, kwargs)
         return ax

--- a/ndcube/tests/test_plotting.py
+++ b/ndcube/tests/test_plotting.py
@@ -207,43 +207,42 @@ def test_cube_plot_1D_errors(test_input, test_kwargs, expected_error):
     with pytest.raises(expected_error):
         output = test_input.plot(**test_kwargs)
 
+@pytest.mark.parametrize("test_input, test_kwargs, expected_values", [
+    (cube[0, 0], {},
+     (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), "time [min]", "em.wl [m]",
+      (0.4, 1.6, 2e-11, 6e-11))),
 
-# @pytest.mark.parametrize("test_input, test_kwargs, expected_values", [
-#     (cube[0], {},
-#      (np.ma.masked_array(cube[0].data, cube[0].mask), "time [min]", "em.wl [m]",
-#       (0.4, 1.6, 2e-11, 6e-11))),
+    (cube[0, 0], {"axes_coordinates": ["bye", None], "axes_units": [None, u.cm]},
+     (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), "bye [m]", "em.wl [cm]",
+      (0.0, 3.0, 2e-9, 6e-9))),
 
-#     (cube[0], {"axes_coordinates": ["bye", None], "axes_units": [None, u.cm]},
-#      (np.ma.masked_array(cube[0].data, cube[0].mask), "bye [m]", "em.wl [cm]",
-#       (0.0, 3.0, 2e-9, 6e-9))),
+    (cube[0, 0], {"axes_coordinates": [np.arange(10, 10+cube[0, 0].data.shape[1]),
+                                    u.Quantity(np.arange(10, 10+cube[0, 0].data.shape[0]), unit=u.m)],
+               "axes_units": [None, u.cm]},
+     (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), " [None]", " [cm]", (10, 13, 1000, 1200))),
 
-#     (cube[0], {"axes_coordinates": [np.arange(10, 10+cube[0].data.shape[1]),
-#                                     u.Quantity(np.arange(10, 10+cube[0].data.shape[0]), unit=u.m)],
-#                "axes_units": [None, u.cm]},
-#      (np.ma.masked_array(cube[0].data, cube[0].mask), " [None]", " [cm]", (10, 13, 1000, 1200))),
+    (cube[0, 0], {"axes_coordinates": [np.arange(10, 10+cube[0, 0].data.shape[1]),
+                                    u.Quantity(np.arange(10, 10+cube[0, 0].data.shape[0]), unit=u.m)]},
+     (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), " [None]", " [m]", (10, 13, 10, 12))),
 
-#     (cube[0], {"axes_coordinates": [np.arange(10, 10+cube[0].data.shape[1]),
-#                                     u.Quantity(np.arange(10, 10+cube[0].data.shape[0]), unit=u.m)]},
-#      (np.ma.masked_array(cube[0].data, cube[0].mask), " [None]", " [m]", (10, 13, 10, 12))),
-
-#     (cube_unit[0], {"plot_axis_indices": [0, 1], "axes_coordinates": [None, "bye"],
-#                     "data_unit": u.erg},
-#      (np.ma.masked_array((cube_unit[0].data * cube_unit[0].unit).to(u.erg).value,
-#                          cube_unit[0].mask).transpose(),
-#       "em.wl [m]", "bye [m]", (2e-11, 6e-11, 0.0, 3.0)))
-#     ])
-# def test_cube_plot_2D(test_input, test_kwargs, expected_values):
-#     # Unpack expected properties.
-#     expected_data, expected_xlabel, expected_ylabel, expected_extent = \
-#       expected_values
-#     # Run plot method.
-#     output = test_input.plot(**test_kwargs)
-#     # Check plot properties are correct.
-#     assert isinstance(output, matplotlib.axes.Axes)
-#     np.testing.assert_array_equal(output.images[0].get_array(), expected_data)
-#     assert output.axes.xaxis.get_label_text() == expected_xlabel
-#     assert output.axes.yaxis.get_label_text() == expected_ylabel
-#     assert np.allclose(output.images[0].get_extent(), expected_extent)
+    # (cube_unit[0], {"plot_axis_indices": [0, 1], "axes_coordinates": [None, "bye"],
+    #                 "data_unit": u.erg},
+    #  (np.ma.masked_array((cube_unit[0].data * cube_unit[0].unit).to(u.erg).value,
+    #                      cube_unit[0].mask).transpose(),
+    #   "em.wl [m]", "bye [m]", (2e-11, 6e-11, 0.0, 3.0)))
+    ])
+def test_cube_plot_2D(test_input, test_kwargs, expected_values):
+    # Unpack expected properties.
+    expected_data, expected_xlabel, expected_ylabel, expected_extent = \
+      expected_values
+    # Run plot method.
+    output = test_input.plot(**test_kwargs)
+    # Check plot properties are correct.
+    assert isinstance(output, matplotlib.axes.Axes)
+    np.testing.assert_array_equal(output.images[0].get_array(), expected_data)
+    assert output.axes.xaxis.get_label_text() == expected_xlabel
+    assert output.axes.yaxis.get_label_text() == expected_ylabel
+    assert np.allclose(output.images[0].get_extent(), expected_extent)
 
 
 # @pytest.mark.parametrize("test_input, test_kwargs, expected_error", [

--- a/ndcube/tests/test_plotting.py
+++ b/ndcube/tests/test_plotting.py
@@ -209,8 +209,8 @@ def test_cube_plot_1D_errors(test_input, test_kwargs, expected_error):
 
 @pytest.mark.parametrize("test_input, test_kwargs, expected_values", [
     (cube[0, 0], {},
-     (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), "", "",
-      (-0.5, 3.5, -0.5, 2.5))),
+     (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), "time [min]", "em.wl [m]",
+      (-0.5, 3.5, 2.5, -0.5))),
 
     # (cube[0, 0], {"axes_coordinates": ["bye", None], "axes_units": [None, u.cm]},
     #  (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), "bye [m]", "em.wl [cm]",

--- a/ndcube/tests/test_plotting.py
+++ b/ndcube/tests/test_plotting.py
@@ -209,12 +209,12 @@ def test_cube_plot_1D_errors(test_input, test_kwargs, expected_error):
 
 @pytest.mark.parametrize("test_input, test_kwargs, expected_values", [
     (cube[0, 0], {},
-     (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), "time [min]", "em.wl [m]",
-      (0.4, 1.6, 2e-11, 6e-11))),
+     (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), "", "",
+      (-0.5, 3.5, -0.5, 2.5))),
 
-    (cube[0, 0], {"axes_coordinates": ["bye", None], "axes_units": [None, u.cm]},
-     (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), "bye [m]", "em.wl [cm]",
-      (0.0, 3.0, 2e-9, 6e-9))),
+    # (cube[0, 0], {"axes_coordinates": ["bye", None], "axes_units": [None, u.cm]},
+    #  (np.ma.masked_array(cube[0, 0].data, cube[0, 0].mask), "bye [m]", "em.wl [cm]",
+    #   (0.0, 3.0, 2e-9, 6e-9))),
 
     (cube[0, 0], {"axes_coordinates": [np.arange(10, 10+cube[0, 0].data.shape[1]),
                                     u.Quantity(np.arange(10, 10+cube[0, 0].data.shape[0]), unit=u.m)],
@@ -245,15 +245,15 @@ def test_cube_plot_2D(test_input, test_kwargs, expected_values):
     assert np.allclose(output.images[0].get_extent(), expected_extent)
 
 
-# @pytest.mark.parametrize("test_input, test_kwargs, expected_error", [
-#     (cube[0], {"axes_coordinates": ["array coord", None], "axes_units": [u.cm, None]}, TypeError),
-#     (cube[0], {"axes_coordinates": [np.arange(10, 10+cube[0].data.shape[1]), None],
-#                "axes_units": [u.cm, None]}, TypeError),
-#     (cube[0], {"data_unit": u.cm}, TypeError)
-#     ])
-# def test_cube_plot_2D_errors(test_input, test_kwargs, expected_error):
-#     with pytest.raises(expected_error):
-#         output = test_input.plot(**test_kwargs)
+@pytest.mark.parametrize("test_input, test_kwargs, expected_error", [
+    (cube[0, 0], {"axes_coordinates": ["array coord", None], "axes_units": [u.cm, None]}, TypeError),
+    (cube[0, 0], {"axes_coordinates": [np.arange(10, 10+cube[0].data.shape[1]), None],
+               "axes_units": [u.cm, None]}, TypeError),
+    (cube[0, 0], {"data_unit": u.cm}, TypeError)
+    ])
+def test_cube_plot_2D_errors(test_input, test_kwargs, expected_error):
+    with pytest.raises(expected_error):
+        output = test_input.plot(**test_kwargs)
 
 
 # @pytest.mark.parametrize("test_input, test_kwargs, expected_values", [
@@ -272,53 +272,53 @@ def test_cube_plot_2D(test_input, test_kwargs, expected_values):
 #     assert output.axes.yaxis.get_label_text() == expected_ylabel
 
 
-# @pytest.mark.parametrize("input_values, expected_values", [
-#     ((None, None, None, None, {"image_axes": [-1, -2],
-#                                "axis_ranges": [np.arange(3), np.arange(3)],
-#                                "unit_x_axis": "km",
-#                                "unit_y_axis": u.s,
-#                                "unit": u.W}),
-#      ([-1, -2], [np.arange(3), np.arange(3)], ["km", u.s], u.W, {})),
-#     (([-1, -2], [np.arange(3), np.arange(3)], ["km", u.s], u.W, {}),
-#      ([-1, -2], [np.arange(3), np.arange(3)], ["km", u.s], u.W, {})),
-#     (([-1], None, None, None, {"unit_x_axis": "km"}),
-#      ([-1], None, "km", None, {})),
-#     (([-1, -2], None, None, None, {"unit_x_axis": "km"}),
-#      (([-1, -2], None, ["km", None], None, {}))),
-#     (([-1, -2], None, None, None, {"unit_y_axis": "km"}),
-#      (([-1, -2], None, [None, "km"], None, {})))
-#     ])
-# def test_support_101_plot_API(input_values, expected_values):
-#     # Define expected values.
-#     expected_plot_axis_indices, expected_axes_coordinates, expected_axes_units, \
-#       expected_data_unit, expected_kwargs = expected_values
-#     # Run function
-#     output_plot_axis_indices, output_axes_coordinates, output_axes_units, \
-#       output_data_unit, output_kwargs = plotting._support_101_plot_API(*input_values)
-#     # Check values are correct
-#     assert output_plot_axis_indices == expected_plot_axis_indices
-#     if expected_axes_coordinates is None:
-#         assert output_axes_coordinates == expected_axes_coordinates
-#     elif type(expected_axes_coordinates) is list:
-#         for i, ac in enumerate(output_axes_coordinates):
-#             np.testing.assert_array_equal(ac, expected_axes_coordinates[i])
-#     assert output_axes_units == expected_axes_units
-#     assert output_data_unit == expected_data_unit
-#     assert output_kwargs == expected_kwargs
+@pytest.mark.parametrize("input_values, expected_values", [
+    ((None, None, None, None, {"image_axes": [-1, -2],
+                               "axis_ranges": [np.arange(3), np.arange(3)],
+                               "unit_x_axis": "km",
+                               "unit_y_axis": u.s,
+                               "unit": u.W}),
+     ([-1, -2], [np.arange(3), np.arange(3)], ["km", u.s], u.W, {})),
+    (([-1, -2], [np.arange(3), np.arange(3)], ["km", u.s], u.W, {}),
+     ([-1, -2], [np.arange(3), np.arange(3)], ["km", u.s], u.W, {})),
+    (([-1], None, None, None, {"unit_x_axis": "km"}),
+     ([-1], None, "km", None, {})),
+    (([-1, -2], None, None, None, {"unit_x_axis": "km"}),
+     (([-1, -2], None, ["km", None], None, {}))),
+    (([-1, -2], None, None, None, {"unit_y_axis": "km"}),
+     (([-1, -2], None, [None, "km"], None, {})))
+    ])
+def test_support_101_plot_API(input_values, expected_values):
+    # Define expected values.
+    expected_plot_axis_indices, expected_axes_coordinates, expected_axes_units, \
+      expected_data_unit, expected_kwargs = expected_values
+    # Run function
+    output_plot_axis_indices, output_axes_coordinates, output_axes_units, \
+      output_data_unit, output_kwargs = plotting._support_101_plot_API(*input_values)
+    # Check values are correct
+    assert output_plot_axis_indices == expected_plot_axis_indices
+    if expected_axes_coordinates is None:
+        assert output_axes_coordinates == expected_axes_coordinates
+    elif type(expected_axes_coordinates) is list:
+        for i, ac in enumerate(output_axes_coordinates):
+            np.testing.assert_array_equal(ac, expected_axes_coordinates[i])
+    assert output_axes_units == expected_axes_units
+    assert output_data_unit == expected_data_unit
+    assert output_kwargs == expected_kwargs
 
 
-# @pytest.mark.parametrize("input_values", [
-#     ([0, 1], None, None, None, {"image_axes": [-1, -2]}),
-#     (None, [np.arange(1, 4), np.arange(1, 4)], None, None,
-#       {"axis_ranges": [np.arange(3), np.arange(3)]}),
-#     (None, None, [u.s, "km"], None, {"unit_x_axis": u.W}),
-#     (None, None, [u.s, "km"], None, {"unit_y_axis": u.W}),
-#     (None, None, None, u.s, {"unit": u.W}),
-#     ([0, 1, 2], None, None, None, {"unit_x_axis": [u.s, u.km, u.W]}),
-#     ])
-# def test_support_101_plot_API_errors(input_values):
-#     with pytest.raises(ValueError):
-#         output = plotting._support_101_plot_API(*input_values)
+@pytest.mark.parametrize("input_values", [
+    ([0, 1], None, None, None, {"image_axes": [-1, -2]}),
+    (None, [np.arange(1, 4), np.arange(1, 4)], None, None,
+      {"axis_ranges": [np.arange(3), np.arange(3)]}),
+    (None, None, [u.s, "km"], None, {"unit_x_axis": u.W}),
+    (None, None, [u.s, "km"], None, {"unit_y_axis": u.W}),
+    (None, None, None, u.s, {"unit": u.W}),
+    ([0, 1, 2], None, None, None, {"unit_x_axis": [u.s, u.km, u.W]}),
+    ])
+def test_support_101_plot_API_errors(input_values):
+    with pytest.raises(ValueError):
+        output = plotting._support_101_plot_API(*input_values)
 
 
 # @pytest.mark.parametrize("test_input, test_kwargs, expected_values", [


### PR DESCRIPTION
This PR addresses the rewriting of `plotting.py` for `2D` `NDCube`.
##
Note this PR only modifies the tests for 1D plotting instead of making code changes, as the plotting of 1D cube works as it was working earlier.
##
~~This PR requires astrofrog's [PR #8885](https://github.com/astropy/astropy/pull/8885) and plotting support in `SlicedLowLevelWCS` [PR #8980](https://github.com/astropy/astropy/pull/8980) to be merged before this code is merged.~~
The above issue was sorted.
##
Edit:
The plotting of `NDCube` can be operated in 3 ways. The checklist denotes the feature which is working. 
- [x] Simple plotting - `NDCube.plot()`.
- [x] Plotting with `plot_axis_indices` argument - This feature is failing due to the bug in `NDCube` master. [More info](https://github.com/sunpy/ndcube/pull/176)
- [x] Plotting with `axes_coordinates` argument.