### PR TITLE
Fix plotting bug when dependent axes are not first axes.

### DIFF
--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -452,10 +452,10 @@ class NDCubePlotMixin:
                 axis_label_text = self.world_axis_physical_types[i]
                 # If the shape of the data is not 1, or all the axes are not dependent
                 if new_axis_coordinate.ndim != 1 and new_axis_coordinate.ndim != len(data_shape):
-                    index = utils.wcs.get_dependent_data_axes(self.wcs, i, self.missing_axes)
-                    reduce_axis = np.where(index == np.array([i]))[0]
-
-                    index = np.delete(index, reduce_axis)
+                    dependent_axes = utils.wcs.get_dependent_data_axes(self.wcs, i,
+                                                                       self.missing_axes)
+                    reduce_axis = np.where(dependent_axes == np.array([i]))[0]
+                    index = np.delete(np.arange(len(dependent_axes)), reduce_axis)
                     # Reduce the data by taking mean
                     new_axis_coordinate = np.mean(new_axis_coordinate, axis=tuple(index))
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR fixes a bug in ```NDCubePlotMixin._derive_axes_coordinates``` which occurs when dependent axes are not the first data axes.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
#273