### PR TITLE
Method on NDCube for showing physical axes for each array axis

### DIFF
--- a/changelog/281.feature.rst
+++ b/changelog/281.feature.rst
@@ -1,1 +1,1 @@
-New method on NDCube (array_axis_physical_types) to show which physical types are associated with each array axis.
+Added a new method `ndcube.NDCube.array_axis_physical_types` to show which physical types are associated with each array axis.

--- a/changelog/281.feature.rst
+++ b/changelog/281.feature.rst
@@ -1,0 +1,1 @@
+New method on NDCube (array_axis_physical_types) to show which physical types are associated with each array axis.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -223,6 +223,13 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
         return tuple(ctype[::-1])
 
+    @property
+    def array_axis_physical_types(self):
+        world_axis_physical_types = np.array(self.wcs.world_axis_physical_types)
+        axis_correlation_matrix = self.wcs.axis_correlation_matrix
+        return [tuple(world_axis_physical_types[axis_correlation_matrix[:, i]])
+                for i in range(axis_correlation_matrix.shape[1])][::-1]
+
     def pixel_to_world(self, *quantity_axis_list):
         # The docstring is defined in NDDataBase
 

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -225,6 +225,15 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
     @property
     def array_axis_physical_types(self):
+        """
+        Returns the WCS physical types associated with each array axis.
+
+        Returns an iterable of tuples where each tuple corresponds to an array axis and
+        holds strings denoting the WCS physical types associated with that array axis.
+        Since multiple physical types can be associated with one array axis, tuples can
+        be of different lengths. Likewise, as a single physical type can correspond to
+        multiple array axes, the same physical type string can appear in multiple tuples.
+        """
         world_axis_physical_types = np.array(self.wcs.world_axis_physical_types)
         axis_correlation_matrix = self.wcs.axis_correlation_matrix
         return [tuple(world_axis_physical_types[axis_correlation_matrix[:, i]])

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -996,3 +996,13 @@ def test_explode_along_axis(test_input, expected):
     assert isinstance(output[inp_slice], exp_type_cube)
     assert isinstance(output.meta, exp_meta_seq)
     assert isinstance(output[inp_slice].meta, exp_meta_cube)
+
+
+def test_array_axis_physical_types():
+    expected = [
+            ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat'),
+            ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat'),
+            ('em.wl',), ('time',)]
+    output = cube.array_axis_physical_types
+    for i in range(len(expected)):
+        assert all([physical_type in expected[i] for physical_type in output[i]])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR creates a new method on ```NDCube``` that returns the physical types associated with each data/array axis.  For example, given a cube with 4 data axes and 4 world axis physical type, lon, lat, wavelength and time:
```python
>>> cube.array_axis_physical_types
[('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat'),
('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat'),
('em.wl',),
('time',)]
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
