### PR TITLE
Utils refactor

### DIFF
--- a/changelog/280.breaking.rst
+++ b/changelog/280.breaking.rst
@@ -1,1 +1,1 @@
-Remove unused util functions and the ndcube WCS class.  Refactor util functions for converting between between data and WCS indices to reflect the APE14 nomenclature that distinguishes between array, pixel and world axes. 
+Remove unused util functions and the ndcube WCS class.  Refactor util functions for converting between between data and WCS indices to reflect the APE14 nomenclature that distinguishes between array, pixel and world axes.

--- a/changelog/280.breaking.rst
+++ b/changelog/280.breaking.rst
@@ -1,1 +1,1 @@
-Refactor utils.
+Remove unused util functions and the ndcube WCS class.  Refactor util functions for converting between between data and WCS indices to reflect the APE14 nomenclature that distinguishes between array, pixel and world axes. 

--- a/changelog/280.breaking.rst
+++ b/changelog/280.breaking.rst
@@ -1,0 +1,1 @@
+Refactor utils.

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -113,15 +113,6 @@ cube_disordered = NDCube(cube_disordered_inputs[0], cube_disordered_inputs[1],
                          mask=cube_disordered_inputs[2], uncertainty=cube_disordered_inputs[3],
                          extra_coords=cube_disordered_inputs[4])
 
-cube_ordered = NDCubeOrdered(
-    data_ordered,
-    w_ordered,
-    mask=mask_ordered,
-    uncertainty=uncertainty_ordered,
-    extra_coords=[('spam', 3, u.Quantity(range(data_disordered.shape[0]), unit=u.pix)),
-                  ('hello', 2, u.Quantity(range(data_disordered.shape[1]), unit=u.pix)),
-                  ('bye', 1, u.Quantity(range(data_disordered.shape[2]), unit=u.pix))])
-
 cube = NDCube(
     data_cube,
     wt,
@@ -924,15 +915,6 @@ def test_crop_by_coords_error(test_input):
 def test_crop_by_extra_coord(test_input, expected):
     helpers.assert_cubes_equal(
         test_input[0].crop_by_extra_coord(*tuple(test_input[1:])), expected)
-
-
-@pytest.mark.parametrize("test_input,expected", [
-    (cube_disordered_inputs, cube_ordered)])
-def test_ndcubeordered(test_input, expected):
-    helpers.assert_cubes_equal(
-        NDCubeOrdered(test_input[0], test_input[1], mask=test_input[2],
-                      uncertainty=test_input[3], extra_coords=test_input[4]),
-        expected)
 
 
 @pytest.mark.parametrize("test_input,expected", [

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from ndcube import NDCube, NDCubeSequence
-from ndcube.utils.wcs import WCS
+from astropy.wcs import WCS
 
 # sample data for tests
 # TODO: use a fixture reading from a test file. file TBD.

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -5,9 +5,9 @@ from collections import namedtuple
 import astropy.units as u
 import numpy as np
 import pytest
+from astropy.wcs import WCS
 
 from ndcube import NDCube, NDCubeSequence
-from astropy.wcs import WCS
 
 # sample data for tests
 # TODO: use a fixture reading from a test file. file TBD.

--- a/ndcube/tests/test_utils_cube.py
+++ b/ndcube/tests/test_utils_cube.py
@@ -21,68 +21,6 @@ extra_coords_dict_wcs = {"time": {"wcs axis": 0,
                                    "value": u.Quantity(range(axes_length), unit=u.pix)}}
 
 
-@pytest.mark.parametrize(
-    "test_input,expected",
-    [((None, missing_axes_none), None),
-     ((0, missing_axes_none), 2),
-     ((1, missing_axes_none), 1),
-     ((0, missing_axes_0_2), 1),
-     ((1, missing_axes_1), 0),
-     ((-1, missing_axes_0_2), 1),
-     ((-2, missing_axes_1), 2),
-     ((-1, missing_axes_none), 0)])
-def test_data_axis_to_wcs_axis(test_input, expected):
-    assert utils.cube.data_axis_to_wcs_axis(*test_input) == expected
-
-
-@pytest.mark.parametrize("test_input", [(-2, missing_axes_0_2), (1, missing_axes_0_2)])
-def test_data_axis_to_wcs_axis_error(test_input):
-    with pytest.raises(IndexError):
-        utils.cube.data_axis_to_wcs_axis(*test_input)
-
-
-@pytest.mark.parametrize(
-    "test_input,expected",
-    [((None, missing_axes_none), None),
-     ((0, missing_axes_none), 2),
-     ((1, missing_axes_none), 1),
-     ((1, missing_axes_0_2), 0),
-     ((0, missing_axes_1), 1),
-     ((-1, missing_axes_0_2), None),
-     ((-2, missing_axes_0_2), 0),
-     ((-2, missing_axes_1), None),
-     ((-3, missing_axes_1), 1),
-     ((-1, missing_axes_none), 0)])
-def test_wcs_axis_to_data_axis(test_input, expected):
-    assert utils.cube.wcs_axis_to_data_axis(*test_input) == expected
-
-
-@pytest.mark.parametrize("test_input", [(-10, missing_axes_0_2), (10, missing_axes_0_2)])
-def test_wcs_axis_to_data_axis_error(test_input):
-    with pytest.raises(IndexError):
-        utils.cube.data_axis_to_wcs_axis(*test_input)
-
-
-def test_select_order():
-    lists = [['TIME', 'WAVE', 'HPLT-TAN',
-              'HPLN-TAN'], ['WAVE', 'HPLT-TAN', 'UTC',
-                            'HPLN-TAN'], ['HPLT-TAN', 'TIME', 'HPLN-TAN'],
-             ['HPLT-TAN', 'DEC--TAN',
-              'WAVE'], [], ['UTC', 'TIME', 'WAVE', 'HPLT-TAN']]
-
-    results = [
-        [0, 1, 2, 3],
-        [2, 0, 1, 3],
-        [1, 0, 2],  # Second order is initial order
-        [2, 0, 1],
-        [],
-        [1, 0, 2, 3]
-    ]
-
-    for (l, r) in zip(lists, results):
-        assert utils.cube.select_order(l) == r
-
-
 @pytest.mark.parametrize("test_input", [
     ([('name', 0)], np.array([0, 1]), 2, (1, 2)),
     ([(0, 0, 0)], np.array([0, 1]), 2, (1, 2)),

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -46,14 +46,16 @@ def _axis_correlation_matrix():
     return acm
 
 
+@pytest.fixture
+def test_wcs():
+    return TestWCS()
+
+
 class TestWCS():
     def __init__(self):
         self.world_axis_physical_types = [
             'custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl', 'time']
         self.axis_correlation_matrix = _axis_correlation_matrix()
-
-
-TEST_WCS = TestWCS()
 
 
 @pytest.mark.parametrize("test_input,expected", [
@@ -77,11 +79,11 @@ def test_get_dependent_wcs_axes(test_input, expected):
     assert output == expected
 
 
-def test_reflect_axis_index():
+def test_convert_between_array_and_pixel_axes():
     test_input = np.array([1, 4, -2])
     naxes = 5
     expected = np.array([3, 0, 1])
-    output = utils.wcs.reflect_axis_index(test_input, naxes)
+    output = utils.wcs.convert_between_array_and_pixel_axes(test_input, naxes)
     assert all(output == expected)
 
 
@@ -97,16 +99,16 @@ def test_world_axis_to_pixel_axes(axis_correlation_matrix):
     assert all(output == expected)
 
 
-def test_pixel_axis_to_physical_types():
-    output = utils.wcs.pixel_axis_to_physical_types(0, TEST_WCS)
+def test_pixel_axis_to_physical_types(test_wcs):
+    output = utils.wcs.pixel_axis_to_physical_types(0, test_wcs)
     expected = np.array(['custom:pos.helioprojective.lon',
                          'custom:pos.helioprojective.lat', 'time'])
     print(output, expected)
     assert all(output == expected)
 
 
-def test_physical_type_to_pixel_axes():
-    output = utils.wcs.physical_type_to_pixel_axes('lon', TEST_WCS)
+def test_physical_type_to_pixel_axes(test_wcs):
+    output = utils.wcs.physical_type_to_pixel_axes('lon', test_wcs)
     expected = np.array([0, 1])
     assert all(output == expected)
 
@@ -138,7 +140,7 @@ def test_get_dependent_world_axes(axis_correlation_matrix):
     assert all(output == expected)
 
 
-def test_get_dependent_physical_types():
-    output = utils.wcs.get_dependent_physical_types("time", TEST_WCS)
+def test_get_dependent_physical_types(test_wcs):
+    output = utils.wcs.get_dependent_physical_types("time", test_wcs)
     expected = np.array(['custom:pos.helioprojective.lon', 'time'])
     assert all(output == expected)

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -30,22 +30,30 @@ hm_reindexed_102 = {
 wm_reindexed_102 = WCS(header=hm_reindexed_102)
 
 
-@pytest.mark.parametrize(
-    "test_input,expected",
-    [({}, False),
-     ([slice(1, 5), slice(-1, -5, -2)], True)])
-def test_all_slice(test_input, expected):
-    assert utils.wcs._all_slice(test_input) == expected
+@pytest.fixture
+def axis_correlation_matrix():
+    return _axis_correlation_matrix()
 
 
-@pytest.mark.parametrize(
-    "test_input,expected",
-    [({}, []),
-     ((slice(1, 2), slice(1, 3), 2, slice(2, 4), 8),
-      [slice(1, 2, None), slice(1, 3, None), slice(2, 3, None),
-       slice(2, 4, None), slice(8, 9, None)])])
-def test_slice_list(test_input, expected):
-    assert utils.wcs._slice_list(test_input) == expected
+def _axis_correlation_matrix():
+    shape = (4, 4)
+    acm = np.zeros(shape, dtype=bool)
+    for i in range(min(shape)):
+        acm[i, i] = True
+    acm[0, 1] = True
+    acm[1, 0] = True
+    acm[-1, 0] = True
+    return acm
+
+
+class TestWCS():
+    def __init__(self):
+        self.world_axis_physical_types = [
+            'custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl', 'time']
+        self.axis_correlation_matrix = _axis_correlation_matrix()
+
+
+TEST_WCS = TestWCS()
 
 
 @pytest.mark.parametrize("test_input,expected", [
@@ -67,3 +75,70 @@ def test_get_dependent_data_axes(test_input, expected):
 def test_get_dependent_wcs_axes(test_input, expected):
     output = utils.wcs.get_dependent_wcs_axes(*test_input)
     assert output == expected
+
+
+def test_reflect_axis_index():
+    test_input = np.array([1, 4, -2])
+    naxes = 5
+    expected = np.array([3, 0, 1])
+    output = utils.wcs.reflect_axis_index(test_input, naxes)
+    assert all(output == expected)
+
+
+def test_pixel_axis_to_world_axes(axis_correlation_matrix):
+    output = utils.wcs.pixel_axis_to_world_axes(0, axis_correlation_matrix)
+    expected = np.array([0, 1, 3])
+    assert all(output == expected)
+
+
+def test_world_axis_to_pixel_axes(axis_correlation_matrix):
+    output = utils.wcs.world_axis_to_pixel_axes(1, axis_correlation_matrix)
+    expected = np.array([0, 1])
+    assert all(output == expected)
+
+
+def test_pixel_axis_to_physical_types():
+    output = utils.wcs.pixel_axis_to_physical_types(0, TEST_WCS)
+    expected = np.array(['custom:pos.helioprojective.lon',
+                         'custom:pos.helioprojective.lat', 'time'])
+    print(output, expected)
+    assert all(output == expected)
+
+
+def test_physical_type_to_pixel_axes():
+    output = utils.wcs.physical_type_to_pixel_axes('lon', TEST_WCS)
+    expected = np.array([0, 1])
+    assert all(output == expected)
+
+
+@pytest.mark.parametrize("test_input,expected", [('wl', 2), ('em.wl', 2)])
+def test_physical_type_to_world_axis(test_input, expected):
+    world_axis_physical_types = ['custom:pos.helioprojective.lon',
+                                 'custom:pos.helioprojective.lat', 'em.wl', 'time']
+    output = utils.wcs.physical_type_to_world_axis(test_input, world_axis_physical_types)
+    assert output == expected
+
+
+def test_get_dependent_pixel_axes(axis_correlation_matrix):
+    output = utils.wcs.get_dependent_pixel_axes(0, axis_correlation_matrix)
+    expected = np.array([0, 1, 3])
+    assert all(output == expected)
+
+
+def test_get_dependent_array_axes(axis_correlation_matrix):
+    output = utils.wcs.get_dependent_array_axes(3, axis_correlation_matrix)
+    expected = np.array([0, 2, 3])
+    assert all(output == expected)
+
+
+def test_get_dependent_world_axes(axis_correlation_matrix):
+    output = utils.wcs.get_dependent_world_axes(3, axis_correlation_matrix)
+    expected = np.array([0, 3])
+    print(output, expected)
+    assert all(output == expected)
+
+
+def test_get_dependent_physical_types():
+    output = utils.wcs.get_dependent_physical_types("time", TEST_WCS)
+    expected = np.array(['custom:pos.helioprojective.lon', 'time'])
+    assert all(output == expected)

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -49,23 +49,6 @@ def test_slice_list(test_input, expected):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    ((wm, np.array([1, 0, 2])), wm_reindexed_102),
-    ((wm, np.array([1, 0, -1])), wm_reindexed_102)
-])
-def test_reindex_wcs(test_input, expected):
-    helpers.assert_wcs_are_equal(utils.wcs.reindex_wcs(*test_input), expected)
-
-
-@pytest.mark.parametrize("test_input", [
-    (TypeError, wm, 0),
-    (TypeError, wm, np.array(['spam', 'eggs', 'ham'])),
-])
-def test_reindex_wcs_errors(test_input):
-    with pytest.raises(test_input[0]):
-        utils.wcs.reindex_wcs(*test_input[1:])
-
-
-@pytest.mark.parametrize("test_input,expected", [
     ((wm, 0), (0, 1)),
     ((wm, 1), (0, 1)),
     ((wm, 2), (2,)),

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -159,7 +159,7 @@ def _format_input_extra_coords_to_extra_coords_wcs_axis(extra_coords, pixel_keep
             raise ValueError(coord_0_format_error.format(coord))
         # Check coord axis number is valid and convert to a WCS-order axis number.
         if coord[1] is None:
-            new_coord_axis = None
+            wcs_coord_axis = None
         else:
             if isinstance(coord[1], numbers.Integral):
                  wcs_coord_axis = wcs_utils.reflect_axis_index(np.array([coord[1]]), naxes)[0]

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -17,7 +17,7 @@ __all__ = [
     'wcs_axis_to_data_ape14',
     'unique_data_axis']
 
-# Deprecated in favor of utils.wcs.reflect_axis_index
+# Deprecated in favor of utils.wcs.convert_between_array_and_pixel_axes
 def data_axis_to_wcs_ape14(data_axis, pixel_keep, naxes, old_order=False):
     """Converts a data axis number to wcs axis number taking care of the missing axes"""
 
@@ -75,7 +75,7 @@ def data_axis_to_wcs_ape14(data_axis, pixel_keep, naxes, old_order=False):
         # Return the corresponding wcs_axis for the data axis
         return new_wcs_order[index]
 
-# Deprecated in favor of utils.wcs.reflect_axis_index
+# Deprecated in favor of utils.wcs.convert_between_array_and_pixel_axes
 def wcs_axis_to_data_ape14(wcs_axis, pixel_keep, naxes, old_order=False):
     """Converts a wcs axis number to data axis number taking care of the missing axes"""
 
@@ -162,9 +162,9 @@ def _format_input_extra_coords_to_extra_coords_wcs_axis(extra_coords, pixel_keep
             wcs_coord_axis = None
         else:
             if isinstance(coord[1], numbers.Integral):
-                wcs_coord_axis = wcs_utils.reflect_axis_index(np.array([coord[1]]), naxes)[0]
+                wcs_coord_axis = wcs_utils.convert_between_array_and_pixel_axes(np.array([coord[1]]), naxes)[0]
             elif hasattr(coord[1], "__len__") and all([isinstance(c, numbers.Integral) for c in coord[1]]):
-                wcs_coord_axis = tuple(wcs_utils.reflect_axis_index(np.array(coord[1]), naxes))
+                wcs_coord_axis = tuple(wcs_utils.convert_between_array_and_pixel_axes(np.array(coord[1]), naxes))
             else:
                 raise ValueError(coord_1_format_error)
 
@@ -207,7 +207,7 @@ def convert_extra_coords_dict_to_input_format(extra_coords, pixel_keep, naxes):
         result.append((name, axis, extra_coords[name]["value"]))
     return result
 
-# Deprecated in favor of utils.wcs.physical_type_to_pixel_axes + util.wcs.reflect_axis_index
+# Deprecated in favor of utils.wcs.physical_type_to_pixel_axes + util.wcs.convert_between_array_and_pixel_axes
 def get_axis_number_from_axis_name(axis_name, world_axis_physical_types):
     """
     Returns axis number (numpy ordering) given a substring unique to a world

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -162,7 +162,7 @@ def _format_input_extra_coords_to_extra_coords_wcs_axis(extra_coords, pixel_keep
             wcs_coord_axis = None
         else:
             if isinstance(coord[1], numbers.Integral):
-                 wcs_coord_axis = wcs_utils.reflect_axis_index(np.array([coord[1]]), naxes)[0]
+                wcs_coord_axis = wcs_utils.reflect_axis_index(np.array([coord[1]]), naxes)[0]
             elif hasattr(coord[1], "__len__") and all([isinstance(c, numbers.Integral) for c in coord[1]]):
                 wcs_coord_axis = tuple(wcs_utils.reflect_axis_index(np.array(coord[1]), naxes))
             else:

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -20,24 +20,7 @@ __all__ = [
     'wcs_axis_to_data_ape14',
     'unique_data_axis']
 
-
-def data_axis_to_wcs_axis(data_axis, missing_axes):
-    """
-    Converts a data axis number to the corresponding wcs axis number.
-    """
-    if data_axis is None:
-        result = None
-    else:
-        if data_axis < 0:
-            data_axis = np.invert(missing_axes).sum() + data_axis
-        if data_axis > np.invert(missing_axes).sum() - 1 or data_axis < 0:
-            raise IndexError("Data axis out of range.  Number data axes = {}".format(
-                np.invert(missing_axes).sum()))
-        result = len(missing_axes) - \
-            np.where(np.cumsum([b is False for b in missing_axes][::-1]) == data_axis + 1)[0][0] - 1
-    return result
-
-
+# Deprecated in favor of utils.wcs.reflect_axis_index
 def data_axis_to_wcs_ape14(data_axis, pixel_keep, naxes, old_order=False):
     """Converts a data axis number to wcs axis number taking care of the missing axes"""
 
@@ -95,27 +78,7 @@ def data_axis_to_wcs_ape14(data_axis, pixel_keep, naxes, old_order=False):
         # Return the corresponding wcs_axis for the data axis
         return new_wcs_order[index]
 
-
-def wcs_axis_to_data_axis(wcs_axis, missing_axes):
-    """
-    Converts a wcs axis number to the corresponding data axis number.
-    """
-    if wcs_axis is None:
-        result = None
-    else:
-        if wcs_axis < 0:
-            wcs_axis = len(missing_axes) + wcs_axis
-        if wcs_axis > len(missing_axes) - 1 or wcs_axis < 0:
-            raise IndexError("WCS axis out of range.  Number WCS axes = {}".format(
-                len(missing_axes)))
-        if missing_axes[wcs_axis]:
-            result = None
-        else:
-            data_ordered_wcs_axis = len(missing_axes) - wcs_axis - 1
-            result = data_ordered_wcs_axis - sum(missing_axes[::-1][:data_ordered_wcs_axis])
-    return result
-
-
+# Deprecated in favor of utils.wcs.reflect_axis_index
 def wcs_axis_to_data_ape14(wcs_axis, pixel_keep, naxes, old_order=False):
     """Converts a wcs axis number to data axis number taking care of the missing axes"""
 
@@ -176,28 +139,6 @@ def wcs_axis_to_data_ape14(wcs_axis, pixel_keep, naxes, old_order=False):
 
         # Return the corresponding data_axis for the wcs_axis
         return new_data_order[index]
-
-
-def select_order(axtypes):
-    """
-    Returns indices of the correct data order axis priority given a list of WCS
-    CTYPEs.
-
-    For example, given ['HPLN-TAN', 'TIME', 'WAVE'] it will return
-    [1, 2, 0] because index 1 (time) has the lowest priority, followed by
-    wavelength and finally solar-x.
-
-    Parameters
-    ----------
-    axtypes: str list
-        The list of CTYPEs to be modified.
-    """
-    order = sorted([(0, t) if t in ['TIME', 'UTC'] else
-                    (1, t) if t == 'WAVE' else
-                    (2, t) if t == 'HPLT-TAN' else
-                    (axtypes.index(t) + 3, t) for t in axtypes])
-    result = [axtypes.index(s) for (_, s) in order]
-    return result
 
 
 def _format_input_extra_coords_to_extra_coords_wcs_axis(extra_coords, pixel_keep, naxes,
@@ -265,7 +206,7 @@ def convert_extra_coords_dict_to_input_format(extra_coords, pixel_keep, naxes):
         result.append((name, axis, extra_coords[name]["value"]))
     return result
 
-
+# Deprecated in favor of utils.wcs.physical_type_to_pixel_axes + util.wcs.reflect_axis_index
 def get_axis_number_from_axis_name(axis_name, world_axis_physical_types):
     """
     Returns axis number (numpy ordering) given a substring unique to a world
@@ -332,35 +273,6 @@ def _get_dimension_for_pixel(axis_length, edges):
         False stands for pixel_value, while True stands for pixel_edge
     """
     return axis_length + 1 if edges else axis_length
-
-
-def ape14_axes(wcs_object, input_axis):
-    """Returns the corresponding wcs axes after a wcs object
-    is sliced. The `_pixel_keep` attribute of wcs tells us
-    which axis is present, so returns the corresponding wcs
-    axes after slicing.
-
-    Parameters
-    ----------
-    wcs_object : `astropy.wcs.WCS` or similar object
-        The WCS object
-    input_axis : `int` or `list`
-        The list of wcs axes
-
-    Returns
-    -------
-    `int` or `list`
-        The corresponding wcs axes of the sliced wcs object.
-    """
-    wcomp = wcs_object.world_axis_object_components
-    axis_type = np.array([item[0] for item in wcomp])
-    axis_type = axis_type[::-1]
-
-    ape14_axes = np.unique(axis_type, return_inverse=True)[1]
-
-    n_rep_ape14_axes = np.unique(ape14_axes[input_axis])
-
-    return n_rep_ape14_axes[::-1]
 
 
 def unique_data_axis(wcs_object, input_axis):

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -10,9 +10,6 @@ from astropy.units import Quantity
 from ndcube.utils.wcs import _pixel_keep, get_dependent_wcs_axes
 
 __all__ = [
-    'wcs_axis_to_data_axis',
-    'data_axis_to_wcs_axis',
-    'select_order',
     '_pixel_centers_or_edges',
     '_get_dimension_for_pixel',
     'convert_extra_coords_dict_to_input_format',

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -391,26 +391,3 @@ def _get_extra_coord_edges(value, axis=-1):
         # Revert the shape of the edges array
         edges = np.moveaxis(edges, -1, axis)
     return edges
-
-
-def array_from_skycoord(sky_coord, index):
-    """Get the array value from the SkyCoord object
-
-    Parameters
-    ----------
-    sky_coord : `astropy.coordinates.SkyCoord`
-        The SkyCoord object
-    """
-
-    # Get the Tx and Ty value
-    array_val = None
-    if(index == 0):
-    # Get the Tx value in degree
-        array_val = sky_coord.Tx.deg
-    elif(index == 1):
-    # Get the Ty value in degree
-        array_val = sky_coord.Ty.deg
-    else:
-        raise ValueError("Index parameter should be 0 or 1")
-
-    return array_val

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -15,8 +15,14 @@ from astropy.wcs._wcs import InconsistentAxisTypesError
 
 from ndcube.utils import cube as utils_cube
 
-__all__ = ['WCS', 'reindex_wcs', 'wcs_ivoa_mapping', 'get_dependent_data_axes',
-           'get_dependent_wcs_axes', 'append_sequence_axis_to_wcs']
+__all__ = ['wcs_ivoa_mapping', 'get_dependent_data_axes',
+           'get_dependent_wcs_axes', 'append_sequence_axis_to_wcs',
+           'reflect_axis_index',
+           'pixel_axis_to_world_axes', 'world_axis_to_pixel_axes',
+           'pixel_axis_to_physical_types', 'physical_type_to_pixel_axes',
+           'physical_type_to_world_axis',
+           'get_dependent_pixel_axes', 'get_dependent_array_axes',
+           'get_dependent_world_axes', 'get_dependent_physical_types']
 
 
 class TwoWayDict(UserDict):

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -49,156 +49,7 @@ wcs_ivoa_mapping = TwoWayDict()
 for key in wcs_to_ivoa.keys():
     wcs_ivoa_mapping[key] = wcs_to_ivoa[key]
 
-
-class WCS(wcs.WCS):
-
-    def __init__(self, header=None, naxis=None, **kwargs):
-        """
-        Initiates a WCS object with additional functionality to add dummy axes.
-
-        Not all WCS axes are independent.  Some, e.g. latitude and longitude,
-        are dependent and one cannot be used without the other.  Therefore this
-        WCS class has the ability to determine whether a dependent axis is missing
-        and can augment the WCS axes with a dummy axis to enable the translations
-        to work.
-
-        Parameters
-        ----------
-        header: FITS header or `dict` with appropriate FITS keywords.
-
-        naxis: `int`
-            Number of axis described by the header.
-        """
-        self.oriented = False
-        self.was_augmented = WCS._needs_augmenting(header)
-        if self.was_augmented:
-            header = WCS._augment(header, naxis)
-            if naxis is not None:
-                naxis = naxis + 1
-        super().__init__(header=header, naxis=naxis, **kwargs)
-
-    @classmethod
-    def _needs_augmenting(cls, header):
-        """
-        Determines whether a missing dependent axis is missing from the WCS
-        object.
-
-        WCS cannot be created with only one spacial dimension. If
-        WCS detects that returns that it needs to be augmented.
-
-        Parameters
-        ----------
-        header: FITS header or `dict` with appropriate FITS keywords.
-        """
-        try:
-            wcs.WCS(header=header)
-        except InconsistentAxisTypesError as err:
-            if re.search(r'Unmatched celestial axes', str(err)):
-                return True
-        return False
-
-    @classmethod
-    def _augment(cls, header, naxis):
-        """
-        Augments WCS with a dummy axis to take the place of a missing dependent
-        axis.
-        """
-        newheader = deepcopy(header)
-        new_wcs_axes_params = {'CRPIX': 0, 'CDELT': 1, 'CRVAL': 0,
-                               'CNAME': 'redundant axis', 'CTYPE': 'HPLN-TAN',
-                               'CROTA': 0, 'CUNIT': 'deg', 'NAXIS': 1}
-        axis = str(max(newheader.get('NAXIS', 0), naxis) + 1)
-        for param in new_wcs_axes_params:
-            attr = new_wcs_axes_params[param]
-            newheader[param + axis] = attr
-        try:
-            wcs.WCS(header=newheader).get_axis_types()
-        except InconsistentAxisTypesError as err:
-            projection = re.findall(r'expected [^,]+', str(err))[0][9:]
-            newheader['CTYPE' + axis] = projection
-        return newheader
-
-
-def _all_slice(obj):
-    """
-    Returns True if all the elements in the object are slices else return
-    False.
-    """
-    result = False
-    if not isinstance(obj, (tuple, list)):
-        return result
-    result |= all(isinstance(o, slice) for o in obj)
-    return result
-
-
-def _slice_list(obj):
-    """
-    Return list of all the slices.
-
-    Example
-    -------
-    >>> _slice_list((slice(1,2), slice(1,3), 2, slice(2,4), 8))
-    [slice(1, 2, None), slice(1, 3, None), slice(2, 3, None), slice(2, 4, None), slice(8, 9, None)]
-    """
-    result = []
-    if not isinstance(obj, (tuple, list)):
-        return result
-    for i, o in enumerate(obj):
-        if isinstance(o, int):
-            result.append(slice(o, o + 1))
-        elif isinstance(o, slice):
-            result.append(o)
-    return result
-
-
-def reindex_wcs(wcs, inds):
-    # From astropy.spectral_cube.wcs_utils
-    """
-    Re-index a WCS given indices.  The number of axes may be reduced.
-
-    Parameters
-    ----------
-    wcs: sunpy.wcs.wcs.WCS
-        The WCS to be manipulated
-    inds: np.array(dtype='int')
-        The indices of the array to keep in the output.
-        e.g. swapaxes: [0,2,1,3]
-        dropaxes: [0,1,3]
-    """
-
-    if not isinstance(inds, np.ndarray):
-        raise TypeError("Indices must be an ndarray")
-
-    if inds.dtype.kind != 'i':
-        raise TypeError('Indices must be integers')
-
-    outwcs = WCS(naxis=len(inds))
-    wcs_params_to_preserve = ['cel_offset', 'dateavg', 'dateobs', 'equinox',
-                              'latpole', 'lonpole', 'mjdavg', 'mjdobs', 'name',
-                              'obsgeo', 'phi0', 'radesys', 'restfrq',
-                              'restwav', 'specsys', 'ssysobs', 'ssyssrc',
-                              'theta0', 'velangl', 'velosys', 'zsource']
-    for par in wcs_params_to_preserve:
-        setattr(outwcs.wcs, par, getattr(wcs.wcs, par))
-
-    cdelt = wcs.wcs.cdelt
-
-    try:
-        outwcs.wcs.pc = wcs.wcs.pc[inds[:, None], inds[None, :]]
-    except AttributeError:
-        outwcs.wcs.pc = np.eye(wcs.naxis)
-
-    outwcs.wcs.crpix = wcs.wcs.crpix[inds]
-    outwcs.wcs.cdelt = cdelt[inds]
-    outwcs.wcs.crval = wcs.wcs.crval[inds]
-    outwcs.wcs.cunit = [wcs.wcs.cunit[i] for i in inds]
-    outwcs.wcs.ctype = [wcs.wcs.ctype[i] for i in inds]
-    outwcs.wcs.cname = [wcs.wcs.cname[i] for i in inds]
-    outwcs._naxis = [wcs._naxis[i] for i in inds]
-
-    return outwcs
-
-
+# Deprecated in favor of get_dependent_array_axes
 def get_dependent_data_axes(wcs_object, data_axis):
     """
     Given a data axis index, return indices of dependent data axes.
@@ -232,6 +83,7 @@ def get_dependent_data_axes(wcs_object, data_axis):
     return dependent_data_axes
 
 
+# Deprecated in favor of get_dependent_pixel_axes
 def get_dependent_wcs_axes(wcs_object, wcs_axis):
     """
     Given a WCS axis index, return indices of dependent WCS axes.
@@ -300,3 +152,257 @@ def _pixel_keep(wcs_object):
     if hasattr(wcs_object, "_pixel_keep"):
         return wcs_object._pixel_keep
     return np.arange(wcs_object.pixel_n_dim)
+
+
+def reflect_axis_index(input_axis, naxes):
+    """Reflects axis index about center of number of axes.
+
+    This is used to convert between array axes in numpy order and pixel axes in WCS order.
+    Works in both directions.
+
+    Parameters
+    ----------
+    axis: `int` of `numpy.ndarray` of `int`
+        The axis number(s) before reflection.
+
+    naxes: `int`
+        The number of array axes.
+
+    Returns
+    -------
+    reflected_axis: `int` of `numpy.ndarray` of `int
+        The axis number(s) after reflection.
+    """
+    if axis is None:
+        return None
+    # Check type of input.
+    if isinstance(axis, (numbers.Integral, np.ndarray)):
+        raise TypeError(f"axis must be int or array of ints. Got: {type(axis)}.")
+    # Convert scalar input to array so algorithm can be vectorized.
+    if np.isscalar(axis):
+        input_is_scalar = True
+        axis = np.array([axis])
+    else:
+        input_is_scalar = False
+        # Check input array is of int type.
+        if not isinstance(axis.dtype, numbers.Integral):
+            raise TypeError(f"if axis is array, dtype must be int.  Got: {axis.dtype}")
+    # Convert negative indices to positive equivalents.
+    idx_neg = axis < 0
+    axis[idx_neg] = np.abs(axis[idx_neg]) - 1
+    if any(axis > naxes - 1):
+        raise IndexError("Axis out of range.  "
+                         f"Number of axes = {naxes}; Axis numbers requested = {axes}"))
+    # Reflect axis about center of number of axes.
+    reflected_axis = naxes - 1 - axis
+    # Ensure output is returned as scalar if input was scalar.
+    if input_is_scalar:
+        reflected_axis = reflected_axis[0]
+
+    return reflected_axis
+
+
+def pixel_axis_to_world_axes(pixel_axis, axis_correlation_matrix):
+    """
+    Retrieves the indices of the world axis physical types corresponding to a pixel axis.
+
+    Parameters
+    ----------
+    pixel_axis: `int`
+        The pixel axis index/indices for which the world axes are desired.
+
+    axis_correlation_matrix: `numpy.ndarray` of `bool`
+        2D boolean correlation matrix defining the dependence between the pixel and world axes.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+
+    Returns
+    -------
+    world_axes: `numpy.ndarray`
+        The world axis indices corresponding to the pixel axis.
+    """
+    return np.arange(axis_correlation_matrix.shape[0])[axis_correlation_matrix[:, pixel_axis]]
+
+
+def world_axis_to_pixel_axes(world_axis, axis_correlation_matrix):
+    """
+    Gets the pixel axis indices corresponding to the index of a world axis physical type.
+
+    Parameters
+    ----------
+    world_axis: `int`
+        The index of the physical type for which the pixes axes are desired.
+
+    axis_correlation_matrix: `numpy.ndarray` of `bool`
+        2D boolean correlation matrix defining the dependence between the pixel and world axes.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+
+    Returns
+    -------
+    pixel_axes: `numpy.ndarray`
+        The pixel axis indices corresponding to the world axis.
+    """
+    return np.arange(axis_correlation_matrix.shape[1])[axis_correlation_matrix[world_axis]]
+
+
+def pixel_axis_to_physical_types(pixel_axis, wcs):
+    """
+    Gets the world axis physical types corresponding to a pixel axis.
+
+    Parameters
+    ----------
+    pixel_axis: `int`
+        The pixel axis number(s) for which the world axis numbers are desired.
+
+    wcs: `astropy.wcs.BaseLowLevelWCS`
+        The WCS object defining the relationship between pixel and world axes.
+
+   Returns
+   -------
+   physical_types: `numpy.ndarray` of `str`
+       The physical types corresponding to the pixel axis.
+    """
+    return np.array(wcs.world_axis_physical_types)[wcs.axis_correlation_matrix[:, pixel_axis]]
+
+
+def physical_type_to_pixel_axes(physical_type, wcs):
+    """
+    Gets the pixel axis indices corresponding to a world axis physical type.
+
+    Parameters
+    ----------
+    physical_type: `int`
+        The pixel axis number(s) for which the world axis numbers are desired.
+
+    wcs: `astropy.wcs.BaseLowLevelWCS`
+        The WCS object defining the relationship between pixel and world axes.
+
+   Returns
+   -------
+   pixel_axes: `numpy.ndarray`
+       The pixel axis indices corresponding to the physical type.
+    """
+    world_axis = physical_type_to_world_axis(physical_type, wcs.world_axis_physical_types)
+    return world_axis_to_pixel_axes(world_axis, wcs.axis_correlation_matrix)
+
+
+def physical_type_to_world_axis(physical_type, world_axis_physical_types):
+    """
+    Returns world axis index of a physical type based on WCS world_axis_physical_types.
+
+    Input can be a substring of a physical type, so long as it is unique.
+
+    Parameters
+    ----------
+    physical_type: `str`
+        The physical type or a substring unique to a physical type.
+
+    world_axis_physical_types: sequence of `str`
+        All available physical types.  Ordering must be same as
+        `astropy.wcs.BaseLowLevelWCS.world_axis_physical_types`
+
+    Returns
+    -------
+    world_axis: `numbers.Integral`
+        The world axis index of the physical type.
+    """
+    # Find world axis index described by physical type.
+    widx = np.where(world_axis_physical_types == axis_name)[0]
+    # If physical type does not correspond to entry in world_axis_physical_types,
+    # check if it is a substring of any physical types.
+    if len(widx) == 0:
+        widx = [axis_name in physical_type for physical_type in world_axis_physical_types]
+        widx = np.arange(len(world_axis_physical_types))[widx]
+    if len(widx) != 1:
+        raise ValueError(
+                "Input does not uniquely correspond to a physical type."
+                f" Expected unique substring of one of {world_axis_physical_types}."
+                f"  Got: {physical_type}")
+    # Return axes with duplicates removed.
+    return widx[0]
+
+
+def get_dependent_pixel_axes(pixel_axis, axis_correlation_matrix):
+    """
+    Given a WCS pixel axis index, return indices of dependent WCS pixel axes.
+
+    Both input and output axis indices are in the WCS ordering convention
+    (reverse of numpy ordering convention). The returned axis indices include the input axis.
+
+    Parameters
+    ----------
+    wcs_axis: `int`
+        Index of axis (in WCS ordering convention) for which dependent axes are desired.
+
+    axis_correlation_matrix: `numpy.ndarray` of `bool`
+        2D boolean correlation matrix defining the dependence between the pixel and world axes.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+
+    Returns
+    -------
+    dependent_pixel_axes: `np.ndarray` of `int`
+        Sorted indices of pixel axes dependent on input axis in WCS ordering convention.
+    """
+    # The axis_correlation_matrix is (n_world, n_pixel) but we want to know
+    # which pixel coordinates are linked to which other pixel coordinates.
+    # To do this we take a column from the matrix and find if there are
+    # any entries in common with all other columns in the matrix.
+    world_dep = axis_correlation_matrix[:, pixel_axis:pixel_axis + 1]
+    dependent_pixel_axes = np.sort(np.nonzero((world_dep & axis_correlation_matrix).any(axis=0))[0])
+    return dependent_pixel_axes
+
+
+def get_dependent_array_axes(array_axis, axis_correlation_matrix):
+    """
+    Given an array axis, return the indices of dependent array axes.
+
+    Both input and output axis indices are in the numpy ordering convention.
+    The returned axis indices include the input axis.
+
+    Parameters
+    ----------
+    array_axis: `int`
+        Index of array axis (in numpy ordering convention) for which dependent axes are desired.
+
+    axis_correlation_matrix: `numpy.ndarray` of `bool`
+        2D boolean correlation matrix defining the dependence between the pixel and world axes.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+
+    Returns
+    -------
+    dependent_array_axes: `np.ndarray` of `int`
+        Sorted indices of array axes dependent on input axis in numpy ordering convention.
+    """
+    naxes = axis_correlation_matrix.shape[1]
+    pixel_axis = reflect_axis_index(array_axis, naxes)
+    dependent_pixel_axes = get_dependent_pixel_axes(pixel_axis, axis_correlation_matrix)
+    dependent_array_axes = reflect_axis_index(dependent_pixel_axes, naxes)
+
+
+def get_dependent_world_axes(world_axis, axis_correlation_matrix):
+    """
+    Given a WCS world axis index, return indices of dependent WCS world axes.
+
+    Both input and output axis indices are in the WCS ordering convention
+    (reverse of numpy ordering convention). The returned axis indices include the input axis.
+
+    Parameters
+    ----------
+    world_axis: `int`
+        Index of axis (in WCS ordering convention) for which dependent axes are desired.
+
+    axis_correlation_matrix: `numpy.ndarray` of `bool`
+        2D boolean correlation matrix defining the dependence between the pixel and world axes.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+
+    Returns
+    -------
+    dependent_world_axes: `np.ndarray` of `int`
+        Sorted indices of pixel axes dependent on input axis in WCS ordering convention.
+    """
+    # The axis_correlation_matrix is (n_world, n_pixel) but we want to know
+    # which world coordinates are linked to which other world coordinates.
+    # To do this we take a row from the matrix and find if there are
+    # any entries in common with all other rows in the matrix.
+    pixel_dep = axis_correlation_matrix[world_axis:world_axis + 1]
+    dependent_world_axes = np.sort(np.nonzero((pixel_dep & axis_correlation_matrix).any(axis=1))[0])
+    return dependent_world_axes

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -176,7 +176,7 @@ def reflect_axis_index(axis, naxes):
 
     Returns
     -------
-    reflected_axis: `numpy.ndarray` of `int
+    reflected_axis: `numpy.ndarray` of `int`
         The axis number(s) after reflection.
     """
     # Check type of input.
@@ -249,10 +249,10 @@ def pixel_axis_to_physical_types(pixel_axis, wcs):
     wcs: `astropy.wcs.BaseLowLevelWCS`
         The WCS object defining the relationship between pixel and world axes.
 
-   Returns
-   -------
-   physical_types: `numpy.ndarray` of `str`
-       The physical types corresponding to the pixel axis.
+    Returns
+    -------
+    physical_types: `numpy.ndarray` of `str`
+        The physical types corresponding to the pixel axis.
     """
     return np.array(wcs.world_axis_physical_types)[wcs.axis_correlation_matrix[:, pixel_axis]]
 
@@ -269,10 +269,10 @@ def physical_type_to_pixel_axes(physical_type, wcs):
     wcs: `astropy.wcs.BaseLowLevelWCS`
         The WCS object defining the relationship between pixel and world axes.
 
-   Returns
-   -------
-   pixel_axes: `numpy.ndarray`
-       The pixel axis indices corresponding to the physical type.
+    Returns
+    -------
+    pixel_axes: `numpy.ndarray`
+        The pixel axis indices corresponding to the physical type.
     """
     world_axis = physical_type_to_world_axis(physical_type, wcs.world_axis_physical_types)
     return world_axis_to_pixel_axes(world_axis, wcs.axis_correlation_matrix)

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -206,7 +206,7 @@ def pixel_axis_to_world_axes(pixel_axis, axis_correlation_matrix):
 
     axis_correlation_matrix: `numpy.ndarray` of `bool`
         2D boolean correlation matrix defining the dependence between the pixel and world axes.
-        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix`.
 
     Returns
     -------
@@ -227,7 +227,7 @@ def world_axis_to_pixel_axes(world_axis, axis_correlation_matrix):
 
     axis_correlation_matrix: `numpy.ndarray` of `bool`
         2D boolean correlation matrix defining the dependence between the pixel and world axes.
-        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix`.
 
     Returns
     -------
@@ -329,7 +329,7 @@ def get_dependent_pixel_axes(pixel_axis, axis_correlation_matrix):
 
     axis_correlation_matrix: `numpy.ndarray` of `bool`
         2D boolean correlation matrix defining the dependence between the pixel and world axes.
-        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix`.
 
     Returns
     -------
@@ -359,7 +359,7 @@ def get_dependent_array_axes(array_axis, axis_correlation_matrix):
 
     axis_correlation_matrix: `numpy.ndarray` of `bool`
         2D boolean correlation matrix defining the dependence between the pixel and world axes.
-        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix`.
 
     Returns
     -------
@@ -387,7 +387,7 @@ def get_dependent_world_axes(world_axis, axis_correlation_matrix):
 
     axis_correlation_matrix: `numpy.ndarray` of `bool`
         2D boolean correlation matrix defining the dependence between the pixel and world axes.
-        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix`.
 
     Returns
     -------


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR does two things:
  1. Removes unused util functions.
  2. Refactors the functions that convert between data and WCS axes.  In doing some new conversions are created.

The second a point is needed since the introduction of APE14 for astropy WCS.  Among other things, this draws a much more explicit distinction between array axes, WCS pixel axes (the reverse order of array axes) and WCS world axes which correspond to the world axis physical types.  This is because there is not always a 1-to-1 mapping from pixel axes to world axes/physical types.  Previously, ```ndcube``` code only converted between array (data) axes and WCS axes which is now ambiguous, or at the very least confusing because it wrapped the array-to-pixel (WCS order) mapping with the pixel-to-physical type mapping.  These new functions make this clearer and more explicit.

Nine new functions have been created, a couple of which are just rebranded old functions to match the new array-pixel-world naming convention and minimize the complexity of required inputs.  But the rest are either new or proper refactors.  They are described below and are grouped in 3 categories: conversions between array and WCS pixel axes, conversions between WCS pixel axes, world axes, and physical types, and dependent axes functions.

#### Array/WCS pixel Conversions
* ```reflect_axis_index()```: Converts between array (data) axes and WCS pixel axes.  (Effectively reflecting the axis number through about the mean of the number of array/pixel dimensions.  This function works in either direction as the mapping is symmetric.  It is also vectorized so an array of array or pixel axes can be input at one time.

#### WCS pixel/world/physical types Conversions
These functions convert between pixel axis indices (defined in the WCS ordering convention), world axes (which are the indices of the relevant physical types in ```wcs.world_axis_physical_types```), and physical types.  As different pixel axes will have different numbers of world axes/physical types corresponding to them (and vice versa), these functions are not vectorized.  The fact that more then one axis can be returned from a single input axes is reflected by the fact that the input is axis type in the function name is singular, while the output type is plural.
* ```pixel_axis_to_world_axes```: Gives the world axes that are dependent on the supplied pixel axis.
* ```world_axis_to_pixel_axes```: Gives the pixel axes that are dependent on the supplied world axis.
* ```pixel_axis_to_physical_types```: Gives the physical types that are dependent on the supplied pixel axis.
* ```physical_type_to_pixel_axes```: Gives the pixel axes that are dependent on the supplied physical type.
* ```physical_type_to_world_axis```: Gives the world axes that are dependent on the supplied physical type.  This is called by ```physical_type_to_pixel_axes``` and is not trivial because it allows unique substrings to be supplied.

The mapping from ```world_axis``` to ```physical_type``` is trivial and so not included.

#### Dependent Axes
* ```get_dependent_pixel_axes```: Given a pixel axis index (WCS ordering), return all WCS pixel axis indices dependent on it, including itself.
* ```get_dependent_array_axes```: Given an array axis index (numpy ordering), return all array axis indices dependent on it, including itself.
* ```get_dependent_world_axes```: Given a world axis index (WCS ordering), return all WCS world axis indices dependent on it, including itself.

The corresponding ```get_dependent_physical_types``` is not supplied but could be.  However, this should simply be 
```python
def get_dependent_physical_types(physical_type, wcs):
    world_axis = physical_type_to_world_axis(physical_type, wcs.world_axis_physical_types)
    dependent_world_axes = get_dependent_world_axes(world_axis, wcs.axis_correlation_matrix)
    dependent_physical_types = np.array(wcs.world_axis_physical_types)[dependent_world_axes]
    return dependent_physical_types
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
