### PR TITLE
Fix bug preventing 2D NDCubes being animated a 1D line.

### DIFF
--- a/changelog/381.bugfix.rst
+++ b/changelog/381.bugfix.rst
@@ -1,0 +1,1 @@
+Enable 2-D NDCubes to be visualized as a 1-D animated line.

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -79,7 +79,7 @@ class NDCubePlotMixin:
                 ax = self._plot_1D_cube(plot_wcs, axes, axes_coordinates,
                                         axes_units, data_unit, **kwargs)
 
-            elif naxis == 2:
+            elif naxis == 2 and 'y' in plot_axes:
                 ax = self._plot_2D_cube(plot_wcs, axes, plot_axes, axes_coordinates,
                                         axes_units, data_unit, **kwargs)
             else:

--- a/ndcube/tests/figure_hashes_mpl_332_ft_261_astropy_41_sunpy_203.json
+++ b/ndcube/tests/figure_hashes_mpl_332_ft_261_astropy_41_sunpy_203.json
@@ -14,6 +14,7 @@
   "ndcube.tests.test_plotting.test_plot_2D_cube_from_slice[ln_lt_l_t-cslice2-kwargs2]": "f782f8839978e3e2ccfe7c4f29833d2c8b35657963f7eb57167cf6815075c80d",
   "ndcube.tests.test_plotting.test_plot_2D_cube_from_slice[unit_uncertainty-cslice3-kwargs3]": "77b0b9a0067897786777a78974cff240a3268ed38937047c3945473e82bc4cf0",
   "ndcube.tests.test_plotting.test_plot_2D_cube_from_slice[mask-cslice4-kwargs4]": "490f4d37a93ab800ab2eb4fa077c448bcd6ebc30d64ab374118f5a9288246fb3",
+  "ndcube.tests.test_plotting.test_animate_2D_cube": "33dd112561f3f79249ffcef67218f547d3f1127d3124ea0d2716054e0f217329",
   "ndcube.tests.test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice0-kwargs0]": "eeaf0f6ba120d5dd730f66953a6b15f91533e8378b83608936eb5588f157574d",
   "ndcube.tests.test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice1-kwargs1]": "97683e58de61e6f15cc6efd6a84837d0bfada56aa2e274e1dcd39d71399372f4",
   "ndcube.tests.test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs2]": "5966170e7eed2dbadc950a4ef23bda8b9bf435a0ad6f44e2936c8f4b14fd1114",

--- a/ndcube/tests/figure_hashes_mpl_332_ft_261_astropy_dev_sunpy_dev.json
+++ b/ndcube/tests/figure_hashes_mpl_332_ft_261_astropy_dev_sunpy_dev.json
@@ -14,6 +14,7 @@
   "ndcube.tests.test_plotting.test_plot_2D_cube_from_slice[ln_lt_l_t-cslice2-kwargs2]": "f782f8839978e3e2ccfe7c4f29833d2c8b35657963f7eb57167cf6815075c80d",
   "ndcube.tests.test_plotting.test_plot_2D_cube_from_slice[unit_uncertainty-cslice3-kwargs3]": "77b0b9a0067897786777a78974cff240a3268ed38937047c3945473e82bc4cf0",
   "ndcube.tests.test_plotting.test_plot_2D_cube_from_slice[mask-cslice4-kwargs4]": "490f4d37a93ab800ab2eb4fa077c448bcd6ebc30d64ab374118f5a9288246fb3",
+  "ndcube.tests.test_plotting.test_animate_2D_cube": "33dd112561f3f79249ffcef67218f547d3f1127d3124ea0d2716054e0f217329",
   "ndcube.tests.test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice0-kwargs0]": "eeaf0f6ba120d5dd730f66953a6b15f91533e8378b83608936eb5588f157574d",
   "ndcube.tests.test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice1-kwargs1]": "97683e58de61e6f15cc6efd6a84837d0bfada56aa2e274e1dcd39d71399372f4",
   "ndcube.tests.test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs2]": "5966170e7eed2dbadc950a4ef23bda8b9bf435a0ad6f44e2936c8f4b14fd1114",

--- a/ndcube/tests/test_plotting.py
+++ b/ndcube/tests/test_plotting.py
@@ -78,6 +78,15 @@ def test_plot_2D_cube_from_slice(ndcube_4d, cslice, kwargs):
 
 
 @figure_test
+def test_animate_2D_cube(ndcube_2d_ln_lt):
+    cube = ndcube_2d_ln_lt
+    ax = cube.plot(plot_axes=[None, 'x'])
+    assert isinstance(ax, sunpy.visualization.animator.ArrayAnimatorWCS)
+
+    return ax.fig
+
+
+@figure_test
 @pytest.mark.parametrize(("ndcube_4d", "cslice", "kwargs"),
                          (
                              ("ln_lt_l_t", np.s_[:, :, 0, :], {}),


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://github.com/sunpy/sunpy/blob/master/CODE_OF_CONDUCT.rst

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/newcomers.html#code

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/pr_review_procedure.html#continuous-integration.
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #376 
