### PR TITLE
Fix NDCubeSequence slicing behavior for slice item

### DIFF
--- a/changelog/241.bugfix.rst
+++ b/changelog/241.bugfix.rst
@@ -1,0 +1,4 @@
+Changes behavior of NDCubeSequence slicing. Previously, a slice item of interval
+length 1 would cause an NDCube object to be returned. Now an NDCubeSequence made
+up of 1 NDCube is returned. This is consistent with how interval length 1 slice
+items slice arrays.

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -1,3 +1,6 @@
+import copy
+import numbers
+
 import numpy as np
 
 import astropy.units as u
@@ -80,8 +83,12 @@ class NDCubeSequenceBase:
         return self.data[0].world_axis_physical_types
 
     def __getitem__(self, item):
-        if len(self.dimensions) == 1:
+        if isinstance(item, numbers.Integral):
             return self.data[item]
+        elif isinstance(item, slice):
+            result = copy.deepcopy(self)
+            result.data = self.data[item]
+            return result
         else:
             return utils.sequence.slice_sequence(self, item)
 

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -116,12 +116,14 @@ nan_time_extra_coord[2] = np.nan
     (seq[2], NDCube),
     (seq[3], NDCube),
     (seq[0:1], NDCubeSequence),
+    (seq[0:1, 0:2], NDCubeSequence),
+    (seq[0:1, 0], NDCubeSequence),
     (seq[1:3], NDCubeSequence),
     (seq[0:2], NDCubeSequence),
     (seq[slice(0, 2)], NDCubeSequence),
     (seq[slice(0, 3)], NDCubeSequence),
 ])
-def test_slice_first_index_sequence(test_input, expected):
+def test_slice_first_index_sequence_type(test_input, expected):
     assert isinstance(test_input, expected)
 
 
@@ -132,7 +134,7 @@ def test_slice_first_index_sequence(test_input, expected):
     (seq[slice(0, 2)], 2 * u.pix),
     (seq[slice(0, 3)], 3 * u.pix),
 ])
-def test_slice_first_index_sequence(test_input, expected):
+def test_slice_first_index_sequence_dimensions(test_input, expected):
     assert test_input.dimensions[0] == expected
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR changes the slicing behavior of ```NDCubeSequence```.
Previously, a slice item of interval length 1 would cause an NDCube
object to be returned. Now an NDCubeSequence made up of 1 NDCube is
returned. This is consistent with how interval length 1 slice items
slice arrays.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #235 
