### PR TITLE
Deprecate world_axis_physical_types properties

### DIFF
--- a/changelog/309.feature.rst
+++ b/changelog/309.feature.rst
@@ -1,0 +1,1 @@
+Add new properties to NDCubeSequence, array_axis_physical_types and cube_like_array_axis_physical_types, and deprecate the world_axis_physical_types properties on NDCube and NDCubeSequence.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -224,8 +224,8 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
     @property
     @deprecated(since='1.4.1',
-                message='NDCube.world_axis_physical_types will be removed in version 2.0. ' + \
-                        'Use NDCube.wcs.world_axis_physical_types or ' + \
+                message='NDCube.world_axis_physical_types will be removed in version 2.0. '
+                        'Use NDCube.wcs.world_axis_physical_types or '
                         'NDCube.array_axis_physical_types instead.')
     def world_axis_physical_types(self):
         """

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1,19 +1,20 @@
 
 import abc
-import warnings
-import textwrap
-import numbers
 from collections import namedtuple
+import numbers
+import textwrap
+import warnings
 
-import numpy as np
 import astropy.nddata
 import astropy.units as u
+from astropy.utils.decorators import deprecated
+import numpy as np
 
-from ndcube import utils
+from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
 from ndcube.ndcube_sequence import NDCubeSequence
+from ndcube import utils
 from ndcube.utils import wcs as wcs_utils
 from ndcube.utils.cube import _pixel_centers_or_edges, _get_dimension_for_pixel
-from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
 
 
 __all__ = ['NDCubeABC', 'NDCubeBase', 'NDCube', 'NDCubeOrdered']
@@ -222,6 +223,10 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         return u.Quantity(self.data.shape, unit=u.pix)
 
     @property
+    @deprecated(since='1.4.1',
+                message='NDCube.world_axis_physical_types will be removed in version 2.0. ' + \
+                        'Use NDCube.wcs.world_axis_physical_types or ' + \
+                        'NDCube.array_axis_physical_types instead.')
     def world_axis_physical_types(self):
         """
         Returns an iterable of strings describing the physical type for each

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -539,7 +539,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
             # Use inferred world axes to extract the desired coord value
             # and corresponding physical types.
             world_indices = np.array(list(world_indices), dtype=int)
-            axes_coords = np.array(axes_coords)[world_indices]
+            axes_coords = np.array(axes_coords, dtype=object)[world_indices]
             world_axis_physical_types = tuple(np.array(world_axis_physical_types)[world_indices])
 
         # Return in array order.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -375,7 +375,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         # Define the dimensions of the cube and the total number of axes.
         cube_dimensions = np.array(self.dimensions.value, dtype=int)
         n_dimensions = cube_dimensions.size
-        world_axis_types = self.world_axis_physical_types
+        world_axis_types = self.wcs.world_axis_physical_types[::-1]
 
         # Determine axis numbers of user supplied axes.
         if axes == ():

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -62,7 +62,7 @@ class NDCubeSequenceBase:
 
     @property
     @deprecated(since='1.4.1',
-                message='NDCubeSequence.world_axis_physical_types will be removed in ndcube 2.0' + \
+                message='NDCubeSequence.world_axis_physical_types will be removed in ndcube 2.0'
                         '.  Use NDCubeSequence.array_axis_physical_types instead.')
     def world_axis_physical_types(self):
         return tuple(["meta.obs.sequence"] + list(self.data[0].world_axis_physical_types))
@@ -88,8 +88,8 @@ class NDCubeSequenceBase:
 
     @property
     @deprecated(since='1.4.1',
-                message='NDCubeSequence.cube_like_world_axis_physical_types will be removed ' + \
-                        'in ndcube 2.0.  ' + \
+                message='NDCubeSequence.cube_like_world_axis_physical_types will be removed '
+                        'in ndcube 2.0.  '
                         'Use NDCubeSequence.cube_like_array_axis_physical_types instead.')
     def cube_like_world_axis_physical_types(self):
         return self.data[0].world_axis_physical_types

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -1,12 +1,13 @@
-import textwrap
 import copy
 import numbers
+import textwrap
 
-import numpy as np
 import astropy.units as u
+from astropy.utils.decorators import deprecated
+import numpy as np
 
-from ndcube import utils
 from ndcube.mixins.sequence_plotting import NDCubeSequencePlotMixin
+from ndcube import utils
 
 __all__ = ['NDCubeSequence']
 
@@ -60,8 +61,15 @@ class NDCubeSequenceBase:
         return tuple(dimensions)
 
     @property
+    @deprecated(since='1.4.1',
+                message='NDCubeSequence.world_axis_physical_types will be removed in ndcube 2.0' + \
+                        '.  Use NDCubeSequence.array_axis_physical_types instead.')
     def world_axis_physical_types(self):
         return tuple(["meta.obs.sequence"] + list(self.data[0].world_axis_physical_types))
+
+    @property
+    def array_axis_physical_types(self):
+        return [("meta.obs.sequence",)] + self.data[0].array_axis_physical_types
 
     @property
     def cube_like_dimensions(self):
@@ -79,8 +87,18 @@ class NDCubeSequenceBase:
         return cube_like_dimensions
 
     @property
+    @deprecated(since='1.4.1',
+                message='NDCubeSequence.cube_like_world_axis_physical_types will be removed ' + \
+                        'in ndcube 2.0.  ' + \
+                        'Use NDCubeSequence.cube_like_array_axis_physical_types instead.')
     def cube_like_world_axis_physical_types(self):
         return self.data[0].world_axis_physical_types
+
+    @property
+    def cube_like_array_axis_physical_types(self):
+        if self._common_axis is None:
+            raise ValueError("Common axis must be set.")
+        return self.data[0].array_axis_physical_types
 
     def __getitem__(self, item):
         if isinstance(item, numbers.Integral):

--- a/ndcube/tests/helpers.py
+++ b/ndcube/tests/helpers.py
@@ -40,7 +40,7 @@ def assert_cubes_equal(test_input, expected_cube):
             type(test_input.uncertainty), type(expected_cube.uncertainty)))
     if test_input.uncertainty is not None:
         assert test_input.uncertainty.array.shape == expected_cube.uncertainty.array.shape
-    assert test_input.world_axis_physical_types == expected_cube.world_axis_physical_types
+    assert test_input.wcs.world_axis_physical_types == expected_cube.wcs.world_axis_physical_types
     assert all(test_input.dimensions.value == expected_cube.dimensions.value)
     assert test_input.dimensions.unit == expected_cube.dimensions.unit
     if type(test_input.extra_coords) is not type(expected_cube.extra_coords):  # noqa


### PR DESCRIPTION
in favor of array_axis_physical_types properties. This required new properties to be added to NDCubeSequence. The world_axis_physical_types properties will be removed in 2.0