### PR TITLE
Make return type of NDCube.axis_world_coords consistent.

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -343,7 +343,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
             axes_coords[i] = axis_coord[tuple(slices)].T
 
         if not axes:
-            return axes_coords
+            return tuple(axes_coords)
 
         # Create a mapping from world index in the WCS to object index in axes_coords
         world_index_to_object_index = {}


### PR DESCRIPTION
Fixes #351 