### PR TITLE
Allow crop to accept single coord objects as corner inputs.

### DIFF
--- a/changelog/380.trivial.rst
+++ b/changelog/380.trivial.rst
@@ -1,0 +1,1 @@
+Allow corner inputs to `~ndcube.NDCube.crop` to not be wrapped in a `tuple` is only one high level coordinate objects required.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -440,23 +440,19 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
     @utils.misc.sanitise_wcs
     def crop(self, lower_corner, upper_corner, wcs=None):
         # The docstring is defined in NDCubeBase
-        if len(lower_corner) != len(upper_corner):
-            raise ValueError("lower_corner must have same length as upper_corner, "
-                             f"lower_corner: {lower_corner}; upper_corner: {upper_corner}")
+        lower_corner, upper_corner = utils.misc.sanitize_corners(lower_corner, upper_corner)
         return self._crop(lower_corner, upper_corner, wcs, False)
 
     @utils.misc.sanitise_wcs
     def crop_by_values(self, lower_corner, upper_corner, units=None, wcs=None):
         # The docstring is defined in NDCubeBase
         # Sanitize inputs.
+        lower_corner, upper_corner = utils.misc.sanitize_corners(lower_corner, upper_corner)
         n_coords = len(lower_corner)
-        if len(upper_corner) != n_coords:
-            raise ValueError("lower_corner must have same length as upper_corner")
         if units is None:
             units = [None] * n_coords
         elif len(units) != n_coords:
-            raise ValueError(
-                "units must be None or have same length as lower_corner and upper_corner.")
+            raise ValueError("units must be None or have same length as corner inputs.")
         # Convert float inputs to quantities using units.
         types_with_units = (u.Quantity, type(None))
         for i, (lower, upper, unit) in enumerate(zip(lower_corner, upper_corner, units)):

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1,4 +1,5 @@
 import astropy.units as u
+import astropy.wcs
 import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord, SpectralCoord
@@ -347,6 +348,16 @@ def test_crop(ndcube_4d_ln_lt_l_t):
     helpers.assert_cubes_equal(output, expected)
 
 
+def test_crop_tuple_non_tuple_input(ndcube_2d_ln_lt):
+    cube = ndcube_2d_ln_lt
+    frame = astropy.wcs.utils.wcs_to_celestial_frame(cube.wcs)
+    lower_corner = SkyCoord(Tx=359.99667, Ty=-0.0011111111, unit="deg", frame=frame)
+    upper_corner = SkyCoord(Tx=0.0044444444, Ty=0.0011111111, unit="deg", frame=frame)
+    cropped_by_tuples = cube.crop((lower_corner,), (upper_corner,))
+    cropped_by_coords = cube.crop(lower_corner, upper_corner)
+    helpers.assert_cubes_equal(cropped_by_tuples, cropped_by_coords)
+
+
 def test_crop_with_nones(ndcube_4d_ln_lt_l_t):
     lower_corner = [None] * 3
     upper_corner = [None] * 3
@@ -426,6 +437,16 @@ def test_crop_by_values_indexerror(ndcube_4d_ln_lt_l_t):
     upper_corner[1] *= -1
     with pytest.raises(IndexError):
         ndcube_4d_ln_lt_l_t.crop_by_values(lower_corner, upper_corner)
+
+
+def test_crop_by_values_valueerror1(ndcube_4d_ln_lt_l_t):
+    with pytest.raises(ValueError):
+        ndcube_4d_ln_lt_l_t.crop_by_values([None, None], [None, None], units=["m"])
+
+
+def test_crop_by_values_valueerror2(ndcube_4d_ln_lt_l_t):
+    with pytest.raises(ValueError):
+        ndcube_4d_ln_lt_l_t.crop_by_values([None], [None, None])
 
 
 def test_crop_by_values_1d_dependent(ndcube_4d_ln_lt_l_t):

--- a/ndcube/utils/misc.py
+++ b/ndcube/utils/misc.py
@@ -53,3 +53,14 @@ def sanitise_wcs(func):
         return func(*params.args, **params.kwargs)
 
     return wcs_wrapper
+
+
+def sanitize_corners(*corners):
+    """Sanitize corner inputs to NDCube crop methods."""
+    corners = [list(corner) if isinstance(corner, (tuple, list)) else [corner]
+               for corner in corners]
+    n_coords = [len(corner) for corner in corners]
+    if len(set(n_coords)) != 1:
+        raise ValueError("All corner inputs must have same number of coordinate objects. "
+                         f"Lengths of corner objects: {n_coords}")
+    return corners


### PR DESCRIPTION
This means if only a single high level coordinate object is required,
it does not have to be wrapped in a tuple.

<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/newcomers.html#code

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #377 
