### PR TITLE
Backport 1.3: Change name of Spectrogram.axis_world_coord_values

### DIFF
--- a/changelog/293.bugfix.rst
+++ b/changelog/293.bugfix.rst
@@ -1,0 +1,1 @@
+Change name of NDCube.axis_world_coord_values to NDCube.axis_world_coords_values to be consistent with NDCube.axis_world_coords

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -450,7 +450,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         else:
             return tuple(axes_coords)
 
-    def axis_world_coord_values(self, *axes, edges=False):
+    def axis_world_coords_values(self, *axes, edges=False):
         """
         Returns WCS coordinate values of all pixels for desired axes.
 

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -884,8 +884,8 @@ def test_ndcubeordered(test_input, expected):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    ((cubem, [2]), u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m)),
-    ((cubem, ['em']), u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m))
+    ((cubem, [2]), (u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m),)),
+    ((cubem, ['em']), (u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m),))
 ])
 def test_all_world_coords_with_input(test_input, expected):
     all_coords = test_input[0].axis_world_coords_values(*test_input[1])
@@ -895,8 +895,8 @@ def test_all_world_coords_with_input(test_input, expected):
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    ((cubem, [2]), u.Quantity([1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09], unit=u.m)),
-    ((cubem, ['em']), u.Quantity([1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09], unit=u.m))
+    ((cubem, [2]), (u.Quantity([1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09], unit=u.m),)),
+    ((cubem, ['em']), (u.Quantity([1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09], unit=u.m),))
 ])
 def test_all_world_coord_values_with_input_and_kwargs(test_input, expected):
     all_coords = test_input[0].axis_world_coords_values(*test_input[1], **{"edges": True})
@@ -915,7 +915,8 @@ def test_all_world_coord_values_with_input_and_kwargs(test_input, expected):
                                     [1., 1., 1.]], unit=u.deg),
                         u.Quantity([[1.26915033e-05, 4.99987815e-01, 9.99962939e-01],
                                     [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]],
-                                   unit=u.deg)))
+                                   unit=u.deg),
+                        u.Quantity([1.02e-09], unit=u.m)))
 ])
 def test_axis_world_coords_values_without_input(test_input, expected):
     all_coords = test_input.axis_world_coords_values()

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -888,7 +888,7 @@ def test_ndcubeordered(test_input, expected):
     ((cubem, ['em']), u.Quantity([1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09], unit=u.m))
 ])
 def test_all_world_coords_with_input(test_input, expected):
-    all_coords = test_input[0].axis_world_coords(*test_input[1])
+    all_coords = test_input[0].axis_world_coords_values(*test_input[1])
     for i in range(len(all_coords)):
         np.testing.assert_allclose(all_coords[i].value, expected[i].value)
         assert all_coords[i].unit == expected[i].unit
@@ -898,8 +898,8 @@ def test_all_world_coords_with_input(test_input, expected):
     ((cubem, [2]), u.Quantity([1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09], unit=u.m)),
     ((cubem, ['em']), u.Quantity([1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09], unit=u.m))
 ])
-def test_all_world_coords_with_input_and_kwargs(test_input, expected):
-    all_coords = test_input[0].axis_world_coords(*test_input[1], **{"edges": True})
+def test_all_world_coord_values_with_input_and_kwargs(test_input, expected):
+    all_coords = test_input[0].axis_world_coords_values(*test_input[1], **{"edges": True})
     for i in range(len(all_coords)):
         np.testing.assert_allclose(all_coords[i].value, expected[i].value)
         assert all_coords[i].unit == expected[i].unit
@@ -917,8 +917,8 @@ def test_all_world_coords_with_input_and_kwargs(test_input, expected):
                                     [1.26918126e-05, 5.00000000e-01, 9.99987308e-01]],
                                    unit=u.deg)))
 ])
-def test_axis_world_coords_without_input(test_input, expected):
-    all_coords = test_input.axis_world_coords()
+def test_axis_world_coords_values_without_input(test_input, expected):
+    all_coords = test_input.axis_world_coords_values()
     for i in range(len(all_coords)):
         np.testing.assert_allclose(all_coords[i].value, expected[i].value)
         assert all_coords[i].unit == expected[i].unit


### PR DESCRIPTION
Change to ```Spectrogram.axis_world_coords_values``` to make it consistent with ```Spectrogram.axis_world_coords```.  This PR backports the changes from #293 to the 1.3 branch.