### PR TITLE
NDCollection

### DIFF
--- a/changelog/231.feature.rst
+++ b/changelog/231.feature.rst
@@ -1,0 +1,1 @@
+Add new NDCollection class for linking and manipulating partially or non-aligned NDCubes or NDCubeSequences.

--- a/ndcube/__init__.py
+++ b/ndcube/__init__.py
@@ -13,7 +13,7 @@ from distutils.version import LooseVersion
 
 __minimum_python_version__ = "3.6"
 
-__all__ = ['NDCube', 'NDCubeSequence']
+__all__ = ['NDCube', 'NDCubeSequence', "NDCollection"]
 
 
 class UnsupportedPythonError(Exception):
@@ -28,3 +28,4 @@ if not _SUNPY_SETUP_:   # noqa
     # For egg_info test builds to pass, put package imports here.
     from .ndcube import NDCube, NDCubeOrdered
     from .ndcube_sequence import NDCubeSequence
+    from .ndcollection import NDCollection

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -145,7 +145,7 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
             if item_is_strings:
                 new_data = [self[_item] for _item in item]
                 new_keys = item
-                new_aligned_axes=tuple([self.aligned_axes[_item] for _item in item])
+                new_aligned_axes = tuple([self.aligned_axes[_item] for _item in item])
 
             # Else, the item is assumed to be a typical slicing item.
             # Slice each cube in collection using information in this item.
@@ -240,7 +240,7 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
         return popped_cube
 
     def update(self, key, data, aligned_axes):
-        """Updates collection with in cube."""
+        """Updates existing cube within collection or adds new cube."""
         # Ensure new cube is of supported type.
         if not isinstance(data, SUPPORTED_COLLECTION_TYPES):
             raise TypeError("data must be an instance of {0}. Type is actually {1}".format(
@@ -249,7 +249,8 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
         if isinstance(aligned_axes, int):
             aligned_axes = (aligned_axes,)
         sanitized_axes, n_sanitized_axes = collection_utils._sanitize_aligned_axes(
-                [self[self._first_key], data], (self.aligned_axes[self._first_key], aligned_axes), 2)
+                [self[self._first_key], data],
+                (self.aligned_axes[self._first_key], aligned_axes), 2)
         # Update collection
         super().update({key: data})
         self.aligned_axes.update({key: sanitized_axes[-1]})
@@ -259,4 +260,3 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
         self.aligned_axes.__delitem__(key)
         if key == self._first_key:
             self._first_key = list(self.keys())[0]
-

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -2,12 +2,14 @@ import collections.abc
 
 import numpy as np
 
-from ndcube import NDCube
 from ndcube.utils.cube import convert_extra_coords_dict_to_input_format
+import ndcube.utils.collection as collection_utils
 
+__all__ = ["NDCollection"]
 
-class NDCollection(collections.abc.Sequence):
-    def __init__(self, data, labels, aligned_axes=None, _sanitize_aligned_axes=True):
+#class NDCollection(collections.abc.Sequence):
+class NDCollection:
+    def __init__(self, data, labels=None, aligned_axes=None, dont_sanitize_aligned_axes=False):
         """
         A class for holding and manipulating a collection of aligned NDCube or NDCubeSequences.
 
@@ -21,6 +23,7 @@ class NDCollection(collections.abc.Sequence):
         labels: sequence of `str`
             Name of each cube/sequence. Each label must be unique and
             there must be one per element in the data input.
+            Default is ("0", "1",...)
 
         aligned_axes: `tuple` of `int`, `tuple` of `tuple`s of `int`
             Axes of each cube/sequence that are aligned in numpy order.
@@ -44,7 +47,9 @@ class NDCollection(collections.abc.Sequence):
         """
         # Check inputs
         # Ensure there are no duplicate labels
-        if len(set(labels)) != len(labels):
+        if labels is None:
+            labels = np.arange(len(data)).astype("str")
+        elif len(set(labels)) != len(labels):
             raise ValueError("Duplicate labels detected.")
         if len(labels) != len(data):
             raise ValueError("Data and labels inputs of different lengths.")
@@ -58,7 +63,7 @@ class NDCollection(collections.abc.Sequence):
             # Check all cubes are of same shape
             cube0_dims = data[0].dimensions
             cubes_same_shape = all(
-                [data[i].dimensions == cube0_dims for i in range(n_cubes)])
+                [all(data[i].dimensions == cube0_dims) for i in range(n_cubes)])
             if cubes_same_shape is not True:
                 raise ValueError(
                     "All cubes in data not of same shape. Please set aligned_axes kwarg.")
@@ -66,79 +71,45 @@ class NDCollection(collections.abc.Sequence):
             self.aligned_axes = dict([(labels[i], tuple(range(len(cube0_dims))))
                                       for i in range(n_cubes)])
         else:
-            if _sanitize_aligned_axes is False:
+            if dont_sanitize_aligned_axes is True:
                 self.n_aligned_axes = len(aligned_axes[0])
                 self.aligned_axes = dict(zip(labels, aligned_axes))
             else:
-                aligned_axes, self.n_aligned_axes = _sanitize_aligned_axes(data, aligned_axes)
+                aligned_axes, self.n_aligned_axes = _sanitize_aligned_axes(data, aligned_axes, n_cubes)
                 self.aligned_axes = dict(zip(labels, aligned_axes))
 
     def __getitem__(self, item):
+        item_is_strings = False
         if isinstance(item, str):
-            item = [item]
-        if isinstance(item, collections.abc.Sequence):
-            item_strings = [isinstance(_item, str) for _item in item]
-            item_is_strings = all(item_strings)
-            # Ensure strings are not mixed with slices.
-            if (not item_is_strings) and (not all(np.invert(item_strings))):
-                raise TypeError("Cannot mix labels and non-labels when indexing instance.")
-            new_data = [self.data[_item] for _item in item]
-            new_labels = item
+            return self.data[item]
         else:
-            # Define empty lists of slice items to be applied to each cube in collection.
-            collection_items = [[slice(None)] * len(cube.dimensions) for cube in self.data]
-            # Determine whether any axes are dropped by slicing.
-            # If so, remove them from aligned_axes.
-            drop_aligned_axes_indices = []
-            # If item is an int, first aligned axis is dropped.
-            if isinstance(item, int):
-                drop_aligned_axes_indices = [0]
-                # Insert item to each cube's slice item.
-                for i, key in enumerate(self.labels):
-                    collection_items[i][self.aligned_axes[key][0]] = item
-            # If item is a slice such that only one element is in interval,
-            # first aligned axis is dropped.
-            elif isinstance(item, slice):
-                step = 1 if item.step is None else step = item.step
-                if abs((item.stop - item.start) // step) < 2:
-                    drop_aligned_axes_indices = [0]
-                # Insert item to each cube's slice item.
-                for i, key in enumerate(self.labels):
-                    collection_items[i][self.aligned_axes[key][0]] = item
-            # If item is tuple, search sub-items for ints or 1-interval slices.dd
-            elif isinstance(item, tuple):
-                # If item is tuple, search sub-items for ints or 1-interval slices.
-                if len(item) > self.n_aligned_axes:
-                    raise IndexError("Too many indices")
-                for i, axis_item in enumerate(item):
-                    if isinstance(axis_item, int):
-                        drop_aligned_axes_indices.append(i)
-                    elif isinstance(axis_item, slice):
-                        step = 1 if axis_item.step is None else step = axis_item.step
-                        if abs((axis_item.stop - axis_item.start) // step) < 2):
-                            drop_aligned_axes_indices.append(i)
-                    else:
-                        raise TypeError("Unsupported slicing type: {0}".format(axis_item))
-                    # Enter slice item into correct index for slice tuple of each cube.
-                    for j, key in enumerate(self.labels):
-                        collection_items[j][self.aligned_axes[key][i]] = axis_item
+            if isinstance(item, collections.abc.Sequence):
+                item_strings = [isinstance(_item, str) for _item in item]
+                item_is_strings = all(item_strings)
+                # Ensure strings are not mixed with slices.
+                if (not item_is_strings) and (not all(np.invert(item_strings))):
+                    raise TypeError("Cannot mix labels and non-labels when indexing instance.")
+            if item_is_strings:
+                new_data = [self.data[_item] for _item in item]
+                new_labels = item
+                new_aligned_axes=tuple([self.aligned_axes[_item] for _item in item])
             else:
-                raise TypeError("Unsupported slicing type: {0}".format(axis_item))
-            # Remove dropped axes from aligned_axes.  MUST BE A BETTER WAY TO DO THIS.
-            if len(drop_aligned_axes_index) > 0:
-                new_aligned_axes = []
-                for label in self.labels:
-                    new_aligned_axes.append(list(self.aligned_axes[label]))
-                    for drop_axis in drop_aligned_axes_indices:
-                        new_aligned_axes[-1].pop(drop_axis)
-                    new_aligned_axes[-1] = tuple(new_aligned_axes[-1])
-                new_aligned_axes = tuple(new_aligned_axes)
-            else:
-                new_aligned_axes = self.aligned_axes
-            new_labels = self.labels
-            new_data = [self.data[key][tuple(cube_item)]
-                        for key, cube_item in zip(new_labels, collection_items)]
-        return self.__class__(new_data, labels=new_labels, aligned_axes=new_aligned_axes)
+                # Define empty lists of slice items to be applied to each cube in collection.
+                collection_items = [[slice(None)] * len(self.data[key].dimensions) for key in self.labels]
+                # Determine whether any axes are dropped by slicing.
+                # If so, remove them from aligned_axes.
+                drop_aligned_axes_indices = collection_utils._generate_collection_getitems(
+                        item, collection_items, self.labels, self.aligned_axes, self.n_aligned_axes)
+                if len(drop_aligned_axes_indices) > 0:
+                    new_aligned_axes = collection_utils._update_aligned_axes(
+                            drop_aligned_axes_indices, self.labels, self.aligned_axes)
+                else:
+                    new_aligned_axes = self.aligned_axes
+                new_labels = self.labels
+                new_data = [self.data[key][tuple(cube_item)]
+                            for key, cube_item in zip(new_labels, collection_items)]
+            return self.__class__(new_data, labels=new_labels, aligned_axes=new_aligned_axes)
+            #return new_data, new_labels, new_aligned_axes
 
     def __repr__(self):
         cube_types = type(self.data[self.labels[0]])
@@ -149,10 +120,10 @@ Cube labels: {labels}
 Number of Cubes: {n_cubes}
 Cube Types: {cube_types}
 Aligned dimensions: {aligned_dims}
-Aligned world physical axis types: {align_axis_types}""".format(
+Aligned world physical axis types: {aligned_axis_types}""".format(
     labels=self.labels, n_cubes=n_cubes, cube_types=cube_types,
     aligned_dims=self.aligned_dimensions,
-    aligned_axis_types=self.aligned_world_physical_axis_types))
+    aligned_axis_types=self.aligned_world_axis_physical_types))
 
     @property
     def aligned_dimensions(self):
@@ -163,7 +134,7 @@ Aligned world physical axis types: {align_axis_types}""".format(
         return self.data[self.labels[0]].world_axis_physical_types
 
 
-def _sanitize_aligned_axes(data, aligned_axes):
+def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
     aligned_axes_error_message = "aligned_axes must contain ints or " + \
             "a tuple of ints for each element in data."
     cube0_dims = data[0].dimensions
@@ -197,7 +168,7 @@ def _sanitize_aligned_axes(data, aligned_axes):
         subtuples_are_ints = [False] * n_cubes
         aligned_axes_same_lengths = [False] * n_cubes
         subtuple_types = [False] * n_aligned_axes
-        if not all([len(axes) == self.n_aligned_axes for axes in aligned_axes]):
+        if not all([len(axes) == n_aligned_axes for axes in aligned_axes]):
             raise ValueError("Each element in aligned_axes must have same length.")
         for i in range(n_cubes):
             # Check each cube has at least as many dimensions as there are aligned axes
@@ -210,18 +181,22 @@ def _sanitize_aligned_axes(data, aligned_axes):
                     "and aligned axis numbers must be less than number of cube axes.\n" + \
                     "Cube number: {0};\n".format(i) + \
                     "Number of cube dimensions: {0};\n".format(n_cube_dims) + \
-                    "No. aligned axes: {0};\n".format(self.n_aligned_axes)  + \
+                    "No. aligned axes: {0};\n".format(n_aligned_axes)  + \
                     "Highest aligned axis: {0}".format(max_aligned_axis))
-            for axis in aligned_axis[i]:
-                subtuple_types = isinstance(axis, int)
-                cube_lengths_equal = data[i].dimensions[axis] == cube0_dims[axis]
+            subtuple_types = [False] * n_aligned_axes
+            cube_lengths_equal = [False] * n_aligned_axes
+            for j, axis in enumerate(aligned_axes[i]):
+                subtuple_types[j] = isinstance(axis, (int, np.integer))
+                cube_lengths_equal[j] = data[i].dimensions[axis] == cube0_dims[axis]
             subtuples_are_ints[i] = all(subtuple_types)
-            aligned_axes_same_length[i] = all(cube_lengths_equal)
+            aligned_axes_same_lengths[i] = all(cube_lengths_equal)
         if not all(subtuples_are_ints):
+            print([[type(axis) for axis in aligned_axis] for aligned_axis in aligned_axes], subtuple_types)
             raise ValueError(aligned_axes_error_message)
-        if not all(aligned_axes_same_length):
+        if not all(aligned_axes_same_lengths):
             raise ValueError("Aligned cube/sequence axes must be of same length.")
     else:
         raise ValueError(aligned_axes_error_message)
 
     return aligned_axes, n_aligned_axes
+

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -9,7 +9,7 @@ __all__ = ["NDCollection"]
 
 #class NDCollection(collections.abc.Sequence):
 class NDCollection:
-    def __init__(self, data, keys=None, aligned_axes=None, dont_sanitize_aligned_axes=False):
+    def __init__(self, data, keys=None, aligned_axes=None, meta=None, dont_sanitize_aligned_axes=False):
         """
         A class for holding and manipulating a collection of aligned NDCube or NDCubeSequences.
 
@@ -31,6 +31,9 @@ class NDCollection:
             If elements are tuples of ints, then must be one tuple for every cube/sequence.
             Each element of each tuple gives the axes of each cube/sequence that are aligned.
             Default is all axes are aligned.
+
+        meta: `dict` (Optional)
+            General metadata for the overall collection.
 
         Example
         -------
@@ -54,6 +57,8 @@ class NDCollection:
         if len(keys) != len(data):
             raise ValueError("Data and keys inputs of different lengths.")
 
+        self.meta = meta
+
         n_cubes = len(data)
         self.data = dict(zip(keys, data))
         self.keys = tuple(keys)
@@ -75,7 +80,8 @@ class NDCollection:
                 self.n_aligned_axes = len(aligned_axes[0])
                 self.aligned_axes = dict(zip(keys, aligned_axes))
             else:
-                aligned_axes, self.n_aligned_axes = _sanitize_aligned_axes(data, aligned_axes, n_cubes)
+                aligned_axes, self.n_aligned_axes = collection_utils._sanitize_aligned_axes(
+                        data, aligned_axes, n_cubes)
                 self.aligned_axes = dict(zip(keys, aligned_axes))
 
     def __getitem__(self, item):
@@ -118,7 +124,8 @@ class NDCollection:
                 # Therefore the collection keys remain unchanged.
                 new_keys = self.keys
 
-            return self.__class__(new_data, keys=new_keys, aligned_axes=new_aligned_axes)
+            return self.__class__(new_data, keys=new_keys, aligned_axes=new_aligned_axes,
+                                  meta=self.meta, dont_sanitize_aligned_axes=True)
 
     def _generate_collection_getitems(self, item):
         # There are 3 supported cases of the slice item: int, slice, tuple of ints and/or slices.
@@ -200,71 +207,4 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
     @property
     def aligned_world_axis_physical_types(self):
         return self.data[self.keys[0]].world_axis_physical_types
-
-
-def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
-    aligned_axes_error_message = "aligned_axes must contain ints or " + \
-            "a tuple of ints for each element in data."
-    cube0_dims = data[0].dimensions
-    # If user entered a single int, convert to length 1 tuple of int.
-    if isinstance(aligned_axes, int):
-        aligned_axes = tuple(aligned_axes)
-    if not isinstance(aligned_axes, tuple):
-        raise ValueError(aligned_axes_error_message)
-    # Check type of each element.
-    axes_all_ints = all([isinstance(axis, int) for axis in aligned_axes])
-    axes_all_tuples = all([isinstance(axis, tuple) for axis in aligned_axes])
-    # If all elements are int, duplicate tuple so there is one for each cube.
-    if axes_all_ints is True:
-
-        n_aligned_axes = len(aligned_axes)
-        aligned_axes = tuple([aligned_axes for i in range(n_cubes)])
-
-    # If all elements are tuple, ensure there is a tuple for each cube and
-    # all elements of each sub-tuple are ints.
-    elif axes_all_tuples is True:
-        if len(aligned_axes) != n_cubes:
-            raise ValueError(
-                "aligned_axes must have a tuple for each element in data.")
-
-        n_aligned_axes = len(aligned_axes[0])
-
-        # Ensure all elements of sub-tuples are ints,
-        # each tuple has the same number of aligned axes,
-        # number of aligned axes are <= number of cube dimensions,
-        # and the dimensions of the aligned axes in each cube are the same.
-        subtuples_are_ints = [False] * n_cubes
-        aligned_axes_same_lengths = [False] * n_cubes
-        subtuple_types = [False] * n_aligned_axes
-        if not all([len(axes) == n_aligned_axes for axes in aligned_axes]):
-            raise ValueError("Each element in aligned_axes must have same length.")
-        for i in range(n_cubes):
-            # Check each cube has at least as many dimensions as there are aligned axes
-            # and that all cubes have enough dimensions to accommodate aligned axes.
-            n_cube_dims = len(data[i].dimensions)
-            max_aligned_axis = max(aligned_axes[i])
-            if n_cube_dims < max([max_aligned_axis, n_aligned_axes]):
-                raise ValueError(
-                    "Each cube in data must have at least as many axes as aligned axes " + \
-                    "and aligned axis numbers must be less than number of cube axes.\n" + \
-                    "Cube number: {0};\n".format(i) + \
-                    "Number of cube dimensions: {0};\n".format(n_cube_dims) + \
-                    "No. aligned axes: {0};\n".format(n_aligned_axes)  + \
-                    "Highest aligned axis: {0}".format(max_aligned_axis))
-            subtuple_types = [False] * n_aligned_axes
-            cube_lengths_equal = [False] * n_aligned_axes
-            for j, axis in enumerate(aligned_axes[i]):
-                subtuple_types[j] = isinstance(axis, (int, np.integer))
-                cube_lengths_equal[j] = data[i].dimensions[axis] == cube0_dims[axis]
-            subtuples_are_ints[i] = all(subtuple_types)
-            aligned_axes_same_lengths[i] = all(cube_lengths_equal)
-        if not all(subtuples_are_ints):
-            print([[type(axis) for axis in aligned_axis] for aligned_axis in aligned_axes], subtuple_types)
-            raise ValueError(aligned_axes_error_message)
-        if not all(aligned_axes_same_lengths):
-            raise ValueError("Aligned cube/sequence axes must be of same length.")
-    else:
-        raise ValueError(aligned_axes_error_message)
-
-    return aligned_axes, n_aligned_axes
 

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -230,7 +230,7 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
     def pop(self, key):
         """Removes the cube corresponding to the key from the collection and returns it."""
         # Extract desired cube from collection.
-        popped_cube = self.pop(key)
+        popped_cube = super().pop(key)
         # Delete corresponding aligned axes
         popped_aligned_axes = self.aligned_axes.pop(key)
         # If first key removed, update.

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -78,14 +78,12 @@ class NDCollection(dict):
         if aligned_axes.lower() == "all":
             # Check all cubes are of same shape
             cube0_dims = data[0].dimensions
-            cubes_same_shape = all(
-                [all(data[i].dimensions == cube0_dims) for i in range(n_cubes)])
+            cubes_same_shape = all([all(d.dimensions == cube0_dims) for d in data])
             if cubes_same_shape is not True:
                 raise ValueError(
                     "All cubes in data not of same shape. Please set aligned_axes kwarg.")
             self.n_aligned_axes = len(cube0_dims)
-            self.aligned_axes = dict([(keys[i], tuple(range(len(cube0_dims))))
-                                      for i in range(n_cubes)])
+            self.aligned_axes = dict([(k, tuple(range(len(cube0_dims)))) for k in keys])
         elif aligned_axes is None:
             self.n_aligned_axes = 0
             self.aligned_axes = None
@@ -145,7 +143,7 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
             if item_is_strings:
                 new_data = [self[_item] for _item in item]
                 new_keys = item
-                new_aligned_axes = tuple([self.aligned_axes[_item] for _item in item])
+                new_aligned_axes = tuple([self.aligned_axes[item_] for item_ in item])
 
             # Else, the item is assumed to be a typical slicing item.
             # Slice each cube in collection using information in this item.
@@ -186,7 +184,6 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
                 collection_items[i][self.aligned_axes[key][0]] = item
 
         # Case 2: slice
-        # If only one element in interval of slice, first aligned axis is dropped.
         elif isinstance(item, slice):
             # Insert item to each cube's slice item.
             for i, key in enumerate(self):
@@ -200,7 +197,6 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
             # Ensure item is not longer than number of aligned axes
             if len(item) > self.n_aligned_axes:
                 raise IndexError("Too many indices")
-            # If item is tuple, search sub-items for ints or 1-interval slices.
             for i, axis_item in enumerate(item):
                 if isinstance(axis_item, int):
                     drop_aligned_axes_indices.append(i)

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -7,8 +7,6 @@ from ndcube import NDCube, NDCubeSequence
 from ndcube.utils.cube import convert_extra_coords_dict_to_input_format
 import ndcube.utils.collection as collection_utils
 
-SUPPORTED_COLLECTION_TYPES = (NDCube, NDCubeSequence)
-
 __all__ = ["NDCollection"]
 
 class NDCollection(dict):
@@ -59,12 +57,6 @@ class NDCollection(dict):
             raise ValueError("Duplicate keys detected.")
         if len(keys) != len(data):
             raise ValueError("Data and keys inputs of different lengths.")
-        data_types = [isinstance(cube, SUPPORTED_COLLECTION_TYPES) for cube in data]
-        if not all(data_types):
-            bad_data_index = np.arange(len(data))[np.invert(data_types)][0]
-            raise TypeError(
-                    "All data entries must be of types {0}.\n{1}th data entry is type {2}".format(
-                        SUPPORTED_COLLECTION_TYPES, bad_data_index, type(data[bad_data_index])))
 
         self._first_key = keys[0]
         self._cube_types = type(data[0])
@@ -237,10 +229,6 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
 
     def update(self, key, data, aligned_axes):
         """Updates existing cube within collection or adds new cube."""
-        # Ensure new cube is of supported type.
-        if not isinstance(data, SUPPORTED_COLLECTION_TYPES):
-            raise TypeError("data must be an instance of {0}. Type is actually {1}".format(
-                SUPPORTED_COLLECTION_TYPES, type(data)))
         # Sanitize aligned axes.
         if isinstance(aligned_axes, int):
             aligned_axes = (aligned_axes,)

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -1,5 +1,6 @@
 import collections.abc
 import copy
+import textwrap
 
 import numpy as np
 
@@ -10,7 +11,7 @@ import ndcube.utils.collection as collection_utils
 __all__ = ["NDCollection"]
 
 class NDCollection(dict):
-    def __init__(self, data, keys, aligned_axes="all", meta=None, dont_sanitize_aligned_axes=False):
+    def __init__(self, data, keys, aligned_axes="all", meta=None):
         """
         A class for holding and manipulating a collection of aligned NDCube or NDCubeSequences.
 
@@ -90,16 +91,17 @@ class NDCollection(dict):
                 self.aligned_axes = dict(zip(keys, aligned_axes))
 
     def __repr__(self):
-        return ("""NDCollection
-------------
-Cube keys: {keys}
-Number of Cubes: {n_cubes}
-Cube Types: {cube_types}
-Aligned dimensions: {aligned_dims}
-Aligned world physical axis types: {aligned_axis_types}""".format(
-    keys=self.keys(), n_cubes=len(self), cube_types=self._cube_types,
-    aligned_dims=self.aligned_dimensions,
-    aligned_axis_types=self.aligned_world_axis_physical_types))
+        return (textwrap.dedent("""
+            NDCollection
+            ------------
+            Cube keys: {keys}
+            Number of Cubes: {n_cubes}
+            Cube Types: {cube_types}
+            Aligned dimensions: {aligned_dims}
+            Aligned world physical axis types: {aligned_axis_types}""".format(
+                keys=self.keys(), n_cubes=len(self), cube_types=self._cube_types,
+                aligned_dims=self.aligned_dimensions,
+                aligned_axis_types=self.aligned_world_axis_physical_types)))
 
     @property
     def aligned_dimensions(self):
@@ -244,3 +246,4 @@ Aligned world physical axis types: {aligned_axis_types}""".format(
         self.aligned_axes.__delitem__(key)
         if key == self._first_key:
             self._first_key = list(self.keys())[0]
+

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -12,7 +12,7 @@ SUPPORTED_COLLECTION_TYPES = (NDCube, NDCubeSequence)
 __all__ = ["NDCollection"]
 
 class NDCollection(dict):
-    def __init__(self, data, keys, aligned_axes="All", meta=None, dont_sanitize_aligned_axes=False):
+    def __init__(self, data, keys, aligned_axes="all", meta=None, dont_sanitize_aligned_axes=False):
         """
         A class for holding and manipulating a collection of aligned NDCube or NDCubeSequences.
 
@@ -75,7 +75,7 @@ class NDCollection(dict):
 
         n_cubes = len(data)
         # If aligned_axes not set, assume all axes are aligned in order.
-        if aligned_axes == "All":
+        if aligned_axes.lower() == "all":
             # Check all cubes are of same shape
             cube0_dims = data[0].dimensions
             cubes_same_shape = all(

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -1,11 +1,12 @@
+import collections
 
 import numpy as np
 
 from ndcube import NDCube
 from ndcube.utils.cube import convert_extra_coords_dict_to_input_format
 
-class NDCollection():
-    def __init__(self, data, labels, wcs):
+class NDCollection(collections.Sequence):
+    def __init__(self, data, labels, aligned_axes=None, _sanitize_aligned_axes=True):
         """
         A class for holding and manipulating a collection of aligned NDCube or NDCubeSequences.
 
@@ -20,8 +21,24 @@ class NDCollection():
             Name of each cube/sequence. Each label must be unique and
             there must be one per element in the data input.
 
-        wcs: `~astropy.wcs.WCS`
-            Single WCS that describes all cubes/sequences.
+        aligned_axes: `tuple` of `int`, `tuple` of `tuple`s of `int`
+            Axes of each cube/sequence that are aligned in numpy order.
+            If elements are int, then the same axis numbers in all cubes/sequences are aligned.
+            If elements are tuples of ints, then must be one tuple for every cube/sequence.
+            Each element of each tuple gives the axes of each cube/sequence that are aligned.
+            Default is all axes are aligned.
+
+        Example
+        -------
+        Say the collection holds two NDCubes, each of 3 dimensions.
+        aligned_axes = (1, 2)
+        means that axis 1 (0-based counting) of cube0 is aligned with axis 1 of cube1,
+        and axis 2 of cube0 is aligned with axis 2 of cube1.
+        However, if
+        aligned_axes = ((0, 1), (2, 1))
+        then the first tuple corresponds to cube0 and the second with cube1.
+        This is interpretted as axis 0 of cube0 is aligned with axis 2 of cube1 while
+        axis 1 of cube0 is aligned with axis 1 of cube1.
 
         """
         # Check inputs
@@ -31,18 +48,27 @@ class NDCollection():
         if len(labels) != len(data):
             raise ValueError("Data and labels inputs of different lengths.")
 
-        # Overwrite cubes' wcs with one supplied by user
-        # to ensure all cubes have same WCS.
-        # This should be relaxed in future versions.
-        new_data = [NDCube(cube.data, wcs, uncertainty=cube.uncertainty, mask=cube.mask,
-                           unit=cube.unit, meta=cube.meta,
-                           extra_coords=convert_extra_coords_dict_to_input_format(
-                               cube.extra_coords, cube.missing_axes))
-                    for cube in data]
-        data = new_data
-
-        self.data = dict([(labels[i], data[i]) for i in range(len(data))])
+        n_cubes = len(data)
+        self.data = dict(zip(labels, data))
         self.labels = labels
+        self.wcs = self.data[self.labels[0]].wcs
+
+        # If aligned_axes not set, assume all axes are aligned in order.
+        if aligned_axes is None:
+            # Check all cubes are of same shape
+            cubes_same_shape = all(
+                [data[i].dimensions == cube0_dims for i in range(n_cubes)])
+            if cubes_same_shape is not True:
+                raise ValueError(
+                    "All cubes in data not of same shape. Please set aligned_axes kwarg.")
+            self.n_aligned_axes = len(cube0_dims)
+            self.aligned_axes = tuple([tuple(range(len(cube0_shape))) for i in range(n_cubes)])
+        else:
+            if _sanitize_aligned_axes is False:
+                self.n_aligned_axes = len(aligned_axes[0])
+                self.aligned_axes = aligned_axes
+            else:
+                self.aligned_axes, self.n_aligned_axes = _sanitize_aligned_axes(data, aligned_axes)
 
     def __getitem__(self, item):
         try:
@@ -84,3 +110,65 @@ Aligned dimensions: {aligned_dims}""".format(labels=self.labels, n_cubes=n_cubes
         return self.data[self.labels[0]].world_axis_physical_types
 
 
+def _sanitize_aligned_axes(data, aligned_axes):
+    aligned_axes_error_message = "aligned_axes must contain ints or " + \
+            "a tuple of ints for each element in data."
+    cube0_dims = data[0].dimensions
+    # If user entered a single int, convert to length 1 tuple of int.
+    if isinstance(aligned_axes, int):
+        aligned_axes = tuple(aligned_axes)
+    if not isinstance(aligned_axes, tuple):
+        raise ValueError(aligned_axes_error_message)
+    # Check type of each element.
+    axes_all_ints = all([isinstance(axis, int) for axis in aligned_axes])
+    axes_all_tuples = all([isinstance(axis, tuple) for axis in aligned_axes])
+    # If all elements are int, duplicate tuple so there is one for each cube.
+    if axes_all_ints is True:
+
+        n_aligned_axes = len(aligned_axes)
+        aligned_axes = tuple([aligned_axes for i in range(n_cubes)])
+
+    # If all elements are tuple, ensure there is a tuple for each cube and
+    # all elements of each sub-tuple are ints.
+    elif axes_all_tuples is True:
+        if len(aligned_axes) != n_cubes:
+            raise ValueError(
+                "aligned_axes must have a tuple for each element in data.")
+
+        n_aligned_axes = len(aligned_axes[0])
+
+        # Ensure all elements of sub-tuples are ints,
+        # each tuple has the same number of aligned axes,
+        # number of aligned axes are <= number of cube dimensions,
+        # and the dimensions of the aligned axes in each cube are the same.
+        subtuples_are_ints = [False] * n_cubes
+        aligned_axes_same_lengths = [False] * n_cubes
+        subtuple_types = [False] * n_aligned_axes
+        if not all([len(axes) == self.n_aligned_axes for axes in aligned_axes]):
+            raise ValueError("Each element in aligned_axes must have same length.")
+        for i in range(n_cubes):
+            # Check each cube has at least as many dimensions as there are aligned axes
+            # and that all cubes have enough dimensions to accommodate aligned axes.
+            n_cube_dims = len(data[i].dimensions)
+            max_aligned_axis = max(aligned_axes[i])
+            if n_cube_dims < max([max_aligned_axis, n_aligned_axes]):
+                raise ValueError(
+                    "Each cube in data must have at least as many axes as aligned axes " + \
+                    "and aligned axis numbers must be less than number of cube axes.\n" + \
+                    "Cube number: {0};\n".format(i) + \
+                    "Number of cube dimensions: {0};\n".format(n_cube_dims) + \
+                    "No. aligned axes: {0};\n".format(self.n_aligned_axes)  + \
+                    "Highest aligned axis: {0}".format(max_aligned_axis))
+            for axis in aligned_axis[i]:
+                subtuple_types = isinstance(axis, int)
+                cube_lengths_equal = data[i].dimensions[axis] == cube0_dims[axis]
+            subtuples_are_ints[i] = all(subtuple_types)
+            aligned_axes_same_length[i] = all(cube_lengths_equal)
+        if not all(subtuples_are_ints):
+            raise ValueError(aligned_axes_error_message)
+        if not all(aligned_axes_same_length):
+            raise ValueError("Aligned cube/sequence axes must be of same length.")
+    else:
+        raise ValueError(aligned_axes_error_message)
+
+    return aligned_axes, n_aligned_axes

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -1,0 +1,86 @@
+
+import numpy as np
+
+from ndcube import NDCube
+from ndcube.utils.cube import convert_extra_coords_dict_to_input_format
+
+class NDCollection():
+    def __init__(self, data, labels, wcs):
+        """
+        A class for holding and manipulating a collection of aligned NDCube or NDCubeSequences.
+
+        Data cubes/sequences must be aligned, i.e. have the same WCS and be the same shape.
+
+        Parameters
+        ----------
+        data: sequence of `~ndcube.NDCube` or `~ndcube.NDCubeSequence`
+            The data cubes/sequences to held in the collection.
+
+        labels: sequence of `str`
+            Name of each cube/sequence. Each label must be unique and
+            there must be one per element in the data input.
+
+        wcs: `~astropy.wcs.WCS`
+            Single WCS that describes all cubes/sequences.
+
+        """
+        # Check inputs
+        # Ensure there are no duplicate labels
+        if len(set(labels)) != len(labels):
+            raise ValueError("Duplicate labels detected.")
+        if len(labels) != len(data):
+            raise ValueError("Data and labels inputs of different lengths.")
+
+        # Overwrite cubes' wcs with one supplied by user
+        # to ensure all cubes have same WCS.
+        # This should be relaxed in future versions.
+        new_data = [NDCube(cube.data, wcs, uncertainty=cube.uncertainty, mask=cube.mask,
+                           unit=cube.unit, meta=cube.meta,
+                           extra_coords=convert_extra_coords_dict_to_input_format(
+                               cube.extra_coords, cube.missing_axes))
+                    for cube in data]
+        data = new_data
+
+        self.data = dict([(labels[i], data[i]) for i in range(len(data))])
+        self.labels = labels
+
+    def __getitem__(self, item):
+        try:
+            item_strings = [isinstance(_item, str) for _item in item]
+            item_is_strings = all(item_strings)
+            # Ensure strings are not mixed with slices.
+            if (not item_is_strings) and (not all(np.invert(item_strings))):
+                raise TypeError("Cannot mix labels and non-labels when indexing instance.")
+        except:
+            item_is_strings = False
+        if isinstance(item, str) or item_is_strings:
+            if isinstance(item, str):
+                item = [item]
+            new_data = [self.data[_item] for _item in item]
+            new_labels = item
+        else:
+            new_labels = self.labels
+            new_data = [self.data[key][item] for key in new_labels]
+        return self.__class__(new_data, labels=new_labels, wcs=self.data[new_labels[0]].wcs)
+
+    def __repr__(self):
+        cube_types = type(self.data[self.labels[0]])
+        n_cubes = len(self.labels)
+        return ("""NDCollection
+----------
+Cube labels: {labels}
+Number of Cubes: {n_cubes}
+Cube Types: {cube_types}
+Aligned dimensions: {aligned_dims}""".format(labels=self.labels, n_cubes=n_cubes,
+                                             cube_types=cube_types,
+                                             aligned_dims=self.dimensions))
+
+    @property
+    def dimensions(self):
+        return self.data[self.labels[0]].dimensions
+
+    @property
+    def world_axis_physical_types(self):
+        return self.data[self.labels[0]].world_axis_physical_types
+
+

--- a/ndcube/tests/helpers.py
+++ b/ndcube/tests/helpers.py
@@ -6,7 +6,7 @@ import unittest
 
 import numpy as np
 
-from ndcube import utils
+from ndcube import NDCube, NDCubeSequence, utils
 
 __all__ = ['assert_extra_coords_equal',
            'assert_metas_equal',
@@ -34,11 +34,19 @@ def assert_cubes_equal(test_input, expected_cube):
     assert np.all(test_input.mask == expected_cube.mask)
     assert_wcs_are_equal(test_input.wcs, expected_cube.wcs)
     assert test_input.missing_axes == expected_cube.missing_axes
-    assert test_input.uncertainty.array.shape == expected_cube.uncertainty.array.shape
+    if type(test_input.uncertainty) is not type(expected_cube.uncertainty):
+        raise AssertionError("NDCube uncertainties not of same type: {0} != {1}".format(
+            type(test_input.uncertainty), type(expected_cube.uncertainty)))
+    if test_input.uncertainty is not None:
+        assert test_input.uncertainty.array.shape == expected_cube.uncertainty.array.shape
     assert test_input.world_axis_physical_types == expected_cube.world_axis_physical_types
     assert all(test_input.dimensions.value == expected_cube.dimensions.value)
     assert test_input.dimensions.unit == expected_cube.dimensions.unit
-    assert_extra_coords_equal(test_input.extra_coords, expected_cube.extra_coords)
+    if type(test_input.extra_coords) is not type(expected_cube.extra_coords):
+        raise AssertionError("NDCube extra_coords not of same type: {0} != {1}".format(
+            type(test_input.extra_coords), type(expected_cube.extra_coords)))
+    if test_input.extra_coords is not None:
+        assert_extra_coords_equal(test_input.extra_coords, expected_cube.extra_coords)
 
 
 def assert_cubesequences_equal(test_input, expected_sequence):
@@ -61,3 +69,17 @@ def assert_wcs_are_equal(wcs1, wcs2):
     assert list(wcs1.wcs.cdelt) == list(wcs2.wcs.cdelt)
     assert list(wcs1.wcs.cunit) == list(wcs2.wcs.cunit)
     assert wcs1.wcs.naxis == wcs2.wcs.naxis
+
+
+def assert_collections_equal(collection1, collection2):
+    assert collection1.keys() == collection2.keys()
+    assert collection1.aligned_axes == collection2.aligned_axes
+    for cube1, cube2 in zip(collection1.values(), collection2.values()):
+        # Check cubes are same type.
+        assert type(cube1) is type(cube2)
+        if isinstance(cube1, NDCube):
+            assert_cubes_equal(cube1, cube2)
+        elif isinstance(cube1, NDCubeSequence):
+            assert_cubesequences_equal(cube1, cube2)
+        else:
+            raise TypeError("Unsupported Type in NDCollection: {0}".format(type(cube1)))

--- a/ndcube/tests/test_ndcollection.py
+++ b/ndcube/tests/test_ndcollection.py
@@ -1,0 +1,117 @@
+import copy
+
+import pytest
+import numpy as np
+import astropy.wcs
+
+from ndcube import NDCube, NDCubeSequence, NDCollection
+from ndcube.tests import helpers
+
+# Define some mock data
+data0 = np.ones((3, 4, 5))
+data1 = np.zeros((5, 3, 4))
+data2 = data0 * 2
+
+# Define WCS object for all cubes. 
+wcs_input_dict = { 
+'CTYPE1': 'WAVE    ', 'CUNIT1': 'Angstrom', 'CDELT1': 0.2, 'CRPIX1': 0, 'CRVAL1': 10, 'NAXIS1': 5, 
+'CTYPE2': 'HPLT-TAN', 'CUNIT2': 'deg', 'CDELT2': 0.5, 'CRPIX2': 2, 'CRVAL2': 0.5, 'NAXIS2': 4, 
+'CTYPE3': 'HPLN-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.4, 'CRPIX3': 2, 'CRVAL3': 1, 'NAXIS3': 3} 
+input_wcs = astropy.wcs.WCS(wcs_input_dict)
+
+wcs_input_dict1 = {
+'CTYPE3': 'WAVE    ', 'CUNIT3': 'Angstrom', 'CDELT3': 0.2, 'CRPIX3': 0, 'CRVAL3': 10, 'NAXIS3': 5,
+'CTYPE1': 'HPLT-TAN', 'CUNIT1': 'deg', 'CDELT1': 0.5, 'CRPIX1': 2, 'CRVAL1': 0.5, 'NAXIS1': 4,
+'CTYPE2': 'HPLN-TAN', 'CUNIT2': 'deg', 'CDELT2': 0.4, 'CRPIX2': 2, 'CRVAL2': 1, 'NAXIS2': 3}
+input_wcs1 = astropy.wcs.WCS(wcs_input_dict1)
+
+# Define cubes.
+cube0 = NDCube(data0, input_wcs)
+cube1 = NDCube(data1, input_wcs1)
+cube2 = NDCube(data2, input_wcs)
+
+# Define sequences.
+sequence02 = NDCubeSequence([cube0, cube2])
+sequence20 = NDCubeSequence([cube2, cube0])
+
+# Define collections
+aligned_axes = ((1, 2), (2, 0), (1, 2))
+keys = ("cube0", "cube1", "cube2")
+cube_collection = NDCollection([cube0, cube1, cube2], keys, aligned_axes)
+#seq_collection = NDCollection([sequence01, sequence12], ("seq0", "seq1"))
+
+
+@pytest.mark.parametrize("item,collection,expected", [
+    (0, cube_collection,
+        NDCollection(data=[cube0[:, 0], cube1[:, :, 0], cube2[:, 0]],
+                     keys=keys, aligned_axes=((1,), (0,), (1,)))),
+
+    (slice(1, 3), cube_collection,
+        NDCollection(data=[cube0[:, 1:3], cube1[:, :, 1:3], cube2[:, 1:3]],
+                     keys=keys, aligned_axes=aligned_axes)),
+
+    (slice(-3, -1), cube_collection,
+        NDCollection(data=[cube0[:, -3:-1], cube1[:, :, -3:-1], cube2[:, -3:-1]],
+                     keys=keys, aligned_axes=aligned_axes)),
+
+    ((slice(None), slice(1, 2)), cube_collection,
+        NDCollection(data=[cube0[:, :, 1:2], cube1[1:2], cube2[:, :, 1:2]],
+                     keys=keys, aligned_axes=aligned_axes)),
+
+    ((slice(2, 4), slice(-3, -1)), cube_collection,
+        NDCollection(data=[cube0[:, 2:4, -3:-1], cube1[-3:-1, :, 2:4], cube2[:, 2:4, -3:-1]],
+                     keys=keys, aligned_axes=aligned_axes)),
+
+    ((0, 0), cube_collection, NDCollection(data=[cube0[:, 0, 0], cube1[0, :, 0], cube2[:, 0, 0]],
+                                           keys=keys, aligned_axes=None)),
+    
+    (("cube0", "cube2"), cube_collection, 
+        NDCollection(data=[cube0, cube2],
+                     keys=("cube0", "cube2"), aligned_axes=(aligned_axes[0], aligned_axes[2])))]) 
+def test_collection_slicing(item, collection, expected):
+    helpers.assert_collections_equal(collection[item], expected)
+
+
+@pytest.mark.parametrize("item,collection,expected", [("cube1", cube_collection, cube1)])
+def test_slice_cube_from_collection(item, collection, expected):
+    helpers.assert_cubes_equal(collection[item], expected)
+
+
+@pytest.mark.parametrize("collection", [(cube_collection)])
+def test_collection_copy(collection):
+    expected = copy.deepcopy(collection)
+    output = collection.copy()
+    helpers.assert_collections_equal(output, expected)
+
+
+@pytest.mark.parametrize("collection,popped_key,expected_popped,expected_collection", [
+    (cube_collection, "cube0", cube0, NDCollection(data=[cube1, cube2], keys=("cube1", "cube2"),
+                                                   aligned_axes=aligned_axes[1:]))])
+def test_collection_pop(collection, popped_key, expected_popped, expected_collection):
+    popped_collection = collection.copy()
+    output = popped_collection.pop(popped_key)
+    helpers.assert_cubes_equal(output, expected_popped)
+    helpers.assert_collections_equal(popped_collection, expected_collection)
+
+
+@pytest.mark.parametrize("collection,key,data,aligned_axes,expected", [
+    (cube_collection, "cube1", cube2, aligned_axes[2], 
+        NDCollection(data=[cube0, cube2, cube2], keys=keys, aligned_axes=((1, 2), (1, 2), (1, 2)))),
+
+    (cube_collection, "cube3", cube2, aligned_axes[2],
+        NDCollection(data=[cube0, cube1, cube2, cube2], keys=("cube0", "cube1", "cube2", "cube3"),
+                     aligned_axes=((1, 2), (2, 0), (1, 2), (1, 2))))])
+def test_collection_update(collection, key, data, aligned_axes, expected):
+    updated_collection = collection.copy()
+    updated_collection.update(key, data, aligned_axes)
+    helpers.assert_collections_equal(updated_collection, expected)
+
+
+@pytest.mark.parametrize("collection,key,expected", [
+    (cube_collection, "cube0", NDCollection(data=[cube1, cube2], keys=("cube1", "cube2"),
+                                            aligned_axes=aligned_axes[1:]))])
+def test_del_collection(collection, key, expected):
+    del_collection = collection.copy()
+    del del_collection[key]
+    helpers.assert_collections_equal(del_collection, expected)
+    pass

--- a/ndcube/tests/test_ndcollection.py
+++ b/ndcube/tests/test_ndcollection.py
@@ -12,11 +12,11 @@ data0 = np.ones((3, 4, 5))
 data1 = np.zeros((5, 3, 4))
 data2 = data0 * 2
 
-# Define WCS object for all cubes. 
-wcs_input_dict = { 
-'CTYPE1': 'WAVE    ', 'CUNIT1': 'Angstrom', 'CDELT1': 0.2, 'CRPIX1': 0, 'CRVAL1': 10, 'NAXIS1': 5, 
-'CTYPE2': 'HPLT-TAN', 'CUNIT2': 'deg', 'CDELT2': 0.5, 'CRPIX2': 2, 'CRVAL2': 0.5, 'NAXIS2': 4, 
-'CTYPE3': 'HPLN-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.4, 'CRPIX3': 2, 'CRVAL3': 1, 'NAXIS3': 3} 
+# Define WCS object for all cubes.
+wcs_input_dict = {
+'CTYPE1': 'WAVE    ', 'CUNIT1': 'Angstrom', 'CDELT1': 0.2, 'CRPIX1': 0, 'CRVAL1': 10, 'NAXIS1': 5,
+'CTYPE2': 'HPLT-TAN', 'CUNIT2': 'deg', 'CDELT2': 0.5, 'CRPIX2': 2, 'CRVAL2': 0.5, 'NAXIS2': 4,
+'CTYPE3': 'HPLN-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.4, 'CRPIX3': 2, 'CRVAL3': 1, 'NAXIS3': 3}
 input_wcs = astropy.wcs.WCS(wcs_input_dict)
 
 wcs_input_dict1 = {
@@ -64,10 +64,10 @@ cube_collection = NDCollection([cube0, cube1, cube2], keys, aligned_axes)
 
     ((0, 0), cube_collection, NDCollection(data=[cube0[:, 0, 0], cube1[0, :, 0], cube2[:, 0, 0]],
                                            keys=keys, aligned_axes=None)),
-    
-    (("cube0", "cube2"), cube_collection, 
+
+    (("cube0", "cube2"), cube_collection,
         NDCollection(data=[cube0, cube2],
-                     keys=("cube0", "cube2"), aligned_axes=(aligned_axes[0], aligned_axes[2])))]) 
+                     keys=("cube0", "cube2"), aligned_axes=(aligned_axes[0], aligned_axes[2])))])
 def test_collection_slicing(item, collection, expected):
     helpers.assert_collections_equal(collection[item], expected)
 
@@ -95,7 +95,7 @@ def test_collection_pop(collection, popped_key, expected_popped, expected_collec
 
 
 @pytest.mark.parametrize("collection,key,data,aligned_axes,expected", [
-    (cube_collection, "cube1", cube2, aligned_axes[2], 
+    (cube_collection, "cube1", cube2, aligned_axes[2],
         NDCollection(data=[cube0, cube2, cube2], keys=keys, aligned_axes=((1, 2), (1, 2), (1, 2)))),
 
     (cube_collection, "cube3", cube2, aligned_axes[2],

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -1,59 +1,12 @@
 import numpy as np
 
 
-def _generate_collection_getitems(item, collection_items, keys, aligned_axes, n_aligned_axes):
-    # Determine whether any axes are dropped by slicing.
-    # If so, remove them from aligned_axes.
-    drop_aligned_axes_indices = []
-    # If item is an int, first aligned axis is dropped.
-    if isinstance(item, int):
-        drop_aligned_axes_indices = [0]
-        # Insert item to each cube's slice item.
-        for i, key in enumerate(keys):
-            collection_items[i][aligned_axes[key][0]] = item
-    # If item is a slice such that only one element is in interval,
-    # first aligned axis is dropped.
-    elif isinstance(item, slice):
-        if item.step is None:
-            step = 1
-        else:
-            step = item.step
-        if abs((item.stop - item.start) // step) < 2:
-            drop_aligned_axes_indices = [0]
-        # Insert item to each cube's slice item.
-        for i, key in enumerate(keys):
-            collection_items[i][aligned_axes[key][0]] = item
-    # If item is tuple, search sub-items for ints or 1-interval slices.dd
-    elif isinstance(item, tuple):
-        # If item is tuple, search sub-items for ints or 1-interval slices.
-        if len(item) > n_aligned_axes:
-            raise IndexError("Too many indices")
-        for i, axis_item in enumerate(item):
-            if isinstance(axis_item, int):
-                drop_aligned_axes_indices.append(i)
-            elif isinstance(axis_item, slice):
-                if axis_item.step is None:
-                    step = 1
-                else:
-                    step = axis_item.step
-                if abs((axis_item.stop - axis_item.start) // step) < 2:
-                    drop_aligned_axes_indices.append(i)
-            else:
-                raise TypeError("Unsupported slicing type: {0}".format(axis_item))
-            # Enter slice item into correct index for slice tuple of each cube.
-            for j, key in enumerate(keys):
-                collection_items[j][aligned_axes[key][i]] = axis_item
-    else:
-        raise TypeError("Unsupported slicing type: {0}".format(axis_item))
-
-    return np.array(drop_aligned_axes_indices)
-
-def _update_aligned_axes(drop_aligned_axes_indices, keys, aligned_axes):
+def _update_aligned_axes(drop_aligned_axes_indices, aligned_axes):
     # Remove dropped axes from aligned_axes.  MUST BE A BETTER WAY TO DO THIS.
     if len(drop_aligned_axes_indices) > 0:
         new_aligned_axes = []
-        for label in keys:
-            cube_aligned_axes = np.array(aligned_axes[label])
+        for key in aligned_axes.keys():
+            cube_aligned_axes = np.array(aligned_axes[key])
             for drop_axis_index in drop_aligned_axes_indices:
                 drop_axis = cube_aligned_axes[drop_axis_index]
                 cube_aligned_axes = np.delete(cube_aligned_axes, drop_axis_index)
@@ -67,3 +20,39 @@ def _update_aligned_axes(drop_aligned_axes_indices, keys, aligned_axes):
         new_aligned_axes = aligned_axes
 
     return new_aligned_axes
+
+def slice_interval_is_1(item, axis_length):
+    # Make start index numeric and positive.
+    if item.start is None:
+        start = 0
+    else:
+        start = item.start
+    start = make_index_positive(start, axis_length)
+
+    # Make stop index numeric and positive.
+    if item.stop is None:
+        stop = axis_length
+    else:
+        stop = item.stop
+    stop = make_index_positive(stop, axis_length)
+
+    # Make step numeric.
+    if item.step is None:
+        step = 1
+    else:
+        step = item.step
+
+    # Check if slice interval is 1.
+    if abs((stop - start) // step) == 1:
+        result = True
+    else:
+        result = False
+
+    return result
+
+def make_index_positive(index, axis_length):
+    if index < 0:
+        pos_index = axis_length + index
+    else:
+        pos_index = index
+    return pos_index

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -1,5 +1,84 @@
 import numpy as np
 
+def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
+    """
+    Converts input aligned_axes to standard format.
+
+    aligned_axes can be supplied by the user in a few ways:
+    *. A tuple of tuples of ints, where each tuple corresponds to a cube
+    in the collection, and each int designates the an aligned axis in numpy order.
+    In this case, the axis represented by the 0th int in the 0th tuple is aligned
+    with the 0th int in the 1st tuple and so on.
+    *. A single tuple of ints if all aligned axes are in the same order.
+    *. A single int if only one axis is aligned and if the aligned axis in each cube
+    is in the same order.
+
+    """
+    aligned_axes_error_message = "aligned_axes must contain ints or " + \
+            "a tuple of ints for each element in data."
+    cube0_dims = data[0].dimensions
+    # If user entered a single int or string, convert to length 1 tuple of int.
+    if isinstance(aligned_axes, int):
+        aligned_axes = tuple(aligned_axes)
+    if not isinstance(aligned_axes, tuple):
+        raise ValueError(aligned_axes_error_message)
+    # Check type of each element.
+    axes_all_ints = all([isinstance(axis, int) for axis in aligned_axes])
+    axes_all_tuples = all([isinstance(axis, tuple) for axis in aligned_axes])
+    # If all elements are int, duplicate tuple so there is one for each cube.
+    if axes_all_ints is True:
+
+        n_aligned_axes = len(aligned_axes)
+        aligned_axes = tuple([aligned_axes for i in range(n_cubes)])
+
+    # If all elements are tuple, ensure there is a tuple for each cube and
+    # all elements of each sub-tuple are ints.
+    elif axes_all_tuples is True:
+        if len(aligned_axes) != n_cubes:
+            raise ValueError(
+                "aligned_axes must have a tuple for each element in data.")
+
+        n_aligned_axes = len(aligned_axes[0])
+
+        # Ensure all elements of sub-tuples are ints,
+        # each tuple has the same number of aligned axes,
+        # number of aligned axes are <= number of cube dimensions,
+        # and the dimensions of the aligned axes in each cube are the same.
+        subtuples_are_ints = [False] * n_cubes
+        aligned_axes_same_lengths = [False] * n_cubes
+        subtuple_types = [False] * n_aligned_axes
+        if not all([len(axes) == n_aligned_axes for axes in aligned_axes]):
+            raise ValueError("Each element in aligned_axes must have same length.")
+        for i in range(n_cubes):
+            # Check each cube has at least as many dimensions as there are aligned axes
+            # and that all cubes have enough dimensions to accommodate aligned axes.
+            n_cube_dims = len(data[i].dimensions)
+            max_aligned_axis = max(aligned_axes[i])
+            if n_cube_dims < max([max_aligned_axis, n_aligned_axes]):
+                raise ValueError(
+                    "Each cube in data must have at least as many axes as aligned axes " + \
+                    "and aligned axis numbers must be less than number of cube axes.\n" + \
+                    "Cube number: {0};\n".format(i) + \
+                    "Number of cube dimensions: {0};\n".format(n_cube_dims) + \
+                    "No. aligned axes: {0};\n".format(n_aligned_axes)  + \
+                    "Highest aligned axis: {0}".format(max_aligned_axis))
+            subtuple_types = [False] * n_aligned_axes
+            cube_lengths_equal = [False] * n_aligned_axes
+            for j, axis in enumerate(aligned_axes[i]):
+                subtuple_types[j] = isinstance(axis, (int, np.integer))
+                cube_lengths_equal[j] = data[i].dimensions[axis] == cube0_dims[axis]
+            subtuples_are_ints[i] = all(subtuple_types)
+            aligned_axes_same_lengths[i] = all(cube_lengths_equal)
+        if not all(subtuples_are_ints):
+            print([[type(axis) for axis in aligned_axis] for aligned_axis in aligned_axes], subtuple_types)
+            raise ValueError(aligned_axes_error_message)
+        if not all(aligned_axes_same_lengths):
+            raise ValueError("Aligned cube/sequence axes must be of same length.")
+    else:
+        raise ValueError(aligned_axes_error_message)
+
+    return aligned_axes, n_aligned_axes
+
 
 def _update_aligned_axes(drop_aligned_axes_indices, aligned_axes):
     # Remove dropped axes from aligned_axes.  MUST BE A BETTER WAY TO DO THIS.
@@ -20,6 +99,7 @@ def _update_aligned_axes(drop_aligned_axes_indices, aligned_axes):
         new_aligned_axes = aligned_axes
 
     return new_aligned_axes
+
 
 def slice_interval_is_1(item, axis_length):
     # Make start index numeric and positive.
@@ -56,3 +136,4 @@ def make_index_positive(index, axis_length):
     else:
         pos_index = index
     return pos_index
+

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -93,9 +93,13 @@ def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
     return aligned_axes, n_aligned_axes
 
 
-def _update_aligned_axes(drop_aligned_axes_indices, aligned_axes):
+def _update_aligned_axes(drop_aligned_axes_indices, aligned_axes, first_key):
     # Remove dropped axes from aligned_axes.  MUST BE A BETTER WAY TO DO THIS.
-    if len(drop_aligned_axes_indices) > 0:
+    if len(drop_aligned_axes_indices) <= 0:
+        new_aligned_axes = tuple(aligned_axes.values())
+    elif len(drop_aligned_axes_indices) == len(aligned_axes[first_key]):
+        new_aligned_axes = None
+    else:
         new_aligned_axes = []
         for key in aligned_axes.keys():
             cube_aligned_axes = np.array(aligned_axes[key])
@@ -108,8 +112,6 @@ def _update_aligned_axes(drop_aligned_axes_indices, aligned_axes):
                 drop_aligned_axes_indices[w] -= 1
             new_aligned_axes.append(tuple(cube_aligned_axes))
         new_aligned_axes = tuple(new_aligned_axes)
-    else:
-        new_aligned_axes = tuple(aligned_axes.values())
 
     return new_aligned_axes
 

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -65,10 +65,8 @@ def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
                 raise ValueError(
                     "Each cube in data must have at least as many axes as aligned axes "
                     "and aligned axis numbers must be less than number of cube axes.\n"
-                    "Cube number: {0};\n".format(i)
-                    "Number of cube dimensions: {0};\n".format(n_cube_dims)
-                    "No. aligned axes: {0};\n".format(n_aligned_axes)
-                    "Highest aligned axis: {0}".format(max_aligned_axis))
+                    "Cube number: {0};\nNumber of cube dimensions: {0};\nNo. aligned axes: {0};\nHighest aligned axis: {0}".format(
+                        i, n_cube_dims, n_aligned_axes, max_aligned_axis))
             subtuple_types = [False] * n_aligned_axes
             cube_lengths_equal = [False] * n_aligned_axes
             for j, axis in enumerate(aligned_axes[i]):

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -2,7 +2,7 @@ import numpy as np
 import astropy.units as u
 
 
-def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
+def _sanitize_aligned_axes(data, aligned_axes):
     """
     Converts input aligned_axes to standard format.
 
@@ -33,6 +33,7 @@ def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
     axes_all_ints = all([isinstance(axis, int) for axis in aligned_axes])
     axes_all_tuples = all([isinstance(axis, tuple) for axis in aligned_axes])
     # If all elements are int, duplicate tuple so there is one for each cube.
+    n_cubes = len(data)
     if axes_all_ints is True:
 
         n_aligned_axes = len(aligned_axes)
@@ -42,8 +43,7 @@ def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
     # all elements of each sub-tuple are ints.
     elif axes_all_tuples is True:
         if len(aligned_axes) != n_cubes:
-            raise ValueError(
-                "aligned_axes must have a tuple for each element in data.")
+            raise ValueError("aligned_axes must have a tuple for each element in data.")
 
         n_aligned_axes = len(aligned_axes[0])
 

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -113,11 +113,3 @@ def _update_aligned_axes(drop_aligned_axes_indices, aligned_axes, first_key):
         new_aligned_axes = tuple(new_aligned_axes)
 
     return new_aligned_axes
-
-
-def make_index_positive(index, axis_length):
-    if index < 0:
-        pos_index = axis_length + index
-    else:
-        pos_index = index
-    return pos_index

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -19,7 +19,7 @@ def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
     cube0_dims = data[0].dimensions
     # If user entered a single int or string, convert to length 1 tuple of int.
     if isinstance(aligned_axes, int):
-        aligned_axes = tuple(aligned_axes)
+        aligned_axes = (aligned_axes,)
     if not isinstance(aligned_axes, tuple):
         raise ValueError(aligned_axes_error_message)
     # Check type of each element.
@@ -76,6 +76,13 @@ def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
             raise ValueError("Aligned cube/sequence axes must be of same length.")
     else:
         raise ValueError(aligned_axes_error_message)
+
+    # Ensure all aligned axes are of same length.
+    check_dimensions = set([len(set(
+        [cube.dimensions[cube_aligned_axes[j]] for cube, cube_aligned_axes in zip(data, aligned_axes)]))
+        for j in range(n_aligned_axes)])
+    if check_dimensions != {1}:
+        raise ValueError("Aligned axes are not all of same length.")
 
     return aligned_axes, n_aligned_axes
 

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def _generate_collection_getitems(item, collection_items, labels, aligned_axes, n_aligned_axes):
+def _generate_collection_getitems(item, collection_items, keys, aligned_axes, n_aligned_axes):
     # Determine whether any axes are dropped by slicing.
     # If so, remove them from aligned_axes.
     drop_aligned_axes_indices = []
@@ -9,7 +9,7 @@ def _generate_collection_getitems(item, collection_items, labels, aligned_axes, 
     if isinstance(item, int):
         drop_aligned_axes_indices = [0]
         # Insert item to each cube's slice item.
-        for i, key in enumerate(labels):
+        for i, key in enumerate(keys):
             collection_items[i][aligned_axes[key][0]] = item
     # If item is a slice such that only one element is in interval,
     # first aligned axis is dropped.
@@ -21,7 +21,7 @@ def _generate_collection_getitems(item, collection_items, labels, aligned_axes, 
         if abs((item.stop - item.start) // step) < 2:
             drop_aligned_axes_indices = [0]
         # Insert item to each cube's slice item.
-        for i, key in enumerate(labels):
+        for i, key in enumerate(keys):
             collection_items[i][aligned_axes[key][0]] = item
     # If item is tuple, search sub-items for ints or 1-interval slices.dd
     elif isinstance(item, tuple):
@@ -41,18 +41,18 @@ def _generate_collection_getitems(item, collection_items, labels, aligned_axes, 
             else:
                 raise TypeError("Unsupported slicing type: {0}".format(axis_item))
             # Enter slice item into correct index for slice tuple of each cube.
-            for j, key in enumerate(labels):
+            for j, key in enumerate(keys):
                 collection_items[j][aligned_axes[key][i]] = axis_item
     else:
         raise TypeError("Unsupported slicing type: {0}".format(axis_item))
 
     return np.array(drop_aligned_axes_indices)
 
-def _update_aligned_axes(drop_aligned_axes_indices, labels, aligned_axes):
+def _update_aligned_axes(drop_aligned_axes_indices, keys, aligned_axes):
     # Remove dropped axes from aligned_axes.  MUST BE A BETTER WAY TO DO THIS.
     if len(drop_aligned_axes_indices) > 0:
         new_aligned_axes = []
-        for label in labels:
+        for label in keys:
             cube_aligned_axes = np.array(aligned_axes[label])
             for drop_axis_index in drop_aligned_axes_indices:
                 drop_axis = cube_aligned_axes[drop_axis_index]

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+
+def _generate_collection_getitems(item, collection_items, labels, aligned_axes, n_aligned_axes):
+    # Determine whether any axes are dropped by slicing.
+    # If so, remove them from aligned_axes.
+    drop_aligned_axes_indices = []
+    # If item is an int, first aligned axis is dropped.
+    if isinstance(item, int):
+        drop_aligned_axes_indices = [0]
+        # Insert item to each cube's slice item.
+        for i, key in enumerate(labels):
+            collection_items[i][aligned_axes[key][0]] = item
+    # If item is a slice such that only one element is in interval,
+    # first aligned axis is dropped.
+    elif isinstance(item, slice):
+        if item.step is None:
+            step = 1
+        else:
+            step = item.step
+        if abs((item.stop - item.start) // step) < 2:
+            drop_aligned_axes_indices = [0]
+        # Insert item to each cube's slice item.
+        for i, key in enumerate(labels):
+            collection_items[i][aligned_axes[key][0]] = item
+    # If item is tuple, search sub-items for ints or 1-interval slices.dd
+    elif isinstance(item, tuple):
+        # If item is tuple, search sub-items for ints or 1-interval slices.
+        if len(item) > n_aligned_axes:
+            raise IndexError("Too many indices")
+        for i, axis_item in enumerate(item):
+            if isinstance(axis_item, int):
+                drop_aligned_axes_indices.append(i)
+            elif isinstance(axis_item, slice):
+                if axis_item.step is None:
+                    step = 1
+                else:
+                    step = axis_item.step
+                if abs((axis_item.stop - axis_item.start) // step) < 2:
+                    drop_aligned_axes_indices.append(i)
+            else:
+                raise TypeError("Unsupported slicing type: {0}".format(axis_item))
+            # Enter slice item into correct index for slice tuple of each cube.
+            for j, key in enumerate(labels):
+                collection_items[j][aligned_axes[key][i]] = axis_item
+    else:
+        raise TypeError("Unsupported slicing type: {0}".format(axis_item))
+
+    return np.array(drop_aligned_axes_indices)
+
+def _update_aligned_axes(drop_aligned_axes_indices, labels, aligned_axes):
+    # Remove dropped axes from aligned_axes.  MUST BE A BETTER WAY TO DO THIS.
+    if len(drop_aligned_axes_indices) > 0:
+        new_aligned_axes = []
+        for label in labels:
+            cube_aligned_axes = np.array(aligned_axes[label])
+            for drop_axis_index in drop_aligned_axes_indices:
+                drop_axis = cube_aligned_axes[drop_axis_index]
+                cube_aligned_axes = np.delete(cube_aligned_axes, drop_axis_index)
+                w = np.where(cube_aligned_axes > drop_axis)
+                cube_aligned_axes[w] -= 1
+                w = np.where(drop_aligned_axes_indices > drop_axis_index)
+                drop_aligned_axes_indices[w] -= 1
+            new_aligned_axes.append(tuple(cube_aligned_axes))
+        new_aligned_axes = tuple(new_aligned_axes)
+    else:
+        new_aligned_axes = aligned_axes
+
+    return new_aligned_axes

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -1,6 +1,7 @@
 import numpy as np
 import astropy.units as u
 
+
 def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
     """
     Converts input aligned_axes to standard format.
@@ -16,7 +17,7 @@ def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
 
     """
     aligned_axes_error_message = "aligned_axes must contain ints or " + \
-            "a tuple of ints for each element in data."
+        "a tuple of ints for each element in data."
     if isinstance(data[0].dimensions, u.Quantity):
         cube0_dims = data[0].dimensions[np.array(aligned_axes[0])]
     elif isinstance(data[0].dimensions, tuple):
@@ -62,11 +63,11 @@ def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
             max_aligned_axis = max(aligned_axes[i])
             if n_cube_dims < max([max_aligned_axis, n_aligned_axes]):
                 raise ValueError(
-                    "Each cube in data must have at least as many axes as aligned axes " + \
-                    "and aligned axis numbers must be less than number of cube axes.\n" + \
-                    "Cube number: {0};\n".format(i) + \
-                    "Number of cube dimensions: {0};\n".format(n_cube_dims) + \
-                    "No. aligned axes: {0};\n".format(n_aligned_axes)  + \
+                    "Each cube in data must have at least as many axes as aligned axes "
+                    "and aligned axis numbers must be less than number of cube axes.\n"
+                    "Cube number: {0};\n".format(i)
+                    "Number of cube dimensions: {0};\n".format(n_cube_dims)
+                    "No. aligned axes: {0};\n".format(n_aligned_axes)
                     "Highest aligned axis: {0}".format(max_aligned_axis))
             subtuple_types = [False] * n_aligned_axes
             cube_lengths_equal = [False] * n_aligned_axes
@@ -84,9 +85,9 @@ def _sanitize_aligned_axes(data, aligned_axes, n_cubes):
         raise ValueError(aligned_axes_error_message)
 
     # Ensure all aligned axes are of same length.
-    check_dimensions = set([len(set(
-        [cube.dimensions[cube_aligned_axes[j]] for cube, cube_aligned_axes in zip(data, aligned_axes)]))
-        for j in range(n_aligned_axes)])
+    check_dimensions = set([len(set([cube.dimensions[cube_aligned_axes[j]]
+                                     for cube, cube_aligned_axes in zip(data, aligned_axes)]))
+                            for j in range(n_aligned_axes)])
     if check_dimensions != {1}:
         raise ValueError("Aligned axes are not all of same length.")
 
@@ -122,4 +123,3 @@ def make_index_positive(index, axis_length):
     else:
         pos_index = index
     return pos_index
-


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
This PR is a continuation of #231.  (I messed up the git history and it was easier to open a new PR.)  As with #231, this PR introduces a new class for holding a collection of NDCubes/Sequences.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Still To Do
- [ ] Get refactor of ```NDCollection.__init__``` working.
- [ ] Change ```NDCollection``` test inputs to pytest fixtures.
- [ ] Rename ```NDCollection.update``` to something like ```NDCollection.extend``` and implement a new ```NDCollection.update``` that takes another ```NDCollection``` in the same way the ```dict.update``` takes another ```dict```.
- [ ] Make ```NDCollection._first_key``` and ```NDCollection._cube_types``` properties.
- [ ] Add ```NDCollection``` to guide in docs
- [ ] Extend tests to ```NDCollection``` of ```NDCubeSequences```
