### PR TITLE
Add missing docstrings to public attributes

### DIFF
--- a/ndcube/conftest.py
+++ b/ndcube/conftest.py
@@ -451,6 +451,7 @@ def ndcubesequence_3c_l_ln_lt_cax1(wcs_3d_lt_ln_l):
 
     base_time3 = base_time2 + TimeDelta([shape[common_axis] * 60], format='sec')
     gc3 = GlobalCoords()
+    gc3.add('distance', 'custom:distance', 3*u.m)
     cube3 = gen_ndcube_3d_l_ln_lt_ectime(wcs_3d_lt_ln_l, 1, base_time3, gc3)
     cube3.data[:] *= 3
 

--- a/ndcube/extra_coords/extra_coords.py
+++ b/ndcube/extra_coords/extra_coords.py
@@ -105,6 +105,23 @@ class ExtraCoordsABC(abc.ABC):
 
 
 class ExtraCoords(ExtraCoordsABC):
+    """
+    A representation of additional world coordinates associated with pixel axes.
+
+    ExtraCoords can be initialised by either specifying a
+    `~astropy.wcs.wcsapi.LowLevelWCS` object and a ``mapping``, or it can be
+    built up by specifying one or more lookup tables.
+
+    Parameters
+    ----------
+    wcs
+        The WCS specifying the extra coordinates.
+    mapping
+       The mapping between the array dimensions and pixel dimensions in the
+       extra coords object. This is an iterable of ``(array_dimension, pixel_dimension)`` pairs
+       of length equal to the number of pixel dimensions in the extra coords.
+
+    """
     def __init__(self, *, wcs=None, mapping=None):
         if (wcs is None and mapping is not None) or (wcs is not None and mapping is None):
             raise ValueError("Either both WCS and mapping have to be specified together or neither.")

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -9,40 +9,43 @@ __all__ = ["NDCollection"]
 
 
 class NDCollection(dict):
+    """
+    Class for holding and manipulating an unordered collection of NDCubes or NDCubeSequences.
+
+    Parameters
+    ----------
+    data: sequence of `tuple`s of (`str`, `~ndcube.NDCube` or `~ndcube.NDCubeSequence`)
+        The names and data cubes/sequences to held in the collection.
+
+    aligned_axes: `tuple` of `int`, `tuple` of `tuple`s of `int`, 'all', or None, optional
+        Axes of each cube/sequence that are aligned in numpy order.
+        If elements are int, then the same axis numbers in all cubes/sequences are aligned.
+        If elements are tuples of ints, then there must be one tuple for every cube/sequence.
+        Each element of each tuple gives the axes of each cube/sequence that are aligned.
+        If 'all', all axes are aligned in natural order, i.e. the 0th axes of all cubes
+        are aligned, as are the 1st, and so on.
+        Default=None
+
+    meta: `dict`, optional
+        General metadata for the overall collection.
+
+    Example
+    -------
+    Say the collection holds two NDCubes, each of 3 dimensions.
+
+    >>> aligned_axes = (1, 2)  # doctest:  +SKIP
+
+    means that axis 1 (0-based counting) of cube0 is aligned with axis 1 of cube1,
+    and axis 2 of cube0 is aligned with axis 2 of cube1.
+    However, if
+
+    >>> aligned_axes = ((0, 1), (2, 1))  # doctest: +SKIP
+
+    then the first tuple corresponds to cube0 and the second with cube1.
+    This is interpretted as axis 0 of cube0 is aligned with axis 2 of cube1 while
+    axis 1 of cube0 is aligned with axis 1 of cube1.
+    """
     def __init__(self, key_data_pairs, aligned_axes=None, meta=None, **kwargs):
-        """
-        A class for holding and manipulating a collection of aligned NDCube or NDCubeSequences.
-
-        Parameters
-        ----------
-        data: sequence of `tuple`s of (`str`, `~ndcube.NDCube` or `~ndcube.NDCubeSequence`)
-            The names and data cubes/sequences to held in the collection.
-
-        aligned_axes: `tuple` of `int`, `tuple` of `tuple`s of `int`, 'all', or None, optional
-            Axes of each cube/sequence that are aligned in numpy order.
-            If elements are int, then the same axis numbers in all cubes/sequences are aligned.
-            If elements are tuples of ints, then must be one tuple for every cube/sequence.
-            Each element of each tuple gives the axes of each cube/sequence that are aligned.
-            If 'all', all axes are aligned in natural order, i.e. the 0th axes of all cubes
-            are aligned, as are the 1st, and so on.
-            Default=None
-
-        meta: `dict`, optional
-            General metadata for the overall collection.
-
-        Example
-        -------
-        Say the collection holds two NDCubes, each of 3 dimensions.
-        ``aligned_axes = (1, 2)``
-        means that axis 1 (0-based counting) of cube0 is aligned with axis 1 of cube1,
-        and axis 2 of cube0 is aligned with axis 2 of cube1.
-        However, if
-        ``aligned_axes = ((0, 1), (2, 1))``
-        then the first tuple corresponds to cube0 and the second with cube1.
-        This is interpretted as axis 0 of cube0 is aligned with axis 2 of cube1 while
-        axis 1 of cube0 is aligned with axis 1 of cube1.
-
-        """
         # Enter data and metadata into object.
         super().__init__(key_data_pairs)
         self.meta = meta
@@ -86,10 +89,9 @@ class NDCollection(dict):
     @property
     def aligned_dimensions(self):
         """
-        Returns the lengths of all aligned axes.
+        The lengths of all aligned axes.
 
         If there are no aligned axes, returns None.
-
         """
         if self.aligned_axes is not None:
             return np.asanyarray(self[self._first_key].dimensions, dtype=object)[
@@ -99,10 +101,12 @@ class NDCollection(dict):
     @property
     def aligned_axis_physical_types(self):
         """
-        Returns the physical types of each aligned axis common to all objects in the collection.
+        The physical types common to all members that are associated with each aligned axis.
 
-        If there are no aligned axes, raises a ValueError.  If there are no physical types
-        to an aligned axis, an empty tuple is returned for that axis.
+        One tuple is retured for each axis as there can be more than one physical type
+        associated with an aligned axis.  If there are no physical types associated
+        with an aligned that is common to all collection members, an empty tuple is
+        returned for that axis.  If there are no aligned axes, raises a ValueError.
         """
         if self.aligned_axes is None:
             raise ValueError("aligned_axes must be set to use this property.")
@@ -214,12 +218,22 @@ class NDCollection(dict):
                               meta=self.meta, sanitize_inputs=False)
 
     def setdefault(self):
+        """Not supported by `~ndcube.NDCollection`"""
         raise NotImplementedError("NDCollection does not support setdefault.")
 
     def popitem(self):
+        """Not supported by `~ndcube.NDCollection`"""
         raise NotImplementedError("NDCollection does not support popitem.")
 
     def pop(self, key):
+        """
+        Remove a member from the `~ndcube.NDCollection` and return it.
+
+        Parameters
+        ----------
+        key: `str`
+            The name of the member to remove and return.
+        """
         # Extract desired cube from collection.
         popped_cube = super().pop(key)
         # Delete corresponding aligned axes
@@ -230,9 +244,8 @@ class NDCollection(dict):
         """
         Merges a new collection with current one replacing objects with common keys.
 
-        Takes either a single input (`NDCollection`) or two inputs
-        (sequence of key/value pair and aligned axes associated with each key/value pair.
-
+        Takes either a single input (`~ndcube.NDCollection`) or two inputs
+        (sequence of key/value pairs and aligned axes associated with each key/value pair.
         """
         # If two inputs, inputs must be key_data_pairs and aligned_axes.
         if len(args) == 2:

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -624,4 +624,3 @@ class NDCube(NDCubeBase, NDCubePlotMixin):
         Default is False.
 
     """
-    pass

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -31,7 +31,7 @@ class NDCubeABC(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
     @abc.abstractproperty
     def dimensions(self):
         """
-        The pixel dimensions of the cube.
+        The array dimensions of the cube.
         """
 
     @abc.abstractmethod
@@ -124,8 +124,7 @@ class NDCubeABC(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
 
 class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
     """
-    Class representing N dimensional cubes. Extra arguments are passed on to
-    `~astropy.nddata.NDData`.
+    Class representing N-D data described by a single array and set of WCS transformations.
 
     Parameters
     ----------
@@ -580,4 +579,48 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
 
 class NDCube(NDCubeBase, NDCubePlotMixin, astropy.nddata.NDArithmeticMixin):
-    pass
+    """
+    Class representing N-D data described by a single array and set of WCS transformations.
+
+    Parameters
+    ----------
+    data: `numpy.ndarray`
+        The array holding the actual data in this object.
+
+    wcs: `astropy.wcs.wcsapi.BaseLowLevelWCS`, `astropy.wcs.wcsapi.BaseHighLevelWCS`, optional
+        The WCS object containing the axes' information, optional only if
+        ``data`` is an `astropy.nddata.NDData` object.
+
+    uncertainty : any type, optional
+        Uncertainty in the dataset. Should have an attribute uncertainty_type
+        that defines what kind of uncertainty is stored, for example "std"
+        for standard deviation or "var" for variance. A metaclass defining
+        such an interface is NDUncertainty - but isn’t mandatory. If the uncertainty
+        has no such attribute the uncertainty is stored as UnknownUncertainty.
+        Defaults to None.
+
+    mask : any type, optional
+        Mask for the dataset. Masks should follow the numpy convention
+        that valid data points are marked by False and invalid ones with True.
+        Defaults to None.
+
+    meta : dict-like object, optional
+        Additional meta information about the dataset. If no meta is provided
+        an empty collections.OrderedDict is created. Default is None.
+
+    unit : Unit-like or str, optional
+        Unit for the dataset. Strings that can be converted to a Unit are allowed.
+        Default is None.
+
+    extra_coords : iterable of `tuple`, each with three entries
+        (`str`, `int`, `astropy.units.quantity` or array-like)
+        Gives the name, axis of data, and values of coordinates of a data axis not
+        included in the WCS object.
+
+    copy : bool, optional
+        Indicates whether to save the arguments as copy. True copies every attribute
+        before saving it while False tries to save every parameter as reference.
+        Note however that it is not always possible to save the input as reference.
+        Default is False.
+
+    """

--- a/ndcube/tests/test_ndcubesequence.py
+++ b/ndcube/tests/test_ndcubesequence.py
@@ -185,7 +185,6 @@ def test_common_axis_coords(ndc):
 
 @pytest.mark.parametrize("ndc", (("ndcubesequence_3c_l_ln_lt_cax1",)), indirect=("ndc",))
 def test_sequence_axis_coords(ndc):
-    expected = {'global coord': [None, 0*u.pix, None],
-                'distance': [1*u.m, 2*u.m, None]}
+    expected = {'distance': [1*u.m, 2*u.m, 3*u.m]}
     output = ndc.sequence_axis_coords
     assert output == expected


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/newcomers.html#code

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
This PR adds docstrings to all public attributes for `NDCubeSequence` and `NDCollection`.  `NDCube` doctrings will be improved after the `NDCubeABC` is finalized after community consultation.

This PR also restricts the output of `NDCubeSequence.sequence_axis_coords` to coords common to all cubes in sequence.

Fixes #362 
