### PR TITLE
Fixes the bug associated with axes_coordinates

### DIFF
--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -421,7 +421,9 @@ class NDCubePlotMixin:
             if axis_coordinate is None:
                 # Fix: We would downscale the dependent data into the shape of the axes.
                 xdata = self.axis_world_coords(i, edges=edges)
-                if xdata.ndim != data_shape[i]:
+
+                # If the shape of the data is not 1, or all the axes are not dependent
+                if xdata.ndim != 1 and xdata.ndim != len(data_shape):
                     axis_label_text = self.world_axis_physical_types[i]
 
                     index = utils.wcs.get_dependent_data_axes(self.wcs, i, self.missing_axes)
@@ -430,7 +432,8 @@ class NDCubePlotMixin:
                     index = np.delete(index, reduce_axis)
                     # Reduce the data by taking mean
                     new_axis_coordinate = np.mean(xdata, axis=tuple(index))
-                new_axis_coordinate = xdata
+                else:
+                    new_axis_coordinate = xdata
             elif isinstance(axis_coordinate, str):
                 # If axis coordinate is a string, derive axis values from
                 # corresponding extra coord.

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -446,7 +446,7 @@ class NDCubePlotMixin:
                     index = np.delete(index, reduce_axis)
                     # Reduce the data by taking mean
                     new_axis_coordinate = np.mean(new_axis_coordinate, axis=tuple(index))
-                
+
             elif isinstance(axis_coordinate, str):
                 # If axis coordinate is a string, derive axis values from
                 # corresponding extra coord.

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -427,7 +427,7 @@ class NDCubePlotMixin:
                     axis_label_text = self.world_axis_physical_types[i]
 
                     index = utils.wcs.get_dependent_data_axes(self.wcs, i, self.missing_axes)
-                    reduce_axis = np.where(index == np.array(i))[0]
+                    reduce_axis = np.where(index == i)[0]
 
                     index = np.delete(index, reduce_axis)
                     # Reduce the data by taking mean

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -62,7 +62,7 @@ class NDCubePlotMixin:
             If None is specified for an axis then the array indices will be used
             for that axis.
             The physical coordinates expected by axes_coordinates should be an array of
-            pixel_edges instead of pixel_centers.
+            pixel_edges.
 
         """
         # If old API is used, convert to new API.
@@ -294,7 +294,7 @@ class NDCubePlotMixin:
             If None is specified for an axis then the array indices will be used
             for that axis.
             The physical coordinates expected by axes_coordinates should be an array of
-            pixel_edges instead of pixel_centers.
+            pixel_edges.
 
         """
         # For convenience in inserting dummy variables later, ensure

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -421,7 +421,7 @@ class NDCubePlotMixin:
                 xdata = self.axis_world_coords(i, edges=edges)
                 if xdata.ndim != data_shape[i]:
                     axis_label_text = self.world_axis_physical_types[i]
-                    
+
                     index = utils.wcs.get_dependent_data_axes(self.wcs, i, self.missing_axes)
                     reduce_axis = np.where(index == np.array(i))[0]
 

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -61,6 +61,8 @@ class NDCubePlotMixin:
             same length as the axis which will provide all values for that slider.
             If None is specified for an axis then the array indices will be used
             for that axis.
+            The physical coordinates expected by axes_coordinates should be an array of
+            pixel_edges instead of pixel_centers.
 
         """
         # If old API is used, convert to new API.
@@ -291,6 +293,8 @@ class NDCubePlotMixin:
             same length as the axis which will provide all values for that slider.
             If None is specified for an axis then the array indices will be used
             for that axis.
+            The physical coordinates expected by axes_coordinates should be an array of
+            pixel_edges instead of pixel_centers.
 
         """
         # For convenience in inserting dummy variables later, ensure
@@ -467,7 +471,7 @@ class NDCubePlotMixin:
                     new_axis_unit = None
                 else:
                     raise TypeError(INVALID_UNIT_SET_MESSAGE)
-                    
+
             # Derive default axis label
             if type(new_axis_coordinate) is datetime.datetime:
                 if axis_label_text == default_label_text:

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -420,10 +420,10 @@ class NDCubePlotMixin:
             # If axis coordinate is None, derive axis values from WCS.
             if axis_coordinate is None:
                 # Fix: We would downscale the dependent data into the shape of the axes.
-                xdata = self.axis_world_coords(i, edges=edges)
+                new_axes_coordinate = self.axis_world_coords(i, edges=edges)
 
                 # If the shape of the data is not 1, or all the axes are not dependent
-                if xdata.ndim != 1 and xdata.ndim != len(data_shape):
+                if new_axes_coordinate.ndim != 1 and new_axes_coordinate.ndim != len(data_shape):
                     axis_label_text = self.world_axis_physical_types[i]
 
                     index = utils.wcs.get_dependent_data_axes(self.wcs, i, self.missing_axes)
@@ -431,9 +431,8 @@ class NDCubePlotMixin:
 
                     index = np.delete(index, reduce_axis)
                     # Reduce the data by taking mean
-                    new_axis_coordinate = np.mean(xdata, axis=tuple(index))
-                else:
-                    new_axis_coordinate = xdata
+                    new_axis_coordinate = np.mean(new_axes_coordinate, axis=tuple(index))
+                
             elif isinstance(axis_coordinate, str):
                 # If axis coordinate is a string, derive axis values from
                 # corresponding extra coord.

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -63,6 +63,10 @@ class NDCubePlotMixin:
             for that axis.
             The physical coordinates expected by axes_coordinates should be an array of
             pixel_edges.
+            A str entry in axes_coordinates signifies that an extra_coord will be used for the axis's coordinates.
+            The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
+
+
 
         """
         # If old API is used, convert to new API.
@@ -295,6 +299,8 @@ class NDCubePlotMixin:
             for that axis.
             The physical coordinates expected by axes_coordinates should be an array of
             pixel_edges.
+            A str entry in axes_coordinates signifies that an extra_coord will be used for the axis's coordinates.
+            The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
         """
         # For convenience in inserting dummy variables later, ensure

--- a/ndcube/mixins/sequence_plotting.py
+++ b/ndcube/mixins/sequence_plotting.py
@@ -697,8 +697,6 @@ class ImageAnimatorNDCubeSequence(ImageAnimatorWCS):
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
         pixel_edges.
-        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
-        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     interval: `int`
         Animation interval in ms
@@ -796,8 +794,6 @@ class ImageAnimatorCubeLikeNDCubeSequence(ImageAnimatorWCS):
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
         pixel_edges.
-        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
-        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     interval: `int`
         Animation interval in ms
@@ -917,8 +913,6 @@ class LineAnimatorNDCubeSequence(LineAnimator):
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
         pixel_edges.
-        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
-        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     interval: `int`
         Animation interval in ms
@@ -1155,8 +1149,6 @@ class LineAnimatorCubeLikeNDCubeSequence(LineAnimator):
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
         pixel_edges.
-        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
-        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     interval: `int`
         Animation interval in ms
@@ -1379,8 +1371,6 @@ def _prep_axes_kwargs(naxis, plot_axis_indices, axes_coordinates, axes_units):
         Length of list equals number of sequence axes.
         The physical coordinates expected by axes_coordinates should be an array of
         pixel_edges.
-        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
-        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     axes_units: None or `list` of `None` `astropy.units.Unit` or `str`
         Length of list equals number of sequence axes.

--- a/ndcube/mixins/sequence_plotting.py
+++ b/ndcube/mixins/sequence_plotting.py
@@ -62,6 +62,8 @@ class NDCubeSequencePlotMixin:
             `None` (implies derive the coordinates from the WCS objects),
             an `astropy.units.Quantity` or a `numpy.ndarray` of coordinates for each pixel,
             or a `str` denoting a valid extra coordinate.
+            The physical coordinates expected by axes_coordinates should be an array of
+            pixel_edges instead of pixel_centers.
 
         axes_units: `None or `list` of `None`, `astropy.units.Unit` and/or `str`
             If None units derived from the WCS objects will be used for all axes.
@@ -168,6 +170,8 @@ class NDCubeSequencePlotMixin:
             `None` (implies derive the coordinates from the WCS objects),
             an `astropy.units.Quantity` or a `numpy.ndarray` of coordinates for each pixel,
             or a `str` denoting a valid extra coordinate.
+            The physical coordinates expected by axes_coordinates should be an array of
+            pixel_edges instead of pixel_centers.
 
         axes_units: `None or `list` of `None`, `astropy.units.Unit` and/or `str`
             If None units derived from the WCS objects will be used for all axes.
@@ -254,6 +258,8 @@ class NDCubeSequencePlotMixin:
             each pixel along the x-axis.
             If a `str`, denotes the extra coordinate to be used.  The extra coordinate must
             correspond to the sequence axis.
+            The physical coordinates expected by axes_coordinates should be an array of
+            pixel_edges instead of pixel_centers.
 
         axes_units: `astropy.unit.Unit` or valid unit `str` or length 1 `list` of those types.
             Unit in which X-axis should be displayed.  Must be compatible with the unit of
@@ -683,6 +689,8 @@ class ImageAnimatorNDCubeSequence(ImageAnimatorWCS):
         same length as the axis which will provide all values for that slider.
         If None is specified for an axis then the array indices will be used
         for that axis.
+        The physical coordinates expected by axis_ranges should be an array of
+        pixel_edges instead of pixel_centers.
 
     interval: `int`
         Animation interval in ms
@@ -778,6 +786,8 @@ class ImageAnimatorCubeLikeNDCubeSequence(ImageAnimatorWCS):
         same length as the axis which will provide all values for that slider.
         If None is specified for an axis then the array indices will be used
         for that axis.
+        The physical coordinates expected by axis_ranges should be an array of
+        pixel_edges instead of pixel_centers.
 
     interval: `int`
         Animation interval in ms
@@ -895,6 +905,8 @@ class LineAnimatorNDCubeSequence(LineAnimator):
         same length as the axis which will provide all values for that slider.
         If None is specified for an axis then the array indices will be used
         for that axis.
+        The physical coordinates expected by axis_ranges should be an array of
+        pixel_edges instead of pixel_centers.
 
     interval: `int`
         Animation interval in ms
@@ -1129,6 +1141,8 @@ class LineAnimatorCubeLikeNDCubeSequence(LineAnimator):
         same length as the axis which will provide all values for that slider.
         If None is specified for an axis then the array indices will be used
         for that axis.
+        The physical coordinates expected by axis_ranges should be an array of
+        pixel_edges instead of pixel_centers.
 
     interval: `int`
         Animation interval in ms
@@ -1349,6 +1363,8 @@ def _prep_axes_kwargs(naxis, plot_axis_indices, axes_coordinates, axes_units):
 
     axes_coordinates: `None` or `list` of `None` `astropy.units.Quantity` `numpy.ndarray` `str`
         Length of list equals number of sequence axes.
+        The physical coordinates expected by axes_coordinates should be an array of
+        pixel_edges instead of pixel_centers.
 
     axes_units: None or `list` of `None` `astropy.units.Unit` or `str`
         Length of list equals number of sequence axes.

--- a/ndcube/mixins/sequence_plotting.py
+++ b/ndcube/mixins/sequence_plotting.py
@@ -64,6 +64,8 @@ class NDCubeSequencePlotMixin:
             or a `str` denoting a valid extra coordinate.
             The physical coordinates expected by axes_coordinates should be an array of
             pixel_edges.
+            A str entry in axes_coordinates signifies that an extra_coord will be used for the axis's coordinates.
+            The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
         axes_units: `None or `list` of `None`, `astropy.units.Unit` and/or `str`
             If None units derived from the WCS objects will be used for all axes.
@@ -172,6 +174,8 @@ class NDCubeSequencePlotMixin:
             or a `str` denoting a valid extra coordinate.
             The physical coordinates expected by axes_coordinates should be an array of
             pixel_edges.
+            A str entry in axes_coordinates signifies that an extra_coord will be used for the axis's coordinates.
+            The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
         axes_units: `None or `list` of `None`, `astropy.units.Unit` and/or `str`
             If None units derived from the WCS objects will be used for all axes.
@@ -260,6 +264,8 @@ class NDCubeSequencePlotMixin:
             correspond to the sequence axis.
             The physical coordinates expected by axes_coordinates should be an array of
             pixel_edges.
+            A str entry in axes_coordinates signifies that an extra_coord will be used for the axis's coordinates.
+            The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
         axes_units: `astropy.unit.Unit` or valid unit `str` or length 1 `list` of those types.
             Unit in which X-axis should be displayed.  Must be compatible with the unit of
@@ -691,6 +697,8 @@ class ImageAnimatorNDCubeSequence(ImageAnimatorWCS):
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
         pixel_edges.
+        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
+        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     interval: `int`
         Animation interval in ms
@@ -788,6 +796,8 @@ class ImageAnimatorCubeLikeNDCubeSequence(ImageAnimatorWCS):
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
         pixel_edges.
+        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
+        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     interval: `int`
         Animation interval in ms
@@ -907,6 +917,8 @@ class LineAnimatorNDCubeSequence(LineAnimator):
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
         pixel_edges.
+        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
+        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     interval: `int`
         Animation interval in ms
@@ -1143,6 +1155,8 @@ class LineAnimatorCubeLikeNDCubeSequence(LineAnimator):
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
         pixel_edges.
+        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
+        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     interval: `int`
         Animation interval in ms
@@ -1365,6 +1379,8 @@ def _prep_axes_kwargs(naxis, plot_axis_indices, axes_coordinates, axes_units):
         Length of list equals number of sequence axes.
         The physical coordinates expected by axes_coordinates should be an array of
         pixel_edges.
+        A str entry in axis_ranges signifies that an extra_coord will be used for the axis's coordinates.
+        The str must be a valid name of an extra_coord that corresponds to the same axis to which it is applied in the plot.
 
     axes_units: None or `list` of `None` `astropy.units.Unit` or `str`
         Length of list equals number of sequence axes.

--- a/ndcube/mixins/sequence_plotting.py
+++ b/ndcube/mixins/sequence_plotting.py
@@ -63,7 +63,7 @@ class NDCubeSequencePlotMixin:
             an `astropy.units.Quantity` or a `numpy.ndarray` of coordinates for each pixel,
             or a `str` denoting a valid extra coordinate.
             The physical coordinates expected by axes_coordinates should be an array of
-            pixel_edges instead of pixel_centers.
+            pixel_edges.
 
         axes_units: `None or `list` of `None`, `astropy.units.Unit` and/or `str`
             If None units derived from the WCS objects will be used for all axes.
@@ -171,7 +171,7 @@ class NDCubeSequencePlotMixin:
             an `astropy.units.Quantity` or a `numpy.ndarray` of coordinates for each pixel,
             or a `str` denoting a valid extra coordinate.
             The physical coordinates expected by axes_coordinates should be an array of
-            pixel_edges instead of pixel_centers.
+            pixel_edges.
 
         axes_units: `None or `list` of `None`, `astropy.units.Unit` and/or `str`
             If None units derived from the WCS objects will be used for all axes.
@@ -259,7 +259,7 @@ class NDCubeSequencePlotMixin:
             If a `str`, denotes the extra coordinate to be used.  The extra coordinate must
             correspond to the sequence axis.
             The physical coordinates expected by axes_coordinates should be an array of
-            pixel_edges instead of pixel_centers.
+            pixel_edges.
 
         axes_units: `astropy.unit.Unit` or valid unit `str` or length 1 `list` of those types.
             Unit in which X-axis should be displayed.  Must be compatible with the unit of
@@ -690,7 +690,7 @@ class ImageAnimatorNDCubeSequence(ImageAnimatorWCS):
         If None is specified for an axis then the array indices will be used
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
-        pixel_edges instead of pixel_centers.
+        pixel_edges.
 
     interval: `int`
         Animation interval in ms
@@ -787,7 +787,7 @@ class ImageAnimatorCubeLikeNDCubeSequence(ImageAnimatorWCS):
         If None is specified for an axis then the array indices will be used
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
-        pixel_edges instead of pixel_centers.
+        pixel_edges.
 
     interval: `int`
         Animation interval in ms
@@ -906,7 +906,7 @@ class LineAnimatorNDCubeSequence(LineAnimator):
         If None is specified for an axis then the array indices will be used
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
-        pixel_edges instead of pixel_centers.
+        pixel_edges.
 
     interval: `int`
         Animation interval in ms
@@ -1142,7 +1142,7 @@ class LineAnimatorCubeLikeNDCubeSequence(LineAnimator):
         If None is specified for an axis then the array indices will be used
         for that axis.
         The physical coordinates expected by axis_ranges should be an array of
-        pixel_edges instead of pixel_centers.
+        pixel_edges.
 
     interval: `int`
         Animation interval in ms
@@ -1364,7 +1364,7 @@ def _prep_axes_kwargs(naxis, plot_axis_indices, axes_coordinates, axes_units):
     axes_coordinates: `None` or `list` of `None` `astropy.units.Quantity` `numpy.ndarray` `str`
         Length of list equals number of sequence axes.
         The physical coordinates expected by axes_coordinates should be an array of
-        pixel_edges instead of pixel_centers.
+        pixel_edges.
 
     axes_units: None or `list` of `None` `astropy.units.Unit` or `str`
         Length of list equals number of sequence axes.

--- a/ndcube/tests/test_plotting.py
+++ b/ndcube/tests/test_plotting.py
@@ -33,6 +33,7 @@ wm = WCS(header=hm, naxis=3)
 
 data = np.array([[[1, 2, 3, 4], [2, 4, 5, 3], [0, -1, 2, 3]],
                  [[2, 4, 5, 1], [10, 5, 2, 2], [10, 3, 3, 0]]])
+
 uncertainty = np.sqrt(data)
 mask_cube = data < 0
 


### PR DESCRIPTION
This PR addresses the bug associated with `axes_coordinates`.
This PR addresses the following problems - 
 1. Make sure the axes_coordinates for >2D plot contains no external values if `axes_coordinate=None` along plot_axis_indices. This makes sure that `axes_coordinates` is a list of None.
2. Edited `_derive_axes_coordinates` to calculate the values for independent and dependent axes. If dependent axes, then the values are downscaled to the data_shape along the axis by taking mean along non-plotting axes.
3. Added the support for getting `edges` in `_derive_axes_coordinates` .

Partially fixes #187 
Ping @DanRyanIrish 
##
Note that this PR should be merged after #176 is merged.