### PR TITLE
Fixes bug in NDCollection.aligned_dimensions.

### DIFF
--- a/changelog/264.bugfix.rst
+++ b/changelog/264.bugfix.rst
@@ -1,1 +1,1 @@
-Fix NDCollection.aligned_dimensions so it doesnt crash when components of collection are NDCubeSequences. 
+Fix NDCollection.aligned_dimensions so it doesnt crash when components of collection are NDCubeSequences.

--- a/changelog/264.bugfix.rst
+++ b/changelog/264.bugfix.rst
@@ -1,0 +1,1 @@
+Fix NDCollection.aligned_dimensions so it doesnt crash when components of collection are NDCubeSequences. 

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -95,7 +95,8 @@ class NDCollection(dict):
 
         """
         if self.aligned_axes is not None:
-            return self[self._first_key].dimensions[np.array(self.aligned_axes[self._first_key])]
+            return np.asanyarray(self[self._first_key].dimensions, dtype=object)[
+                    np.array(self.aligned_axes[self._first_key])]
 
     @property
     def aligned_world_axis_physical_types(self):

--- a/ndcube/tests/test_ndcollection.py
+++ b/ndcube/tests/test_ndcollection.py
@@ -1,8 +1,9 @@
 import copy
 
-import astropy.wcs
-import numpy as np
 import pytest
+import numpy as np
+import astropy.wcs
+import astropy.units as u
 
 from ndcube import NDCollection, NDCube, NDCubeSequence
 from ndcube.tests import helpers
@@ -130,3 +131,10 @@ def test_collection_update_collecton_input():
     expected = NDCollection([("cube0", cube0), ("cube1", cube1_alt), ("cube2", cube2)],
                             aligned_axes)
     helpers.assert_collections_equal(orig_collection, expected)
+
+
+@pytest.mark.parametrize("collection, expected_aligned_dimensions", [
+    (cube_collection, [4, 5]*u.pix),
+    (seq_collection, np.array([2*u.pix, 3*u.pix, 4*u.pix, 5*u.pix], dtype=object))])
+def test_aligned_dimensions(collection, expected_aligned_dimensions):
+    assert all(collection.aligned_dimensions == expected_aligned_dimensions)


### PR DESCRIPTION
Caused when components in collection were NDCubeSequences.

<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR fixes a bug in the ```NDCollection.aligned_dimensions``` property caused when the components within the collection are ```NDCubeSequence``` objects.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #259 
