### PR TITLE
Bugfix for Issue 218: NDCube slicing with numpy.int64

### DIFF
--- a/changelog/223.bugfix.rst
+++ b/changelog/223.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crashing bug when an NDCube axis after the first is sliced with a numpy.int64.

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -7,6 +7,7 @@ Miscellaneous WCS utilities.
 import re
 from copy import deepcopy
 from collections import UserDict
+import numbers
 
 import numpy as np
 from astropy import wcs
@@ -163,7 +164,7 @@ def _wcs_slicer(wcs, missing_axes, item):
                 item_checked.append(slice(0, 1))
         new_wcs = wcs.slice(item_checked)
     # item is int then slicing axis.
-    elif isinstance(item, int) or isinstance(item, np.int64):
+    elif isinstance(item, numbers.Integral):
         # using index to keep track of whether the int(which is converted to
         # slice(int_value, int_value+1)) is already added or not. It checks
         # the dead axis i.e missing_axes to check if it is dead than slice(0,1)
@@ -207,7 +208,10 @@ def _wcs_slicer(wcs, missing_axes, item):
             item_ = _slice_list(item_checked)
             new_wcs = wcs.slice(item_)
             for i, it in enumerate(item_checked):
-                if isinstance(it, int):
+                # If an axis is sliced out, i.e. it's item is an int,
+                # set missing axis to True.
+                # numbers.Integral captures all int types, int, np.int64, etc.
+                if isinstance(it, numbers.Integral):
                     missing_axes[i] = True
     else:
         raise NotImplementedError("Slicing FITS-WCS by {} not supported.".format(type(item)))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
If an NDCube axis after the first axis was sliced with a non-native int type,
e.g. numpy.int64, the slicing would crash due to missing_axes not being
altered.  This commit adds support for numpy.int64 and numpy.int32 types.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #218 
