### PR TITLE
Remove obsolete InheritDocstrings

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -5,7 +5,6 @@ import warnings
 import numpy as np
 import astropy.nddata
 import astropy.units as u
-from astropy.utils.misc import InheritDocstrings
 
 from ndcube import utils
 from ndcube.ndcube_sequence import NDCubeSequence
@@ -17,10 +16,9 @@ from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
 __all__ = ['NDCubeABC', 'NDCubeBase', 'NDCube', 'NDCubeOrdered']
 
 
-class NDCubeMetaClass(abc.ABCMeta, InheritDocstrings):
+class NDCubeMetaClass(abc.ABCMeta):
     """
-    A metaclass that combines `abc.ABCMeta` and
-    `~astropy.utils.misc.InheritDocstrings`.
+    A metaclass that combines `abc.ABCMeta`.
     """
 
 
@@ -78,7 +76,6 @@ class NDCubeABC(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
             reverse of the wcs axis order.
         """
 
-    # InheritDocstrings doesn't work on property methods.
     @abc.abstractproperty
     def dimensions(self):
         pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ tests =
   pytest-mock
   tox
 docs =
-  sphinx
+  sphinx>=1.7
   sphinx-astropy
   sunpy-sphinx-theme
   towncrier


### PR DESCRIPTION
Astropy is raising the following warning for me:
```
WARNING: AstropyDeprecationWarning: The InheritDocstrings class is deprecated and may be removed in a future version.
        Use Sphinx>=1.7 automatically inherits docstring instead. [abc]
```
which I think is coming from ndcube. This PR should remove the warning, and would require sphinx>1.7, which was [released in Feb 2018](https://www.sphinx-doc.org/en/master/changes.html#release-1-7-0-released-feb-12-2018).