### PR TITLE
Maintain common axis through NDCubeSequence.explode_along_axis

### DIFF
--- a/ndcube/ndcube_sequence.py
+++ b/ndcube/ndcube_sequence.py
@@ -202,8 +202,15 @@ class NDCubeSequenceBase:
                 result_cubes_slice[axis] = index
                 # appending the sliced cubes in the result_cube list
                 result_cubes.append(ndcube.__getitem__(tuple(result_cubes_slice)))
+        # Determine common axis for new sequence.
+        if self._common_axis is None or self._common_axis == axis:
+            new_common_axis = None
+        elif self._common_axis > axis:
+            new_common_axis = self._common_axis - 1
+        elif self._common_axis < axis:
+            new_common_axis = self._common_axis
         # creating a new sequence with the result_cubes keeping the meta and common axis as axis
-        return self._new_instance(result_cubes, meta=self.meta)
+        return self._new_instance(result_cubes, common_axis=new_common_axis, meta=self.meta)
 
     def __str__(self):
         return (textwrap.dedent(f"""\

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -108,16 +108,27 @@ def test_index_as_cube(ndc, item, expected_dimensions):
                                                                4 * u.pix)),
                              ("ndcubesequence_4c_ln_lt_l_cax1", 1, (12 * u.pix,
                                                                     2 * u.pix,
-                                                                    4 * u.pix)),
-                             ("ndcubesequence_4c_ln_lt_l", 2, (16 * u.pix,
-                                                               2 * u.pix,
-                                                               3 * u.pix))
+                                                                    4 * u.pix))
                          ),
                          indirect=("ndc",))
-def test_explode_along_axis(ndc, axis, expected_dimensions):
+def test_explode_along_axis_common_axis_None(ndc, axis, expected_dimensions):
     exploded_sequence = ndc.explode_along_axis(axis)
     assert exploded_sequence.dimensions == expected_dimensions
     assert exploded_sequence._common_axis is None
+
+
+@pytest.mark.parametrize("ndc", (('ndcubesequence_4c_ln_lt_l_cax1',)), indirect=("ndc",))
+def test_explode_along_axis_common_axis_same(ndc):
+    exploded_sequence = ndc.explode_along_axis(2)
+    assert exploded_sequence.dimensions == (16*u.pix, 2*u.pix, 3*u.pix)
+    assert exploded_sequence._common_axis == ndc._common_axis
+
+
+@pytest.mark.parametrize("ndc", (('ndcubesequence_4c_ln_lt_l_cax1',)), indirect=("ndc",))
+def test_explode_along_axis_common_axis_changed(ndc):
+    exploded_sequence = ndc.explode_along_axis(0)
+    assert exploded_sequence.dimensions == (8*u.pix, 3*u.pix, 4*u.pix)
+    assert exploded_sequence._common_axis == ndc._common_axis - 1
 
 
 @pytest.mark.parametrize("ndc, expected_dimensions",


### PR DESCRIPTION

<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/newcomers.html#code

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
This PR fixes a bug missed by #358 whereby the common axis was not maintained by `NDCubeSequence.explode_along_axis` when the common axis was not ``None`` and the exploded axis was not the common axis.  This PR adjusts as necessary, rather than drops, the common axis in these scenarios.

Fixes #<Issue Number>
