### PR TITLE
Backport #279

### DIFF
--- a/changelog/283.feature.rst
+++ b/changelog/283.feature.rst
@@ -1,0 +1,1 @@
+Add new method, `~ndcube.NDCube.axis_world_coord_values`, to return world coords for all pixels for all axes in WCS as quantity objects.

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -947,6 +947,6 @@ def test_array_axis_physical_types():
             ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat'),
             ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat'),
             ('em.wl',), ('time',)]
-    output = cube.array_axis_physical_types
-    for i in range(len(expected)):
-        assert all([physical_type in expected[i] for physical_type in output[i]])
+    output = cube_disordered.array_axis_physical_types
+    for i, expected_i in enumerate(expected):
+        assert all([physical_type in expected_i for physical_type in output[i]])

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -37,6 +37,34 @@ hm_reindexed_102 = {
 wm_reindexed_102 = utils.wcs.WCS(header=hm_reindexed_102, naxis=3)
 
 
+@pytest.fixture
+def axis_correlation_matrix():
+    return _axis_correlation_matrix()
+
+
+def _axis_correlation_matrix():
+    shape = (4, 4)
+    acm = np.zeros(shape, dtype=bool)
+    for i in range(min(shape)):
+        acm[i, i] = True
+    acm[0, 1] = True
+    acm[1, 0] = True
+    acm[-1, 0] = True
+    return acm
+
+
+@pytest.fixture
+def test_wcs():
+    return TestWCS()
+
+
+class TestWCS():
+    def __init__(self):
+        self.world_axis_physical_types = [
+            'custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl', 'time']
+        self.axis_correlation_matrix = _axis_correlation_matrix()
+
+
 @pytest.mark.parametrize("test_input,expected", [(ht, True), (hm, False)])
 def test_wcs_needs_augmenting(test_input, expected):
     assert utils.wcs.WCS._needs_augmenting(test_input) is expected
@@ -115,3 +143,25 @@ def test_get_dependent_wcs_axes(test_input, expected):
 ])
 def test_axis_correlation_matrix(test_input, expected):
     assert (utils.wcs.axis_correlation_matrix(test_input) == expected).all()
+
+
+def test_convert_between_array_and_pixel_axes():
+    test_input = np.array([1, 4, -2])
+    naxes = 5
+    expected = np.array([3, 0, 1])
+    output = utils.wcs.convert_between_array_and_pixel_axes(test_input, naxes)
+    assert all(output == expected)
+
+
+def test_pixel_axis_to_world_axes(axis_correlation_matrix):
+    output = utils.wcs.pixel_axis_to_world_axes(0, axis_correlation_matrix)
+    expected = np.array([0, 1, 3])
+    assert all(output == expected)
+
+
+@pytest.mark.parametrize("test_input,expected", [('wl', 2), ('em.wl', 2)])
+def test_physical_type_to_world_axis(test_input, expected):
+    world_axis_physical_types = ['custom:pos.helioprojective.lon',
+                                 'custom:pos.helioprojective.lat', 'em.wl', 'time']
+    output = utils.wcs.physical_type_to_world_axis(test_input, world_axis_physical_types)
+    assert output == expected


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request, so you do not need to remove them!
Please be sure to check out our contributing guidelines, https://github.com/sunpy/sunpy/blob/master/CONTRIBUTING.rst.
Please be sure to check out our code of conduct, https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst. -->

<!-- Please just have a quick search on GitHub to see if a similar pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
We have a brief explanation of them in the documentation, http://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration. -->

### Description
<!-- Provide a general description of what your pull request does. -->
Backport PR #279 to the 1.3 branch, adding new method ```NDCube.axis_world_coord_values```.

Depends on backport PR #282.  DO NOT MERGE UNTIL THAT'S MERGE.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line. -->

Fixes #<Issue Number>
