### PR TITLE
Fix bugs in explode along axes

### DIFF
--- a/changelog/358.bugfix.rst
+++ b/changelog/358.bugfix.rst
@@ -1,0 +1,1 @@
+Stop `ndcube.NDCube.explode_along_axis` setting a common axis to the output `~ndcube.NDCubeSequence`.  The output sequence should have no common axis.

--- a/changelog/358.feature.rst
+++ b/changelog/358.feature.rst
@@ -1,0 +1,1 @@
+Allow `ndcube.NDCubeSequence.explode_along_axis` to explode sequence along any axis, not just the common axis.

--- a/docs/data_classes.rst
+++ b/docs/data_classes.rst
@@ -144,9 +144,9 @@ This returns an `~ndcube.NDCubeSequence` with where the sequence axis acts as th
 
 .. code-block:: python
 
-  >>> exploded.dimensions  # doctest: +SKIP
+  >>> exploded.dimensions
   (<Quantity 5. pix>, <Quantity 4. pix>, <Quantity 4. pix>)
-  >>> exploded.array_axis_physical_types  # doctest: +SKIP
+  >>> exploded.array_axis_physical_types
   [('meta.obs.sequence',),
    ('custom:pos.helioprojective.lat', 'custom:pos.helioprojective.lon'),
    ('custom:pos.helioprojective.lat', 'custom:pos.helioprojective.lon')]

--- a/docs/data_classes.rst
+++ b/docs/data_classes.rst
@@ -315,12 +315,12 @@ So to explode along the wavelength axis, we should use an array axis index of ``
 
 .. code-block:: python
 
-  >>> exploded_sequence = my_sequence.explode_along_axis(2)  # doctest: +SKIP
+  >>> exploded_sequence = my_sequence.explode_along_axis(2)
 
   >>> # Check old and new shapes of the squence
-  >>> my_sequence.dimensions  # doctest: +SKIP
+  >>> my_sequence.dimensions
   (<Quantity 4. pix>, <Quantity 4. pix>, <Quantity 4. pix>, <Quantity 5. pix>)
-  >>> exploded_sequence.dimensions  # doctest: +SKIP
+  >>> exploded_sequence.dimensions
   (<Quantity 20. pix>, <Quantity 4. pix>, <Quantity 4. pix>)
 
 Note that an `~ndcube.NDCubeSequence` can be exploded along any axis.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -547,17 +547,16 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
     def explode_along_axis(self, axis):
         """
-        Separates slices of NDCubes along a given cube axis into a
-        NDCubeSequence of (N-1)DCubes.
+        Separates slices of NDCubes along a given axis into an NDCubeSequence of (N-1)DCubes.
 
         Parameters
         ----------
         axis : `int`
-            The axis along which the data is to be changed.
+            The array axis along which the data is to be changed.
 
         Returns
         -------
-        result : `ndcube_sequence.NDCubeSequence`
+        result : `ndcube.NDCubeSequence`
         """
         # If axis is -ve then calculate the axis from the length of the dimensions of one cube
         if axis < 0:
@@ -577,7 +576,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
             # Appending the sliced cubes in the result_cube list
             result_cubes.append(sliced_cube)
         # Creating a new NDCubeSequence with the result_cubes and common axis as axis
-        return NDCubeSequence(result_cubes, common_axis=axis, meta=self.meta)
+        return NDCubeSequence(result_cubes, meta=self.meta)
 
 
 class NDCube(NDCubeBase, NDCubePlotMixin, astropy.nddata.NDArithmeticMixin):

--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -187,11 +187,7 @@ class NDCubeSequenceBase:
         axis : `int`
             The axis along which the data is to be changed.
         """
-        # if axis is None then set axis as common axis.
-        if self._common_axis is not None:
-            if self._common_axis != axis:
-                raise ValueError("axis and common_axis should be equal.")
-        # is axis is -ve then calculate the axis from the length of the dimensions of one cube
+        # If axis is -ve then calculate the axis from the length of the dimensions of one cube.
         if axis < 0:
             axis = len(self.dimensions[1::]) + axis
         # To store the resultant cube

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -120,12 +120,6 @@ def test_explode_along_axis(ndc, axis, expected_dimensions):
     assert exploded_sequence._common_axis is None
 
 
-@pytest.mark.parametrize("ndc, axis", (("ndcubesequence_4c_ln_lt_l_cax1", 0),), indirect=("ndc",))
-def test_explode_along_axis_error(ndc, axis):
-    with pytest.raises(ValueError):
-        ndc.explode_along_axis(axis)
-
-
 @pytest.mark.parametrize("ndc, expected_dimensions",
                          (
                              ("ndcubesequence_4c_ln_lt_l_cax1", (4 * u.pix,


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/newcomers.html#code

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
Fixes a bug in which `NDCube.explode_along_axis` would set a common axis to output `NDCubeSequence`.  This was not desired behavior.

Allows NDCubeSequence to be exploded along any cube axis, not just the common axis.

Fixes #356
FIxes #357 
