### PR TITLE
[WIP] Refactor NDCubeSequence.index_as_cube

### DIFF
--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -258,20 +258,25 @@ class _IndexAsCubeSlicer:
     def __getitem__(self, item):
         # return utils.sequence._index_sequence_as_cube(self.seq, item)
 
+        n_cube_dimensions = np.array([c.data.shape[self.seq._common_axis]
+                                      for c in self.seq.data])
+
         n_non_common_cube_dims = n_cube_dimensions - 1
+
         if isinstance(item, slice):
-            # If item is slice, turn into a tuple, filling in items for unincluded axes with slice(None).
+            # If item is slice, turn into a tuple, filling in items for un-included axes with slice(None).
             # This ensures it is treated the same as tuple items.
-            item = tuple([item] + [slice(None)] * n_non_common_cube_dims
-        if isinstance(item, number.Integral) or isinstance(item[0], numbers.Integral)):
-            if isinstance(item[0], numbers.Integral)):
+            item = tuple([item] + [slice(None)] * n_non_common_cube_dims)
+        if isinstance(item, number.Integral) or isinstance(item[0], numbers.Integral):
+            if isinstance(item[0], numbers.Integral):
                 item0 = item[0]
-            cube_item = list(item[1:]) + [slice(None)] * n_non_common_cube_dims
+                cube_item = list(item[1:]) + [slice(None)] * n_non_common_cube_dims
             else:
                 item0 = item
                 cube_item = [slice(None)] * n_non_common_cube_dims
             # Convert cube-like index to sequence_index and common_axis_index
-            sequence_index, cube_index = convert_cube_like_index_to_sequence_and_cube_indices(item, n_cube_dimensions)
+            sequence_index, cube_index = self.convert_cube_like_index_to_sequence_and_cube_indices(item,
+                                                                                                   n_cube_dimensions)
             cube_item.insert(common_axis, cube_index)
             cube_item = tuple(cube_item)
             return self.data[sequence_index][cube_item]
@@ -279,15 +284,17 @@ class _IndexAsCubeSlicer:
             # item can now only be a tuple who's common axis item is a slice object.
             # Convert item into iterable of SequenceItems and slice each cube appropriately.
             # item for common_axis must always be a slice for every cube, even if it is only a length-1 slice.
-            # Thus NDCubeSequence.index_as_cube can only slice away common axis if item is int or item's first item is an int.
+            # Thus NDCubeSequence.index_as_cube can only slice away common axis if item
+            # is int or item's first item is an int.
             # i.e. NDCubeSequence.index_as_cube cannot cause common_axis to become None
-            # since in all cases where the common_axis is sliced away involve an NDCube is returned, not an NDCubeSequence.
-            sequence_items = convert_cube_like_tuple_item_to_sequence_items(item)
+            # since in all cases where the common_axis is sliced away involve an NDCube is returned,
+            # not an NDCubeSequence.
+            sequence_items = self.convert_cube_like_tuple_item_to_sequence_items(item)
             result = copy.deepcopy(self)
             result.data = [result.data[sequence_item.sequence_index][sequence_item.cube_item] for sequence_item in
                            sequence_items]
 
-    def convert_cube_like_tuple_item_to_sequence_items(item, n_cube_dimensions):
+    def convert_cube_like_tuple_item_to_sequence_items(self, item, n_cube_dimensions):
         # Fill in slice(None) items for any axes not explicitly accounted for in tuple item.
         item = list(item)
         len_input_item = len(item)
@@ -298,10 +305,13 @@ class _IndexAsCubeSlicer:
         default_cube_item.insert(common_axis, slice(None))
 
         # Convert start and stop cube-like indices to sequence and cube indices.
-        start_sequence_index, start_common_axis_index = convert_cube_like_index_to_sequence_and_cube_indices(
-            item[0].start)
-        stop_sequence_index, stop_common_axis_index = convert_cube_like_index_to_sequence_and_cube_indices(
-            item[0].stop - 1)  # Must get last included item here to avoid ticking over to new NDCube if not needed. Therefore, subtract 1 here and add back on to common axis cube item after.
+        start_sequence_index, start_common_axis_index = \
+            self.convert_cube_like_index_to_sequence_and_cube_indices(item[0].start)
+        stop_sequence_index, stop_common_axis_index = \
+            self.convert_cube_like_index_to_sequence_and_cube_indices(item[0].stop - 1)
+        # Must get last included item here to avoid ticking over to new NDCube if not needed.
+        # Therefore, subtract 1 here and add back on to common axis cube item after.
+
         # Must iterate the stop index by one because Python slices up to but not including stop index.
         stop_common_axis_index += 1
 
@@ -310,21 +320,27 @@ class _IndexAsCubeSlicer:
         # If only one cube included in slicing item, return iterable of single SequenceItem
         if n_cubes_after_first == 0:
             sequence_items = SequenceItem(start_sequence_index,
-                                          slice(start_common_axis_index, stop_common_axis_index)
+                                          slice(start_common_axis_index, stop_common_axis_index))
         else:
             if n_cubes_after_first > 1:  # Condition > 1 to exclude final cube. We will add it separately.
-                sequence_items = [SequenceItem(i, tuple(blank_cube_item * n_cube_dimensions) for i in
-                          range(start_sequence_index + 1, stop_sequence_index)]
+                sequence_items = SequenceItem(i, [tuple(blank_cube_item * n_cube_dimensions) for i in
+                                                  range(start_sequence_index + 1, stop_sequence_index)])
             else:
                 sequence_items = []
             # Insert final cube if there is one after the first.
             if n_cubes_after_first > 0:
                 final_cube_item = copy.deepcopy(default_cube_item)
                 final_cube_item[common_axis] = slice(0, stop_common_axis_index)
-                sequence_items.append(SequenceItem(stop_sequence_index, final_cube_item)
+                sequence_items.append(SequenceItem(stop_sequence_index, final_cube_item))
             # Finally, add Sequence index for first cube.
             first_cube_item = copy.deepcopy(default_cube_item)
             first_cube_item[common_axis] = slice(start_common_axis_index, None)
-            sequence_items.insert(SequenceItem(start_sequence_index, first_cube_item)
+            sequence_items.insert(SequenceItem(start_sequence_index, first_cube_item))
 
         return sequence_items
+
+    def convert_cube_like_index_to_sequence_and_cube_indices(self, item, n_cube_dimensions):
+        """
+        TODO: Add content here
+        """
+        return True

--- a/ndcube/utils/sequence.py
+++ b/ndcube/utils/sequence.py
@@ -265,7 +265,7 @@ def _index_sequence_as_cube(cubesequence, item):
 
 def convert_cube_like_item_to_sequence_items(cube_like_item, common_axis, common_axis_cube_lengths):
     """
-    Converts an input item to NDCubeSequence.index_as_cube to a list od
+    Converts an input item to NDCubeSequence.index_as_cube to a list of
     SequenceSlice objects.
 
     Parameters


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
To refactor `_IndexAsCubeSlicer.__getitem__` as described in https://github.com/sunpy/ndcube/issues/250#issue-592890153, out of a concern that the current slicing in `NDCubeSequence.index_as_cube` is too complicated.  

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #250.
