### PR TITLE
Remove NDCube's inheritance from NDArithmetic

### DIFF
--- a/changelog/361.removal.rst
+++ b/changelog/361.removal.rst
@@ -1,0 +1,2 @@
+Remove NDCube inheritance on NDArithmeticMixin.  Arithmetic methods are currently not supported by NDCube but it is
+intended they will be in the future. This inheritance can be put back at that time.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -579,5 +579,5 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         return NDCubeSequence(result_cubes, meta=self.meta)
 
 
-class NDCube(NDCubeBase, NDCubePlotMixin, astropy.nddata.NDArithmeticMixin):
+class NDCube(NDCubeBase, NDCubePlotMixin):
     pass


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/newcomers.html#code

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
Arithmetic methods are currently not supported by NDCube but it is intended they will be in the future. This inheritance can be put back at that time but should be removed now.

Depends on PR #360.  Merge after that has been merged.

Fixes #<Issue Number>
