### PR TITLE
Raise error if user slices NDCube with Ellipsis.

### DIFF
--- a/changelog/224.bugfix.rst
+++ b/changelog/224.bugfix.rst
@@ -1,0 +1,1 @@
+Raises error if NDCube is sliced with an Ellipsis.

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -183,6 +183,10 @@ def _wcs_slicer(wcs, missing_axes, item):
         new_wcs = wcs.slice(item_checked)
     # if it a tuple like [0:2, 0:3, 2] or [0:2, 1:3]
     elif isinstance(item, tuple):
+        # Ellipsis slicing is currently not supported.
+        # Raise an error if user tries to slice by ellipsis.
+        if Ellipsis in item:
+            raise NotImplementedError("Slicing FITS-WCS by ellipsis not supported.")
         # this is used to not exceed the range of the item tuple
         # if the check of the missing_axes which is False if not dead
         # is a success than the the item of the tuple is added one by


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
ndcube 1.x does not support slicing ```NDCube```s with ```Ellipses```.  However, when a user tries this, the operation does not fail, but rather slices the data correctly, but the FITS-WCS incorrectly.  This PR causes the operation to fail with an informative error.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #216
