### PR TITLE
Backport PR 281.

### DIFF
--- a/changelog/282.features.rst
+++ b/changelog/282.features.rst
@@ -1,0 +1,1 @@
+Added a new method `ndcube.NDCube.array_axis_physical_types` to show which physical types are associated with each array axis.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -259,6 +259,22 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         return tuple(axes_ctype[::-1])
 
     @property
+    def array_axis_physical_types(self):
+        """
+        Returns the WCS physical types associated with each array axis.
+
+        Returns an iterable of tuples where each tuple corresponds to an array axis and
+        holds strings denoting the WCS physical types associated with that array axis.
+        Since multiple physical types can be associated with one array axis, tuples can
+        be of different lengths. Likewise, as a single physical type can correspond to
+        multiple array axes, the same physical type string can appear in multiple tuples.
+        """
+        world_axis_physical_types = np.array(self.wcs.world_axis_physical_types)
+        axis_correlation_matrix = self.wcs.axis_correlation_matrix
+        return [tuple(world_axis_physical_types[axis_correlation_matrix[:, i]])
+                for i in range(axis_correlation_matrix.shape[1])][::-1]
+
+    @property
     def missing_axis(self):
         warnings.warn(
             ("The missing_axis list has been deprecated by missing_axes"

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -9,7 +9,7 @@ import astropy.units as u
 
 from ndcube import utils
 from ndcube.ndcube_sequence import NDCubeSequence
-from ndcube.utils.wcs import wcs_ivoa_mapping
+from ndcube.utils.wcs import wcs_ivoa_mapping, reduced_correlation_matrix_and_world_physical_types
 from ndcube.utils.cube import _pixel_centers_or_edges, _get_dimension_for_pixel
 from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
 
@@ -269,8 +269,10 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         be of different lengths. Likewise, as a single physical type can correspond to
         multiple array axes, the same physical type string can appear in multiple tuples.
         """
-        world_axis_physical_types = np.array(self.wcs.world_axis_physical_types)
-        axis_correlation_matrix = self.wcs.axis_correlation_matrix
+        axis_correlation_matrix, world_axis_physical_types = \
+                reduced_correlation_matrix_and_world_physical_types(
+                        self.wcs.axis_correlation_matrix, self.wcs.world_axis_physical_types,
+                        self.missing_axes)
         return [tuple(world_axis_physical_types[axis_correlation_matrix[:, i]])
                 for i in range(axis_correlation_matrix.shape[1])][::-1]
 

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -940,3 +940,13 @@ def test_explode_along_axis(test_input, expected):
     assert isinstance(output[inp_slice], exp_type_cube)
     assert isinstance(output.meta, exp_meta_seq)
     assert isinstance(output[inp_slice].meta, exp_meta_cube)
+
+
+def test_array_axis_physical_types():
+    expected = [
+            ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat'),
+            ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat'),
+            ('em.wl',), ('time',)]
+    output = cube.array_axis_physical_types
+    for i in range(len(expected)):
+        assert all([physical_type in expected[i] for physical_type in output[i]])

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -439,3 +439,75 @@ def append_sequence_axis_to_wcs(wcs_object):
                        "Coordinate value at reference point"))
     wcs_header["WCSAXES"] = dummy_number
     return WCS(wcs_header)
+
+
+def reduced_axis_correlation_matrix(axis_correlation_matrix, missing_axes,
+                                    return_world_indices=False):
+    """
+    Return axis correlation matrix with missing axes removed.
+
+    This is needed because ndcube 1.3.x does not use astropy.nddata to slice WCSs.
+    Will be removed in ndcube 2.0.
+
+    Parameters
+    ----------
+    axis_correlation_matrix: `numpy.ndarray` of `bool`
+        2D boolean correlation matrix defining the dependence between the pixel and world axes.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix`.
+
+    missing_axes: `list` of `bool`
+        Denotes axes in WCS for which the corresponding data axis is missing.
+
+    return_world_indices: `bool`
+        If True, the indices of the world_axis_physical_types corresponding to the
+        reduced matrix are returned.
+        Default=False
+
+    Returns
+    -------
+    reduced_matrix: `numpy.ndarray` of `bool`
+        axis_correlation_matrix with missing axes removed.
+    """
+    # Remove missing pixel axes
+    pixel_axes = np.invert(missing_axes)
+    reduced_matrix = axis_correlation_matrix[:, pixel_axes]
+    # Remove world axes which now no longer correspond to a pixel axis.
+    world_axes = [reduced_matrix[i].any() for i in range(axis_correlation_matrix.shape[0])]
+    reduced_matrix = reduced_matrix[world_axes]
+    if return_world_indices:
+        return reduced_matrix, world_axes
+    else:
+        return reduced_matrix
+
+
+def reduced_correlation_matrix_and_world_physical_types(
+        axis_correlation_matrix, world_axis_physical_types, missing_axes):
+    """
+    Return axis correlation matrix with missing axes removed.
+
+    This is needed because ndcube 1.3.x does not use astropy.nddata to slice WCSs.
+    Will be removed in ndcube 2.0.
+
+    Parameters
+    ----------
+    axis_correlation_matrix: `numpy.ndarray` of `bool`
+        2D boolean correlation matrix defining the dependence between the pixel and world axes.
+        Format same as `astropy.wcs.BaseLowLevelWCS.axis_correlation_matrix`.
+
+    world_axis_physical_types: iterable of `str`
+        The physical types corresponding to the world axes of the axis correlation matrix.
+
+    missing_axes: `list` of `bool`
+        Denotes axes in WCS for which the corresponding data axis is missing.
+
+    Returns
+    -------
+    reduced_matrix: `numpy.ndarray` of `bool`
+        axis_correlation_matrix with missing axes removed.
+
+    reduced_physical_types: `numpy.ndarray` of `str`
+        The physical types corresponding to the reduced matrix.
+    """
+    reduced_matrix, world_axes = reduced_axis_correlation_matrix(axis_correlation_matrix, missing_axes, return_world_indices=True)
+    reduced_physical_types = np.array(world_axis_physical_types)[world_axes]
+    return reduced_matrix, reduced_physical_types


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
This PR backports PR #281 to the 1.3 branch, adding ```NDCube.array_axis_physical_types``` that associates world types with NDCube's array axes.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
