### PR TITLE
Fix a bug in world_axis_coord_values when there is only one dimension in the WCS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,6 @@ jobs:
   parameters:
     submodules: false
     coverage: codecov
-    posargs: -n=4
     envs:
       - macos: py37
         name: py37_test_macos

--- a/changelog/287.bugfix.rst
+++ b/changelog/287.bugfix.rst
@@ -1,0 +1,2 @@
+Fix axis_world_coord_values when the WCS is 1D and ensure it always returns
+Quantities

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -337,6 +337,8 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
         # Get world coords for all axes and all pixels.
         axes_coords = self.wcs.pixel_to_world(*pixel_inputs)
+        if self.wcs.low_level_wcs.world_n_dim == 1:
+            axes_coords = [axes_coords]
 
         # Reduce duplication across independent dimensions for each coord
         # and transpose to make dimensions mimic numpy array order rather than WCS order.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -336,16 +336,18 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                                        indexing='ij', sparse=True)
 
         # Get world coords for all axes and all pixels.
-        axes_coords = self.wcs.pixel_to_world(*pixel_inputs)
+        axes_coords = self.wcs.low_level_wcs.pixel_to_world_values(*pixel_inputs)
         if self.wcs.low_level_wcs.world_n_dim == 1:
             axes_coords = [axes_coords]
+        # Ensure it's a list not a tuple
+        axes_coords = list(axes_coords)
 
         # Reduce duplication across independent dimensions for each coord
         # and transpose to make dimensions mimic numpy array order rather than WCS order.
         for i, axis_coord in enumerate(axes_coords):
             slices = np.array([slice(None)] * self.wcs.world_n_dim)
             slices[np.invert(self.wcs.axis_correlation_matrix[i])] = 0
-            axes_coords[i] = axis_coord[tuple(slices)].T
+            axes_coords[i] = axis_coord[tuple(slices)].T * u.Unit(self.wcs.low_level_wcs.world_axis_units[i])
 
         world_axis_physical_types = self.wcs.world_axis_physical_types
         # If user has supplied axes, extract only the

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -919,7 +919,8 @@ def test_crop_by_extra_coord(test_input, expected):
 
 @pytest.mark.parametrize("test_input,expected", [
     ((cubem, [2]), (u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m),)),
-    ((cubem, ['em']), (u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m),))
+    ((cubem, ['em']), (u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m),)),
+    ((cubem[0, 0], []), (u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m),))
 ])
 def test_all_world_coords_with_input(test_input, expected):
     all_coords = test_input[0].axis_world_coord_values(*test_input[1])

--- a/ndcube/tests/test_utils_wcs.py
+++ b/ndcube/tests/test_utils_wcs.py
@@ -48,10 +48,10 @@ def _axis_correlation_matrix():
 
 @pytest.fixture
 def test_wcs():
-    return TestWCS()
+    return WCSTest()
 
 
-class TestWCS():
+class WCSTest():
     def __init__(self):
         self.world_axis_physical_types = [
             'custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl', 'time']


### PR DESCRIPTION
For reasons of being nice to the user but unpleasant to the library developer the return type of `pixel_to_world` and `pixel_to_world_values` changes if n_dim == 1. This fixes a bug where the number of axes in the input WCS is 1, and adds a regression test.