### PR TITLE
Replace common_axis_extra_coords with common_axis_coords in NDCubeSequence

### DIFF
--- a/changelog/344.bugfix.1.rst
+++ b/changelog/344.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fixes bug in utils.wcs.array_indices_for_world_objects when the WCS input does not have a world_axis_object_components attribute. The fix causes the low_level_wcs version is tried before the code fails. This enables NDCube.combined_wcs to be used with this function.

--- a/changelog/344.bugfix.1.rst
+++ b/changelog/344.bugfix.1.rst
@@ -1,1 +1,1 @@
-Fixes bug in utils.wcs.array_indices_for_world_objects when the WCS input does not have a world_axis_object_components attribute. The fix causes the low_level_wcs version is tried before the code fails. This enables NDCube.combined_wcs to be used with this function.
+Fixes bug in `~ndcube.utils.wcs.array_indices_for_world_objects` when the WCS input does not have a world_axis_object_components attribute. The fix causes the low_level_wcs version is tried before the code fails. This enables `ndcube.NDCube.combined_wcs` to be used with this function.

--- a/changelog/344.bugfix.2.rst
+++ b/changelog/344.bugfix.2.rst
@@ -1,1 +1,1 @@
-Fixes IndexError in utils.wcs.array_indices_for_world_objects which occured when some of the world axes are dependent.
+Fixes IndexError in `~ndcube.utils.wcs.array_indices_for_world_objects` which occurred when some of the world axes are dependent.

--- a/changelog/344.bugfix.2.rst
+++ b/changelog/344.bugfix.2.rst
@@ -1,0 +1,1 @@
+Fixes IndexError in utils.wcs.array_indices_for_world_objects which occured when some of the world axes are dependent.

--- a/changelog/344.feature.rst
+++ b/changelog/344.feature.rst
@@ -1,0 +1,1 @@
+Implement NDCubeSequence.common_axis_coords to replace NDCubeSequence.common_axis_extra_coords. In contrast to old property, this new property collates coordinates from the wcs as well as extra_coords.

--- a/changelog/344.feature.rst
+++ b/changelog/344.feature.rst
@@ -1,1 +1,1 @@
-Implement NDCubeSequence.common_axis_coords to replace NDCubeSequence.common_axis_extra_coords. In contrast to old property, this new property collates coordinates from the wcs as well as extra_coords.
+Implement `ndcube.NDCubeSequence.common_axis_coords` to replace `~ndcube.NDCubeSequence.common_axis_extra_coords`. In contrast to old property, this new property collates coordinates from the wcs as well as extra_coords.

--- a/changelog/344.removal.rst
+++ b/changelog/344.removal.rst
@@ -1,0 +1,1 @@
+Remove NDCubeSequence.common_axis_extra_coords.  Will be replaced by NDCubeSequence.common_axis_coords

--- a/changelog/344.removal.rst
+++ b/changelog/344.removal.rst
@@ -1,1 +1,1 @@
-Remove NDCubeSequence.common_axis_extra_coords.  Will be replaced by NDCubeSequence.common_axis_coords
+Remove `ndcube.NDCubeSequence.common_axis_extra_coords`.  Will be replaced by `ndcube.NDCubeSequence.common_axis_coords`.

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -139,7 +139,7 @@ class NDCubeSequenceBase:
         common_axis = self._common_axis
         # Get coordinate objects associated with the common axis in all cubes.
         common_axis_names = set.intersection(*[set(cube.array_axis_physical_types[common_axis])
-                                               for cube in self.data]) 
+                                               for cube in self.data])
         common_coords = []
         mappings = []
         for i, cube in enumerate(self.data):

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -135,18 +135,31 @@ class NDCubeSequenceBase:
         return _IndexAsCubeSlicer(self)
 
     @property
-    def common_axis_extra_coords(self):
-        if not isinstance(self._common_axis, int):
-            raise ValueError("Common axis is not set.")
-        # Get names and units of coords along common axis.
-        axis_coord_names, axis_coord_units = utils.sequence._get_axis_extra_coord_names_and_units(
-            self.data, self._common_axis)
-        # Compile dictionary of common axis extra coords.
-        if axis_coord_names is not None:
-            return utils.sequence._get_int_axis_extra_coords(
-                self.data, axis_coord_names, axis_coord_units, self._common_axis)
-        else:
-            return None
+    def common_axis_coords(self):
+        common_axis = self._common_axis
+        # Get coordinate objects associated with the common axis in all cubes.
+        common_axis_names = set.intersection(*[set(cube.array_axis_physical_types[common_axis])
+                                               for cube in self.data]) 
+        common_coords = [cube.axis_world_coords(common_axis, wcs=self.combined_wcs)[0]
+                         for cube in self.data]
+        mappings = [cube.axis_world_coords(common_axis], wcs=self.combined_wcs)[1]
+                    for cube in self.data]
+        # For each coordinate object, generate a list of length-1 objects
+        # along the common axis spanning all cubes.
+        # Assume coordinate objects are returned in the same
+        # order by the WCS of each cube.
+        sequence_coords = []
+        for coord_idx in range(len(common_coords[0])):
+            exploded_coord = []
+            for cube_idx in range(len(common_coords)):
+                coord = common_coords[cube_idx][coord_idx]
+                axis = np.where(np.array(mappings[cube_idx][coord_idx]) == common_axis)[0][0]
+                item = [slice(None)] * len(coord.shape)
+                for i in range(coord.shape[axis]):
+                    item[axis] = i
+                    exploded_coord.append(coord[tuple(item)])
+            sequence.append(exploded_coord)
+        return sequence_coords
 
     @property
     def sequence_axis_coords(self):

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -3,6 +3,7 @@ import unittest
 import astropy.units as u
 import numpy as np
 import pytest
+from astropy.time import Time, TimeDelta
 
 from ndcube import NDCube, NDCubeSequence
 
@@ -151,6 +152,15 @@ def test_cube_like_dimensions(ndc, expected_dimensions):
 def test_cube_like_dimensions_error(ndc):
     with pytest.raises(TypeError):
         ndc.cube_like_dimensions
+
+
+@pytest.mark.parametrize("ndc", (("ndcubesequence_3c_l_ln_lt_cax1",)), indirect=("ndc",))
+def test_common_axis_coords(ndc):
+    common_axis_length = int(ndc.cube_like_dimensions[ndc._common_axis].value)
+    base_time = Time('2000-01-01', format='fits', scale='utc')
+    expected = {'time': [base_time + TimeDelta(60 * i, format='sec')
+                         for i in range(common_axis_length)]}
+    output = ndc.common_axis_coords
 
 
 @pytest.mark.parametrize("ndc", (("ndcubesequence_3c_l_ln_lt_cax1",)), indirect=("ndc",))

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -427,9 +427,13 @@ def array_indices_for_world_objects(wcs, axes=None):
     else:
         world_indices = np.arange(wcs.world_n_dim)
 
-    object_names = np.array([wao_comp[0] for wao_comp in wcs.world_axis_object_components])
+    try:
+        object_names = np.array([wao_comp[0] for wao_comp in wcs.world_axis_object_components])
+    except AttributeError:
+        object_names = np.array([wao_comp[0]
+                                 for wao_comp in wcs.low_level_wcs.world_axis_object_components])
 
-    array_indices = [[]] * len(set(object_names))
+    array_indices = [[]] * len(object_names)
     for world_index, oname in enumerate(object_names):
         # If this world index is deselected by axes= then skip
         if world_index not in world_indices:

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -426,22 +426,20 @@ def array_indices_for_world_objects(wcs, axes=None):
         world_indices = calculate_world_indices_from_axes(wcs, axes)
     else:
         world_indices = np.arange(wcs.world_n_dim)
-
-    try:
-        object_names = np.array([wao_comp[0] for wao_comp in wcs.world_axis_object_components])
-    except AttributeError:
-        object_names = np.array([wao_comp[0]
-                                 for wao_comp in wcs.low_level_wcs.world_axis_object_components])
-
+    object_names = np.array([wao_comp[0]
+                             for wao_comp in wcs.low_level_wcs.world_axis_object_components])
     array_indices = [[]] * len(object_names)
     for world_index, oname in enumerate(object_names):
         # If this world index is deselected by axes= then skip
         if world_index not in world_indices:
             continue
-
+        # Select the first occurence of the object name.
+        # Other occurences are ignored so as to return duplicate coordinate objects.
         oinds = np.atleast_1d(object_names == oname).nonzero()[0][0]
+        # Calculate the array axes corresponding the coordinate's world axis
+        # and enter them into the element of the array indices array corresponding
+        # to the relevant world coordinate object.
         pixel_index = world_axis_to_pixel_axes(world_index, wcs.axis_correlation_matrix)
         array_index = convert_between_array_and_pixel_axes(pixel_index, wcs.pixel_n_dim)
-        array_indices[oinds] = tuple(array_index[::-1])  # Invert to go from pixel order to array order
-
+        array_indices[oinds] = tuple(array_index[::-1])  # Invert from pixel order to array order
     return tuple(ai for ai in array_indices if ai)


### PR DESCRIPTION
This PR introduces a new method on `NDCubeSequence` that uses the 2.0 infrastructure to collate all coordinates associated with the common axis across all cubes in a sequence.  This replaces the old `common_axis_extra_coords` method, but it also gathers coordinates stored in the WCS, not just the extra coords.

In addition, this PR fixes two bugs in `utils.wcs.array_indices_for_world_objects`:
1. When the WCS input does not have a `world_axis_object_components` attribute the `low_level_wcs` version is tried.  This bug applies to the case when the input WCS is a `HighLevelWCSWrapper`, e.g. `NDCube.combined_wcs`.
2. An indexerror is fixed when there are dependent axes present.

Fixes #328 
Fixes #343 