### PR TITLE
Make code base independent of OS bit type.

### DIFF
--- a/changelog/269.bugfix.rst
+++ b/changelog/269.bugfix.rst
@@ -1,0 +1,1 @@
+Generalize int type checking so it is independent of the bit-type of the OS.

--- a/ndcube/mixins/sequence_plotting.py
+++ b/ndcube/mixins/sequence_plotting.py
@@ -1,4 +1,5 @@
 import copy
+import numbers
 
 import astropy.units as u
 import matplotlib as mpl
@@ -1036,7 +1037,7 @@ class LineAnimatorNDCubeSequence(LineAnimator):
                         raise TypeError("Extra coord {} must be of same type for all NDCubes to "
                                         "use it to define a plot axis.".format(axis_extra_coord))
                     if extra_coord_axes.all() == extra_coord_axes[0]:
-                        if isinstance(extra_coord_axes[0], (int, np.int64)):
+                        if isinstance(extra_coord_axes[0], numbers.Integral):
                             extra_coord_axes = [int(extra_coord_axes[0])]
                         else:
                             extra_coord_axes = list(extra_coord_axes[0]).sort()

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -2,6 +2,7 @@
 """
 Utilities for ndcube.
 """
+import numbers
 
 import numpy as np
 from astropy.units import Quantity
@@ -46,7 +47,7 @@ def data_axis_to_wcs_ape14(data_axis, pixel_keep, naxes, old_order=False):
 
     # Make sure that data_axis is a scalar item
     if data_axis is not None:
-        if not isinstance(data_axis, (int, np.int32, np.int64)):
+        if not isinstance(data_axis, numbers.Integral):
             raise ValueError(f"The data_axis parameter accepts \
                 numpy.int64 or numpy.np.int32 datatype, got this {type(data_axis)}")
 
@@ -124,7 +125,7 @@ def wcs_axis_to_data_ape14(wcs_axis, pixel_keep, naxes, old_order=False):
 
     # Make sure that wcs_axis is a scalar item
     if wcs_axis is not None:
-        if not isinstance(wcs_axis, (int, np.int32, np.int64)):
+        if not isinstance(wcs_axis, numbers.Integral):
             raise ValueError(f"The wcs_axis parameter accepts \
                 numpy.int64 or np.int32 datatype, got this {type(wcs_axis)}")
 
@@ -218,8 +219,7 @@ def _format_input_extra_coords_to_extra_coords_wcs_axis(extra_coords, pixel_keep
             raise ValueError(coord_format_error.format(coord))
         if not isinstance(coord[0], str):
             raise ValueError(coord_0_format_error.format(coord))
-        if coord[1] is not None and not isinstance(coord[1], int) and \
-                not isinstance(coord[1], np.int64):
+        if coord[1] is not None and not isinstance(coord[1], numbers.Integral):
             raise ValueError(coord_1_format_error)
 
         # Determine wcs axis corresponding to data axis of coord


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR removes checking of specific int types that depend on the OS bit type, e.g. ```numpy.int64```.  Instead ```numbers.Integral``` is used to check whether a variable is an int type.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #133 
