### PR TITLE
Pixel axis numbers <-> world physical types

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -631,14 +631,14 @@ Axis Types of NDCube: {axis_type}
 
         # Invert extra_coords so that keys are axis numbers and values are axis names.
         extra_coords = self.extra_coords
-        extra_coords_axes = dict([(str(i), []) for i in range(n_dimensions)])
+        extra_coords_axes = dict([('None', [])] + [(str(i), []) for i in range(n_dimensions)])
         for key in extra_coords.keys():
             coord_axes = extra_coords[key]["axis"]
-            if isinstance(coord_axes, numbers.Integral):
+            if isinstance(coord_axes, numbers.Integral) or coord_axes is None:
                 extra_coords_axes[str(coord_axes)].append(key)
             else:
                 for coord_axis in coord_axes:
-                    extra_coord_axes[str(coord_axis)].append(key)
+                    extra_coords_axes[str(coord_axis)].append(key)
 
         # For each pixel axis, find the corresponding axis names.
         n_axes = len(axes)

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -713,9 +713,8 @@ Axis Types of NDCube: {axis_type}
             # Check extra_coords for axis name.
             w_axis_from_extra_coords = [name in key for key in extra_coords.keys()]
             n_instances_in_extra_coords = sum(w_axis_from_extra_coords)
-            if (name_in_wcs and n_instances_in_extra_coords > 0) or \
-                    (n_instances_in_extra_coords > 1):
-                        raise ValueError("axis name provided not unique.")
+            if (name_in_wcs and n_instances_in_extra_coords > 0) or n_instances_in_extra_coords > 1:
+                raise ValueError("axis name provided not unique.")
             elif n_instances_in_extra_coords == 1:
                 dependent_axes = extra_coords[name]["axis"]
             # Enter axes into list.

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -198,10 +198,10 @@ class NDCubeSequenceBase:
         return self.data[0].world_axis_physical_types
 
     def cube_like_pixel_axes_to_world_types(self, *axes):
-        raise NotImplementedError()
+        return self.data[0].pixel_axes_to_world_types(*axes)
 
     def cube_like_world_types_to_pixel_axes(self, *axes_names):
-        raise NotImplementedError()
+        return self.data[0].world_types_to_world_types(*axes_names)
 
     def __getitem__(self, item):
         if len(self.dimensions) == 1:

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -157,7 +157,7 @@ class NDCubeSequenceBase:
             axes_names = np.array(axes_names)
         n_names = len(axes_names)
         axes = np.array([None] * n_names, dtype=object)
-        
+
         # Get world types associated with sequence axis.
         sequence_axes_names = utils.sequence._get_axis_extra_coord_names_and_units(self.data, None)[0]
         if sequence_axes_names is None:
@@ -177,7 +177,6 @@ class NDCubeSequenceBase:
                     *axes_names[cube_names_indices])
 
         return tuple(axes)
-        
 
     @property
     def cube_like_dimensions(self):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR supplies two new methods that map between physical axis names and pixel axis numbers.  They differ from ```NDCube.world_axis_physical_types``` in that they explicitly give all pixel axis numbers for each world axis physical type and vice versa.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #240

To Do:
- [x] Write versions of these methods for ```NDCubeSequence```.
- [ ] Write tests for all new methods.
- [x] Extend methods to include axis names in ```extra_coords```?
