### PR TITLE
Carry over global_coords when slicing NDCube.

### DIFF
--- a/ndcube/mixins/ndslicing.py
+++ b/ndcube/mixins/ndslicing.py
@@ -19,7 +19,9 @@ class NDCubeSlicingMixin(NDSlicingMixin):
         if item is None or (isinstance(item, tuple) and None in item):
             raise IndexError("None indices not supported")
 
-        return super().__getitem__(item)
+        sliced_cube = super().__getitem__(item)
+        sliced_cube._global_coords._internal_coords = self._global_coords._internal_coords
+        return sliced_cube
 
     def _slice(self, item):
         """Construct a set of keyword arguments to initialise a new (sliced)

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -129,6 +129,13 @@ def test_slicing_split_celestial(ndc, item):
                                                               [False, True]], dtype=bool))
 
 
+def test_slicing_preserves_global_coords(ndcube_3d_ln_lt_l):
+    ndc = ndcube_3d_ln_lt_l
+    ndc.global_coords.add('distance', 'pos.distance', 1 * u.m)
+    sndc = ndc[0]
+    assert sndc._global_coords._internal_coords == ndc._global_coords._internal_coords
+
+
 def test_axis_world_coords_wave_ec(ndcube_3d_l_ln_lt_ectime):
     cube = ndcube_3d_l_ln_lt_ectime
 


### PR DESCRIPTION
Fixes #350 