### PR TITLE
Change NDCubeSequence ImageAnimators parent class to ArrayAnimatorWCS.

### DIFF
--- a/changelog/294.breaking.1.rst
+++ b/changelog/294.breaking.1.rst
@@ -1,0 +1,1 @@
+NDCubeSequence animation axes can no longer be set by extra coords.

--- a/changelog/294.breaking.2.rst
+++ b/changelog/294.breaking.2.rst
@@ -1,0 +1,1 @@
+ImageAnimatorNDCubeSequence, ImageAnimatorCubeLikeNDCubeSequence, LineAnimatorNDCubeSequence and LineAnimatorCubeLikeNDCubeSequence have been removed and replaced by NDCubeSequenceAnimator. 

--- a/changelog/294.bugfix.rst
+++ b/changelog/294.bugfix.rst
@@ -1,0 +1,1 @@
+Remove NDCubeSequence animation dependence of deprecated sunpy ImageAnimator and LineAnimator classes in favour of ArrayAnimatorWCS class.

--- a/ndcube/mixins/sequence_plotting.py
+++ b/ndcube/mixins/sequence_plotting.py
@@ -5,7 +5,7 @@ import astropy.units as u
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-from sunpy.visualization.animator import ArrayAnimatorWCS, LineAnimator
+from sunpy.visualization.animator import ArrayAnimatorWCS
 
 from ndcube import utils
 from ndcube.utils.cube import _get_extra_coord_edges
@@ -107,27 +107,15 @@ class NDCubeSequencePlotMixin:
             ax = self._plot_1D_sequence(axes_coordinates,
                                         axes_units, data_unit, **kwargs)
         else:
-            if len(plot_axis_indices) == 1:
-                # Since sequence has more than 1 dimension and number of plot axes is 1,
-                # produce a 1D line animation.
-                if axes_units is not None:
-                    unit_x_axis = axes_units[plot_axis_indices[0]]
-                else:
-                    unit_x_axis = None
-                ax = LineAnimatorNDCubeSequence(self, plot_axis_indices[0], axes_coordinates,
-                                                unit_x_axis, data_unit, **kwargs)
-            elif len(plot_axis_indices) == 2:
-                if naxis == 2:
-                    # Since sequence has 2 dimensions and number of plot axes is 2,
-                    # produce a 2D image.
-                    ax = self._plot_2D_sequence(plot_axis_indices, axes_coordinates,
-                                                axes_units, data_unit, **kwargs)
-                else:
-                    # Since sequence has more than 2 dimensions and number of plot axes is 2,
-                    # produce a 2D animation.
-                    ax = ImageAnimatorNDCubeSequence(
-                            self, plot_axis_indices=plot_axis_indices, axes_units=axes_units,
-                            data_unit=data_unit, **kwargs)
+            if len(plot_axis_indices) == 2 and naxis == 2:
+                # If there are 2 plot axes and only 2 dimensions produce a 2D image.
+                ax = self._plot_2D_sequence(plot_axis_indices, axes_coordinates,
+                                            axes_units, data_unit, **kwargs)
+            else:
+                # Else produce an image or line animation depending number of plot axes.
+                ax = NDCubeSequenceAnimator(
+                        self, plot_axis_indices=plot_axis_indices, axes_units=axes_units,
+                        data_unit=data_unit, **kwargs)
         return ax
 
     def plot_as_cube(self, axes=None, plot_axis_indices=None,
@@ -224,29 +212,15 @@ class NDCubeSequencePlotMixin:
             ax = self._plot_2D_sequence_as_1Dline(axes_coordinates, axes_units, data_unit,
                                                   **kwargs)
         else:
-            if len(plot_axis_indices) == 1:
-                # Since sequence has more than 1 cube-like dimension and
-                # number of plot axes is 1, produce a 1D line animation.
-                if axes_units is not None:
-                    unit_x_axis = axes_units[plot_axis_indices[0]]
-                else:
-                    unit_x_axis = None
-                ax = LineAnimatorCubeLikeNDCubeSequence(self, plot_axis_indices[0],
-                                                        axes_coordinates, unit_x_axis,
-                                                        data_unit=data_unit, **kwargs)
-            elif len(plot_axis_indices) == 2:
-                if naxis == 2:
-                    # Since sequence has 2 cube-like dimensions and
-                    # number of plot axes is 2, produce a 2D image.
-                    ax = self._plot_3D_sequence_as_2Dimage(axes, plot_axis_indices,
-                                                           axes_coordinates, axes_units,
-                                                           data_unit, **kwargs)
-                else:
-                    # Since sequence has more than 2 cube-like dimensions and
-                    # number of plot axes is 2, produce a 2D animation.
-                    ax = ImageAnimatorCubeLikeNDCubeSequence(
-                        self, plot_axis_indices=plot_axis_indices, axes_units=axes_units,
-                        data_unit=data_unit, **kwargs)
+            if len(plot_axis_indices) == 2 and naxis == 2:
+                # If there are 2 plot axes and only 2 cube-like dimensions produce a 2D image.
+                ax = self._plot_3D_sequence_as_2Dimage(axes, plot_axis_indices, axes_coordinates,
+                                                       axes_units, data_unit, **kwargs)
+            else:
+                # Else produce an image or line animation depending number of plot axes.
+                ax = NDCubeSequenceCubeLikeAnimator(
+                    self, plot_axis_indices=plot_axis_indices, axes_units=axes_units,
+                    data_unit=data_unit, **kwargs)
         return ax
 
     def _plot_1D_sequence(self, axes_coordinates=None,
@@ -660,9 +634,12 @@ class NDCubeSequencePlotMixin:
         return ax
 
 
-class ImageAnimatorNDCubeSequence(ArrayAnimatorWCS):
+class NDCubeSequenceAnimator(ArrayAnimatorWCS):
     """
     Animates N-dimensional data with the associated astropy WCS object.
+
+    This class acts as an API translator between `ndcube.NDCubeSequence.plot`
+    and `sunpy.visualization.animator.ArrayAnimatorWCS`
 
     The following keyboard shortcuts are defined in the viewer:
 
@@ -715,8 +692,9 @@ class ImageAnimatorNDCubeSequence(ArrayAnimatorWCS):
 
     Extra keywords are passed to parent class.
     """
-    def __init__(self, seq, wcs=None, plot_axis_indices=None, axes_units=None, data_unit=None,
+    def __init__(self, seq, plot_axis_indices=None, axes_units=None, data_unit=None,
                  **kwargs):
+        print(plot_axis_indices)
         wcs = seq[0].wcs
         # Determine units of each cube in sequence.
         sequence_units, data_unit = _determine_sequence_units(seq.data, data_unit)
@@ -739,7 +717,7 @@ class ImageAnimatorNDCubeSequence(ArrayAnimatorWCS):
                 np.array(plot_axis_indices), n_seq_dims)
         slices = [0] * n_seq_dims
         slices[slices_indices[-1]] = 'y'
-        slices[plot_axis_indices[0]] = 'x'
+        slices[slices_indices[0]] = 'x'
         # Construct coord params input
         if axes_units is not None:
             coord_params = None  # In future construct axis unit helpers.
@@ -749,7 +727,7 @@ class ImageAnimatorNDCubeSequence(ArrayAnimatorWCS):
         super().__init__(data_stack, new_wcs, slices, coord_params=coord_params, **kwargs)
 
 
-class ImageAnimatorCubeLikeNDCubeSequence(ArrayAnimatorWCS):
+class NDCubeSequenceCubeLikeAnimator(ArrayAnimatorWCS):
     """
     Animates N-dimensional data with the associated astropy WCS object.
 
@@ -840,426 +818,6 @@ class ImageAnimatorCubeLikeNDCubeSequence(ArrayAnimatorWCS):
             coord_params = None
 
         super().__init__(data_concat, wcs, slices, coord_params=coord_params, **kwargs)
-
-
-class LineAnimatorNDCubeSequence(LineAnimator):
-    """
-    Animates N-dimensional data with the associated astropy WCS object.
-
-    The following keyboard shortcuts are defined in the viewer:
-
-    left': previous step on active slider
-    right': next step on active slider
-    top': change the active slider up one
-    bottom': change the active slider down one
-    'p': play/pause active slider
-
-    This viewer can have user defined buttons added by specifying the labels
-    and functions called when those buttons are clicked as keyword arguments.
-
-    Parameters
-    ----------
-    seq: `ndcube.datacube.CubeSequence`
-        The list of cubes.
-
-    image_axes: `list`
-        The two axes that make the image
-
-    fig: `matplotlib.figure.Figure`
-        Figure to use
-
-    axis_ranges: list of physical coordinates for array or None
-        If None array indices will be used for all axes.
-        If a list it should contain one element for each axis of the numpy array.
-        For the image axes a [min, max] pair should be specified which will be
-        passed to :func:`matplotlib.pyplot.imshow` as extent.
-        For the slider axes a [min, max] pair can be specified or an array the
-        same length as the axis which will provide all values for that slider.
-        If None is specified for an axis then the array indices will be used
-        for that axis.
-        The physical coordinates expected by axis_ranges should be an array of
-        pixel_edges.
-
-    interval: `int`
-        Animation interval in ms
-
-    colorbar: `bool`
-        Plot colorbar
-
-    button_labels: `list`
-        List of strings to label buttons
-
-    button_func: `list`
-        List of functions to map to the buttons
-
-    unit_x_axis: `astropy.units.Unit`
-        The unit of x axis.
-
-    unit_y_axis: `astropy.units.Unit`
-        The unit of y axis.
-
-    Extra keywords are passed to imshow.
-    """
-
-    def __init__(self, seq, plot_axis_index=None, axis_ranges=None, unit_x_axis=None,
-                 data_unit=None, xlabel=None, ylabel=None, xlim=None, ylim=None, **kwargs):
-        if plot_axis_index is None:
-            plot_axis_index = -1
-        # Combine data from cubes in sequence. If all cubes have a unit,
-        # put data into data_unit.
-        sequence_units, data_unit = _determine_sequence_units(seq.data, data_unit)
-        if sequence_units is None:
-            if data_unit is None:
-                data_concat = np.stack([cube.data for i, cube in enumerate(seq.data)])
-            else:
-                raise TypeError(NON_COMPATIBLE_UNIT_MESSAGE)
-        else:
-            data_concat = np.stack([(cube.data * sequence_units[i]).to(data_unit).value
-                                    for i, cube in enumerate(seq.data)])
-
-        # If some cubes have a mask set, convert data to masked array.
-        # If other cubes do not have a mask set, set all mask to False.
-        # If no cubes have a mask, keep data as a simple array.
-        cubes_with_mask = np.array([False if cube.mask is None else True for cube in seq.data])
-        if cubes_with_mask.any():
-            if cubes_with_mask.all():
-                mask_concat = np.stack([cube.mask for cube in seq.data])
-            else:
-                masks = []
-                for i, cube in enumerate(seq.data):
-                    if cubes_with_mask[i]:
-                        masks.append(cube.mask)
-                    else:
-                        masks.append(np.zeros_like(cube.data, dtype=bool))
-                mask_concat = np.stack(masks)
-            data_concat = np.ma.masked_array(data_concat, mask_concat)
-
-        # Ensure plot_axis_index is represented in the positive convention.
-        if plot_axis_index < 0:
-            plot_axis_index = len(seq.dimensions) + plot_axis_index
-        # Calculate the x-axis values if axis_ranges not supplied.
-        if axis_ranges is None:
-            axis_ranges = [None] * len(seq.dimensions)
-            if plot_axis_index == 0:
-                axis_ranges[plot_axis_index] = _get_extra_coord_edges(
-                    np.arange(len(seq.data)), axis=plot_axis_index)
-            else:
-                cube_plot_axis_index = plot_axis_index - 1
-                # Define unit of x-axis if not supplied by user.
-                if unit_x_axis is None:
-                    wcs_plot_axis_index = utils.cube.data_axis_to_wcs_axis(
-                        cube_plot_axis_index, seq[0].missing_axes)
-                    unit_x_axis = np.asarray(seq[0].wcs.wcs.cunit)[wcs_plot_axis_index]
-                # Get x-axis values from each cube and combine into a single
-                # array for axis_ranges kwargs.
-                x_axis_coords = _get_extra_coord_edges(_get_non_common_axis_x_axis_coords(
-                    seq.data, cube_plot_axis_index, unit_x_axis), axis=plot_axis_index)
-                axis_ranges[plot_axis_index] = np.stack(x_axis_coords)
-            # Set x-axis label.
-            if xlabel is None:
-                xlabel = "{} [{}]".format(seq.world_axis_physical_types[plot_axis_index],
-                                          unit_x_axis)
-        else:
-            # If the axis range is being defined by an extra coordinate...
-            if isinstance(axis_ranges[plot_axis_index], str):
-                axis_extra_coord = axis_ranges[plot_axis_index]
-                if plot_axis_index == 0:
-                    # If the sequence axis is the plot axis, use
-                    # sequence_axis_extra_coords to get the extra coord values
-                    # for whole sequence.
-                    x_axis_coords = seq.sequence_axis_extra_coords[axis_extra_coord]
-                    if isinstance(x_axis_coords, u.Quantity):
-                        if unit_x_axis is None:
-                            unit_x_axis = x_axis_coords.unit
-                        else:
-                            x_axis_coords = x_axis_coords.to(unit_x_axis)
-                        x_axis_coords = x_axis_coords.value
-                else:
-                    # Else get extra coord values from each cube and
-                    # combine into a single array for axis_ranges kwargs.
-                    # First, confirm extra coord is of same type and corresponds
-                    # to same axes in each cube.
-                    extra_coord_type = np.empty(len(seq.data), dtype=object)
-                    extra_coord_axes = np.empty(len(seq.data), dtype=object)
-                    x_axis_coords = []
-                    for i, cube in enumerate(seq.data):
-                        cube_axis_extra_coord = cube.extra_coords[axis_extra_coord]
-                        extra_coord_type[i] = type(cube_axis_extra_coord["value"])
-                        extra_coord_axes[i] = cube_axis_extra_coord["axis"]
-                        x_axis_coords.append(cube_axis_extra_coord["value"])
-                    if extra_coord_type.all() == extra_coord_type[0]:
-                        extra_coord_type = extra_coord_type[0]
-                    else:
-                        raise TypeError("Extra coord {} must be of same type for all NDCubes to "
-                                        "use it to define a plot axis.".format(axis_extra_coord))
-                    if extra_coord_axes.all() == extra_coord_axes[0]:
-                        if isinstance(extra_coord_axes[0], numbers.Integral):
-                            extra_coord_axes = [int(extra_coord_axes[0])]
-                        else:
-                            extra_coord_axes = list(extra_coord_axes[0]).sort()
-                    else:
-                        raise ValueError("Extra coord {} must correspond to same axes in each "
-                                         "NDCube to use it to define a plot axis.".format(
-                                             axis_extra_coord))
-                    # If the extra coord is a quantity, convert to the correct unit.
-                    if extra_coord_type is u.Quantity:
-                        if unit_x_axis is None:
-                            unit_x_axis = seq[0].extra_coords[axis_extra_coord]["value"].unit
-                        x_axis_coords = [x_axis_value.to(unit_x_axis).value
-                                         for x_axis_value in x_axis_coords]
-                    # If extra coord is same for each cube, storing
-                    # values as single 1D axis range will suffice.
-                    if ((np.array(x_axis_coords) == x_axis_coords[0]).all() and
-                            (len(extra_coord_axes) == 1)):
-                        x_axis_coords = x_axis_coords[0]
-                    else:
-                        # Else if all axes are not dependent, create an array of x-axis
-                        # coords for each cube that are the same shape as the data in the
-                        # respective cubes where the x coords are replicated in the extra
-                        # dimensions.  Then stack them together along the sequence axis so
-                        # the final x-axis coord array is the same shape as the data array.
-                        # This will be used in determining the correct x-axis coords for
-                        # each frame of the animation.
-
-                        if len(extra_coord_axes) != data_concat.ndim:
-                            x_axis_coords_copy = copy.deepcopy(x_axis_coords)
-                            x_axis_coords = []
-                            for i, x_axis_cube_coords in enumerate(x_axis_coords_copy):
-                                # For each cube in the sequence, use np.tile to replicate
-                                # the x-axis coords through the higher dimensions.
-                                # But first give extra dummy (length 1) dimensions to the
-                                # x-axis coords array so its number of dimensions is the
-                                # same as the cube's data array.
-                                # First, create shape of pre-np.tiled x-coord array for the cube.
-                                coords_reshape = np.array([1] * seq[i].data.ndim)
-                                # Convert x_axis_cube_coords to a numpy array
-                                x_axis_cube_coords = np.array(x_axis_cube_coords)
-                                coords_reshape[extra_coord_axes] = x_axis_cube_coords.shape
-                                # Then reshape x-axis array to give it the dummy dimensions.
-                                x_axis_cube_coords = x_axis_cube_coords.reshape(
-                                    tuple(coords_reshape))
-                                # Now the correct dummy dimensions are in place so the
-                                # number of dimensions in the x-axis coord array equals
-                                # the number of dimensions of the cube's data array,
-                                # replicating the coords through the higher dimensions
-                                # is simple using np.tile.
-                                tile_shape = np.array(seq[i].data.shape)
-                                tile_shape[extra_coord_axes] = 1
-                                x_axis_cube_coords = np.tile(x_axis_cube_coords, tile_shape)
-                                # Append new dimension-ed x-axis coords array for this cube
-                                # sequence x-axis coords list.
-                                x_axis_coords.append(x_axis_cube_coords)
-                        # Stack the x-axis coords along a new axis for the sequence axis so
-                        # its the same shape as the data array.
-                        x_axis_coords = np.stack(x_axis_coords)
-                # Set x-axis label.
-                if xlabel is None:
-                    xlabel = f"{axis_extra_coord} [{unit_x_axis}]"
-                # Re-enter x-axis values into axis_ranges
-                axis_ranges[plot_axis_index] = _get_extra_coord_edges(
-                    x_axis_coords, axis=plot_axis_index)
-            # Else coordinate must have been defined manually.
-            else:
-                if isinstance(axis_ranges[plot_axis_index], u.Quantity):
-                    if unit_x_axis is None:
-                        unit_x_axis = axis_ranges[plot_axis_index].unit
-                        axis_ranges[plot_axis_index] = axis_ranges[plot_axis_index].value
-                    else:
-                        axis_ranges[plot_axis_index] = \
-                            axis_ranges[plot_axis_index].to(unit_x_axis).value
-                else:
-                    if unit_x_axis is not None:
-                        raise TypeError(AXES_UNIT_ERRONESLY_SET_MESSAGE)
-                if xlabel is None:
-                    xlabel = f" [{unit_x_axis}]"
-        # Make label for y-axis.
-        if ylabel is None:
-            ylabel = f"Data [{data_unit}]"
-        super().__init__(
-            data_concat, plot_axis_index=plot_axis_index, axis_ranges=axis_ranges,
-            xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim, **kwargs)
-
-
-class LineAnimatorCubeLikeNDCubeSequence(LineAnimator):
-    """
-    Animates N-dimensional data with the associated astropy WCS object.
-
-    The following keyboard shortcuts are defined in the viewer:
-
-    left': previous step on active slider
-    right': next step on active slider
-    top': change the active slider up one
-    bottom': change the active slider down one
-    'p': play/pause active slider
-
-    This viewer can have user defined buttons added by specifying the labels
-    and functions called when those buttons are clicked as keyword arguments.
-
-    Parameters
-    ----------
-    seq: `ndcube.datacube.CubeSequence`
-        The list of cubes.
-
-    image_axes: `list`
-        The two axes that make the image
-
-    fig: `matplotlib.figure.Figure`
-        Figure to use
-
-    axis_ranges: list of physical coordinates for array or None
-        If None array indices will be used for all axes.
-        If a list it should contain one element for each axis of the numpy array.
-        For the image axes a [min, max] pair should be specified which will be
-        passed to :func:`matplotlib.pyplot.imshow` as extent.
-        For the slider axes a [min, max] pair can be specified or an array the
-        same length as the axis which will provide all values for that slider.
-        If None is specified for an axis then the array indices will be used
-        for that axis.
-        The physical coordinates expected by axis_ranges should be an array of
-        pixel_edges.
-
-    interval: `int`
-        Animation interval in ms
-
-    colorbar: `bool`
-        Plot colorbar
-
-    button_labels: `list`
-        List of strings to label buttons
-
-    button_func: `list`
-        List of functions to map to the buttons
-
-    unit_x_axis: `astropy.units.Unit`
-        The unit of x axis.
-
-    unit_y_axis: `astropy.units.Unit`
-        The unit of y axis.
-
-    Extra keywords are passed to imshow.
-    """
-
-    def __init__(self, seq, plot_axis_index=None, axis_ranges=None, unit_x_axis=None,
-                 data_unit=None, xlabel=None, ylabel=None, xlim=None, ylim=None, **kwargs):
-        if plot_axis_index is None:
-            plot_axis_index = -1
-        # Combine data from cubes in sequence. If all cubes have a unit,
-        # put data into data_unit.
-        sequence_units, data_unit = _determine_sequence_units(seq.data, data_unit)
-        if sequence_units is None:
-            if data_unit is None:
-                data_concat = np.concatenate([cube.data for i, cube in enumerate(seq.data)],
-                                             axis=seq._common_axis)
-            else:
-                raise TypeError(NON_COMPATIBLE_UNIT_MESSAGE)
-        else:
-            data_concat = np.concatenate([(cube.data * sequence_units[i]).to(data_unit).value
-                                          for i, cube in enumerate(seq.data)],
-                                         axis=seq._common_axis)
-
-        # If some cubes have a mask set, convert data to masked array.
-        # If other cubes do not have a mask set, set all mask to False.
-        # If no cubes have a mask, keep data as a simple array.
-        cubes_with_mask = np.array([False if cube.mask is None else True for cube in seq.data])
-        if cubes_with_mask.any():
-            if cubes_with_mask.all():
-                mask_concat = np.concatenate(
-                    [cube.mask for cube in seq.data], axis=seq._common_axis)
-            else:
-                masks = []
-                for i, cube in enumerate(seq.data):
-                    if cubes_with_mask[i]:
-                        masks.append(cube.mask)
-                    else:
-                        masks.append(np.zeros_like(cube.data, dtype=bool))
-                mask_concat = np.concatenate(masks, axis=seq._common_axis)
-            data_concat = np.ma.masked_array(data_concat, mask_concat)
-
-        # Ensure plot_axis_index is represented in the positive convention.
-        if plot_axis_index < 0:
-            plot_axis_index = len(seq.cube_like_dimensions) + plot_axis_index
-        # Calculate the x-axis values if axis_ranges not supplied.
-        if axis_ranges is None:
-            axis_ranges = [None] * len(seq.cube_like_dimensions)
-            # Define unit of x-axis if not supplied by user.
-            if unit_x_axis is None:
-                wcs_plot_axis_index = utils.cube.data_axis_to_wcs_axis(
-                    plot_axis_index, seq[0].missing_axes)
-                unit_x_axis = np.asarray(
-                    seq[0].wcs.wcs.cunit)[np.invert(seq[0].missing_axes)][wcs_plot_axis_index]
-            if plot_axis_index == seq._common_axis:
-                # Determine whether common axis is dependent.
-                x_axis_cube_coords = np.concatenate(
-                    [cube.axis_world_coords(plot_axis_index).to(unit_x_axis).value
-                     for cube in seq.data], axis=plot_axis_index)
-                dependent_axes = utils.wcs.get_dependent_array_axes(
-                    seq[0].wcs, plot_axis_index, seq[0].missing_axes)
-                if len(dependent_axes) > 1:
-                    independent_axes = list(range(data_concat.ndim))
-                    for i in list(dependent_axes)[::-1]:
-                        independent_axes.pop(i)
-                    # Expand dimensionality of x_axis_cube_coords using np.tile
-                    # Create dummy axes for non-dependent axes
-                    cube_like_shape = np.array([int(s.value) for s in seq.cube_like_dimensions])
-                    dummy_reshape = copy.deepcopy(cube_like_shape)
-                    dummy_reshape[independent_axes] = 1
-                    x_axis_cube_coords = x_axis_cube_coords.reshape(dummy_reshape)
-                    # Now get inverse of number of repeats to create full shaped array.
-                    # The repeats is the inverse of dummy_reshape.
-                    tile_shape = copy.deepcopy(cube_like_shape)
-                    tile_shape[np.array(dependent_axes)] = 1
-                    x_axis_coords = _get_extra_coord_edges(
-                        np.tile(x_axis_cube_coords, tile_shape), axis=plot_axis_index)
-            else:
-                # Get x-axis values from each cube and combine into a single
-                # array for axis_ranges kwargs.
-                x_axis_coords = _get_non_common_axis_x_axis_coords(seq.data, plot_axis_index,
-                                                                   unit_x_axis)
-                axis_ranges[plot_axis_index] = _get_extra_coord_edges(
-                    np.concatenate(x_axis_coords, axis=seq._common_axis), axis=plot_axis_index)
-            # Set axis labels and limits, etc.
-            if xlabel is None:
-                xlabel = "{} [{}]".format(
-                    seq.cube_like_world_axis_physical_types[plot_axis_index], unit_x_axis)
-            if ylabel is None:
-                ylabel = f"Data [{data_unit}]"
-            if axis_ranges is None:
-                axis_ranges = [None] * data_concat.ndim
-
-        super().__init__(
-            data_concat, plot_axis_index=plot_axis_index, axis_ranges=axis_ranges,
-            xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim, **kwargs)
-
-
-def _get_non_common_axis_x_axis_coords(seq_data, plot_axis_index, unit_x_axis):
-    """
-    Get coords of an axis from NDCubes and combine into single array.
-    """
-    x_axis_coords = []
-    for i, cube in enumerate(seq_data):
-        # Get the x-axis coordinates for each cube.
-        if unit_x_axis is None:
-            x_axis_cube_coords = cube.axis_world_coords(plot_axis_index).value
-        else:
-            x_axis_cube_coords = cube.axis_world_coords(plot_axis_index).to(unit_x_axis).value
-        # If the returned x-values have fewer dimensions than the cube,
-        # repeat the x-values through the higher dimensions.
-        if x_axis_cube_coords.shape != cube.data.shape:
-            # Get sequence axes dependent and independent of plot_axis_index.
-            dependent_axes = utils.wcs.get_dependent_array_axes(
-                cube.wcs, plot_axis_index, cube.missing_axes)
-            independent_axes = list(range(len(cube.dimensions)))
-            for i in list(dependent_axes)[::-1]:
-                independent_axes.pop(i)
-            # Expand dimensionality of x_axis_cube_coords using np.tile
-            tile_shape = tuple(list(np.array(
-                cube.data.shape)[independent_axes]) + [1] * len(dependent_axes))
-            x_axis_cube_coords = np.tile(x_axis_cube_coords, tile_shape)
-            # Since np.tile puts original array's dimensions as last,
-            # reshape x_axis_cube_coords to cube's shape.
-            x_axis_cube_coords = x_axis_cube_coords.reshape(cube.data.shape)
-        x_axis_coords.append(x_axis_cube_coords)
-    return x_axis_coords
 
 
 def _determine_sequence_units(cubesequence_data, unit=None):

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -71,7 +71,7 @@ def append_sequence_axis_to_wcs(wcs_object):
     wcs_header.append((f"CUNIT{dummy_number}", "pix",
                        "Coordinate value at reference point"))
     wcs_header["WCSAXES"] = dummy_number
-    return WCS(wcs_header)
+    return wcs.WCS(wcs_header)
 
 
 def _pixel_keep(wcs_object):


### PR DESCRIPTION
This fixes bug when using sunpy master, described in Issue #288. ```NDCubeSequence``` was using ```ImageAnimatorWCS``` in its plot infrastructure which has now been removed from sunpy master.  This PR changes the infrastructure to use the replacement animator, ```ArrayAnimatorWCS```.