### PR TITLE
Fix docstring of NDCubeSequencePlotMixin.plot_as_cube

### DIFF
--- a/changelog/262.trivial.rst
+++ b/changelog/262.trivial.rst
@@ -1,0 +1,1 @@
+Fix docstring formatting to help docs build.

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -1,7 +1,6 @@
+import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
-
-import astropy.units as u
 from sunpy.visualization.animator import ArrayAnimatorWCS
 
 from . import plotting_utils as utils

--- a/ndcube/mixins/sequence_plotting.py
+++ b/ndcube/mixins/sequence_plotting.py
@@ -145,7 +145,7 @@ class NDCubeSequencePlotMixin:
         Based on the cube-like dimensionality of the sequence and value of plot_axis_indices
         kwarg, a Line/Image Plot/Animation is produced.
 
-         Parameters
+        Parameters
         ----------
         axes: `astropy.visualization.wcsaxes.core.WCSAxes` or ??? or None.
             The axes to plot onto. If None the current axes will be used.
@@ -212,9 +212,10 @@ class NDCubeSequencePlotMixin:
 
         Returns
         -------
-        ax: ax: `matplotlib.axes.Axes`, `ndcube.mixins.sequence_plotting.ImageAnimatorNDCubeSequence` or
+        ax: `matplotlib.axes.Axes`, `ndcube.mixins.sequence_plotting.ImageAnimatorNDCubeSequence` or
                 `ndcube.mixins.sequence_plotting.ImageAnimatorCubeLikeNDCubeSequence`
             Axes or animation object depending on dimensionality of NDCubeSequence
+
         """
         # Verify common axis is set.
         if self._common_axis is None:

--- a/ndcube/mixins/sequence_plotting.py
+++ b/ndcube/mixins/sequence_plotting.py
@@ -1,10 +1,9 @@
 import copy
 
+import astropy.units as u
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-
-import astropy.units as u
 
 from ndcube import utils
 from ndcube.utils.cube import _get_extra_coord_edges

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -3,10 +3,9 @@ import abc
 import textwrap
 import warnings
 
-import numpy as np
-
 import astropy.nddata
 import astropy.units as u
+import numpy as np
 import sunpy.coordinates
 from astropy.utils.misc import InheritDocstrings
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS, HighLevelWCSWrapper, SlicedLowLevelWCS

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -2,9 +2,8 @@ import copy
 import numbers
 import textwrap
 
-import numpy as np
-
 import astropy.units as u
+import numpy as np
 
 from ndcube import utils
 from ndcube.mixins.sequence_plotting import NDCubeSequencePlotMixin

--- a/ndcube/tests/conftest.py
+++ b/ndcube/tests/conftest.py
@@ -4,10 +4,9 @@ predicable NDCube objects.
 """
 import datetime
 
+import astropy.units as u
 import numpy as np
 import pytest
-
-import astropy.units as u
 from astropy.wcs import WCS
 
 from ndcube import NDCube

--- a/ndcube/tests/helpers.py
+++ b/ndcube/tests/helpers.py
@@ -5,11 +5,10 @@ Helpers for testing ndcube.
 import unittest
 
 import numpy as np
-from numpy.testing import assert_equal
-
 from astropy.wcs.wcsapi.fitswcs import SlicedFITSWCS, SlicedLowLevelWCS
 from astropy.wcs.wcsapi.low_level_api import BaseLowLevelWCS
 from astropy.wcs.wcsapi.sliced_low_level_wcs import sanitize_slices
+from numpy.testing import assert_equal
 
 from ndcube import NDCube, NDCubeSequence, utils
 

--- a/ndcube/tests/test_ndcollection.py
+++ b/ndcube/tests/test_ndcollection.py
@@ -1,9 +1,8 @@
 import copy
 
+import astropy.wcs
 import numpy as np
 import pytest
-
-import astropy.wcs
 
 from ndcube import NDCollection, NDCube, NDCubeSequence
 from ndcube.tests import helpers

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -4,10 +4,9 @@ Tests for NDCube.
 import datetime
 from collections import OrderedDict
 
+import astropy.units as u
 import numpy as np
 import pytest
-
-import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -2,11 +2,9 @@ import datetime
 import unittest
 from collections import namedtuple
 
+import astropy.units as u
 import numpy as np
 import pytest
-
-import astropy.units as u
-import sunpy.map
 
 from ndcube import NDCube, NDCubeSequence
 from ndcube.utils.wcs import WCS

--- a/ndcube/tests/test_plotting.py
+++ b/ndcube/tests/test_plotting.py
@@ -1,8 +1,7 @@
+import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-
-import astropy.units as u
 import sunpy.visualization.animator
 from astropy.visualization.wcsaxes import WCSAxes
 

--- a/ndcube/tests/test_plotting_utils.py
+++ b/ndcube/tests/test_plotting_utils.py
@@ -1,6 +1,5 @@
-import pytest
-
 import astropy.units as u
+import pytest
 
 import ndcube.mixins.plotting_utils as utils
 

--- a/ndcube/tests/test_utils_collection.py
+++ b/ndcube/tests/test_utils_collection.py
@@ -1,7 +1,6 @@
 
-import pytest
-
 import astropy.units as u
+import pytest
 
 from ndcube.utils import collection as collection_utils
 

--- a/ndcube/tests/test_utils_cube.py
+++ b/ndcube/tests/test_utils_cube.py
@@ -1,9 +1,8 @@
 import unittest
 
+import astropy.units as u
 import numpy as np
 import pytest
-
-import astropy.units as u
 
 from ndcube import utils
 

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy as np
 import pytest
-
 from astropy.wcs import WCS
 
 from ndcube import utils

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -1,8 +1,7 @@
 import numbers
 
-import numpy as np
-
 import astropy.units as u
+import numpy as np
 
 
 def _sanitize_aligned_axes(keys, data, aligned_axes):

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -4,7 +4,6 @@ Utilities for ndcube.
 """
 
 import numpy as np
-
 from astropy.units import Quantity
 
 from ndcube.utils.wcs import _pixel_keep, get_dependent_wcs_axes

--- a/ndcube/utils/sequence.py
+++ b/ndcube/utils/sequence.py
@@ -7,9 +7,8 @@ from copy import deepcopy
 from functools import singledispatch
 from collections import namedtuple
 
-import numpy as np
-
 import astropy.units as u
+import numpy as np
 
 __all__ = ['SequenceSlice', 'SequenceItem', 'slice_sequence', 'convert_item_to_sequence_items',
            'convert_cube_like_item_to_sequence_items', 'convert_slice_nones_to_ints']

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 from collections import UserDict
 
 import numpy as np
-
 from astropy import wcs
 from astropy.wcs._wcs import InconsistentAxisTypesError
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
 
 [options.extras_require]
 test =
-    pytest
+    pytest < 5.4
     pytest-astropy
 docs =
     sphinx
@@ -48,10 +48,10 @@ max_line_length = 110
 [isort]
 line_length = 110
 not_skip = __init__.py
-sections = FUTURE, STDLIB, THIRDPARTY, ASTROPY, FIRSTPARTY, LOCALFOLDER
+sections = FUTURE, STDLIB, THIRDPARTY, FIRSTPARTY, LOCALFOLDER
 default_section = THIRDPARTY
 known_first_party = ndcube
-known_astropy = astropy, asdf, sunpy
+known_third_party = astropy,matplotlib,numpy,pytest,setuptools
 multi_line_output = 0
 balanced_wrapping = True
 include_trailing_comma = False


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
To fix the formatting of the doctring in `NDCubeSequencePlotMixin.plot_as_cube` in `ndcube/mixins/sequence_plotting.py` to get rid of unexpected unindent and missing blank line after block quote errors. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

<!-- Fixes #<Issue Number> -->