### PR TITLE
Replace NDCollection.aligned_world_axis_physical_types

### DIFF
--- a/changelog/347.feature.rst
+++ b/changelog/347.feature.rst
@@ -1,0 +1,1 @@
+New property, `ndcube.NDCollection.aligned_axis_physical_types`.  This replaces `~ndcube.NDCollection.aligned_world_axis_physical_types` and returns a list of tuples, where each tuple gives the physical types common between all memebers of the collection for a given aligned axis.

--- a/changelog/347.removal.rst
+++ b/changelog/347.removal.rst
@@ -1,0 +1,1 @@
+Remove NDCollection.aligned_world_axis_physical_types.  It will be replaced by `~ndcube.NDCollection.aligned_axis_physical_types`.

--- a/ndcube/tests/test_ndcollection.py
+++ b/ndcube/tests/test_ndcollection.py
@@ -139,10 +139,16 @@ def test_aligned_dimensions(collection, expected_aligned_dimensions):
     assert all(collection.aligned_dimensions == expected_aligned_dimensions)
 
 
-@pytest.mark.parametrize("collection, expected_aligned_types", [
-    (cube_collection, ['em.wl', 'custom:pos.helioprojective.lon',
-                       'custom:pos.helioprojective.lat']),
-    (seq_collection, ['meta.obs.sequence', 'custom:pos.helioprojective.lon',
-                      'custom:pos.helioprojective.lat', 'em.wl'])])
-def test_aligned_world_axis_physical_types(collection, expected_aligned_types):
-    assert set(collection.aligned_world_axis_physical_types) == set(expected_aligned_types)
+@pytest.mark.parametrize("collection, expected", [
+    (cube_collection, [('custom:pos.helioprojective.lat', 'custom:pos.helioprojective.lon'),
+                       ('em.wl',)]),
+    (seq_collection, [('meta.obs.sequence',),
+                      ('custom:pos.helioprojective.lat', 'custom:pos.helioprojective.lon'),
+                      ('custom:pos.helioprojective.lat', 'custom:pos.helioprojective.lon'),
+                      ('em.wl',)])])
+def test_aligned_axis_physical_types(collection, expected):
+    output = collection.aligned_axis_physical_types
+    print(output)
+    assert len(output) == len(expected)
+    for output_axis_types, expect_axis_types in zip(output, expected):
+        assert set(output_axis_types) == set(expect_axis_types)


### PR DESCRIPTION
This PR replaces `NDCollection.aligned_world_axis_physical_types` with a new property, `NDCollection.aligned_axis_physical_types`.  The new property returns the physical types which are common between all members of collection for eachaligned axis.  This behaviour more closely mimics that of `array_axis_physical_types` on `NDCube`.