### PR TITLE
Make sunpy dependency optional

### DIFF
--- a/changelog/393.trivial.rst
+++ b/changelog/393.trivial.rst
@@ -1,0 +1,2 @@
+Make sunpy an optional dependence. Without it, the _animate_cube plotting
+functionality will be disabled.

--- a/ndcube/mixins/__init__.py
+++ b/ndcube/mixins/__init__.py
@@ -1,2 +1,5 @@
 from .ndslicing import NDCubeSlicingMixin
-from .plotting import NDCubePlotMixin
+try:
+    from .plotting import NDCubePlotMixin
+except ImportError:
+    pass

--- a/ndcube/mixins/__init__.py
+++ b/ndcube/mixins/__init__.py
@@ -1,5 +1,2 @@
 from .ndslicing import NDCubeSlicingMixin
-try:
-    from .plotting import NDCubePlotMixin
-except ImportError:
-    pass
+from .plotting import NDCubePlotMixin

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -6,12 +6,6 @@ import numpy as np
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.visualization.wcsaxes import WCSAxes
 
-try:
-    from sunpy.visualization.animator import ArrayAnimatorWCS
-    sunpy_available = True
-except ImportError:
-    sunpy_available = False
-
 from . import plotting_utils as utils
 
 __all__ = ['NDCubePlotMixin']
@@ -191,9 +185,11 @@ class NDCubePlotMixin:
     def _animate_cube(self, wcs, plot_axes=None, axes_coordinates=None,
                       axes_units=None, data_unit=None, **kwargs):
 
-        if not sunpy_available:
-            raise ModuleNotFoundError("Sunpy is required for animated "
-                                      "cube plots.")
+        try:
+            from sunpy.visualization.animator import ArrayAnimatorWCS
+        except ImportError:
+            raise ImportError("Sunpy is required for animated "
+                              "cube plots.")
 
         # If data_unit set, convert data to that unit
         if data_unit is None:

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -186,7 +186,7 @@ class NDCubePlotMixin:
                       axes_units=None, data_unit=None, **kwargs):
 
         try:
-            from sunpy.visualization.animator import ArrayAnimatorWCS
+            from sunpy.visualization.animator import ArrayAnimatorWCS  # isort:skip
         except ImportError:
             raise ImportError("Sunpy is required for animated "
                               "cube plots.")

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.visualization.wcsaxes import WCSAxes
+
 try:
     from sunpy.visualization.animator import ArrayAnimatorWCS
     sunpy_available = True
@@ -86,13 +87,10 @@ class NDCubePlotMixin:
             elif naxis == 2 and 'y' in plot_axes:
                 ax = self._plot_2D_cube(plot_wcs, axes, plot_axes, axes_coordinates,
                                         axes_units, data_unit, **kwargs)
-            elif sunpy_available:
+            else:
                 ax = self._animate_cube(plot_wcs, plot_axes=plot_axes,
                                         axes_coordinates=axes_coordinates,
                                         axes_units=axes_units, **kwargs)
-            else:
-                raise ModuleNotFoundError("Sunpy is required for animated "
-                                          "cube plots.")
 
         return ax
 
@@ -192,6 +190,10 @@ class NDCubePlotMixin:
 
     def _animate_cube(self, wcs, plot_axes=None, axes_coordinates=None,
                       axes_units=None, data_unit=None, **kwargs):
+
+        if not sunpy_available:
+            raise ModuleNotFoundError("Sunpy is required for animated "
+                                      "cube plots.")
 
         # If data_unit set, convert data to that unit
         if data_unit is None:

--- a/ndcube/mixins/plotting.py
+++ b/ndcube/mixins/plotting.py
@@ -5,7 +5,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.visualization.wcsaxes import WCSAxes
-from sunpy.visualization.animator import ArrayAnimatorWCS
+try:
+    from sunpy.visualization.animator import ArrayAnimatorWCS
+    sunpy_available = True
+except ImportError:
+    sunpy_available = False
 
 from . import plotting_utils as utils
 
@@ -82,10 +86,13 @@ class NDCubePlotMixin:
             elif naxis == 2 and 'y' in plot_axes:
                 ax = self._plot_2D_cube(plot_wcs, axes, plot_axes, axes_coordinates,
                                         axes_units, data_unit, **kwargs)
-            else:
+            elif sunpy_available:
                 ax = self._animate_cube(plot_wcs, plot_axes=plot_axes,
                                         axes_coordinates=axes_coordinates,
                                         axes_units=axes_units, **kwargs)
+            else:
+                raise ModuleNotFoundError("Sunpy is required for animated "
+                                          "cube plots.")
 
         return ax
 

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -23,10 +23,12 @@ from ndcube.wcs.wrappers import CompoundLowLevelWCS
 
 __all__ = ['NDCubeABC', 'NDCubeBase', 'NDCube']
 
+
 class PlaceholderClass:
     def plot(self, **kwargs):
         raise ModuleNotFoundError("Plotting functionality requires sunpy, "
                                   "which is not installed.")
+
 
 if sunpy_available:
     from ndcube.mixins import NDCubePlotMixin

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -6,6 +6,7 @@ import astropy.nddata
 import astropy.units as u
 import gwcs
 import numpy as np
+
 try:
     # Import sunpy coordinates if available to register the frames and WCS functions with astropy
     import sunpy.coordinates  # pylint: disable=unused-import  # NOQA
@@ -17,7 +18,7 @@ from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
 from ndcube import utils
 from ndcube.extra_coords import ExtraCoords
 from ndcube.global_coords import GlobalCoords
-from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
+from ndcube.mixins import NDCubePlotMixin, NDCubeSlicingMixin
 from ndcube.ndcube_sequence import NDCubeSequence
 from ndcube.wcs.wrappers import CompoundLowLevelWCS
 

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import gwcs
 import numpy as np
 try:
+    # Import sunpy coordinates if available to register the frames and WCS functions with astropy
     import sunpy.coordinates  # pylint: disable=unused-import  # NOQA
 except ImportError:
     pass

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -6,19 +6,33 @@ import astropy.nddata
 import astropy.units as u
 import gwcs
 import numpy as np
-import sunpy.coordinates  # pylint: disable=unused-import  # NOQA
+try:
+    import sunpy.coordinates  # pylint: disable=unused-import  # NOQA
+    sunpy_available = True
+except ImportError:
+    sunpy_available = False
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
 
 from ndcube import utils
 from ndcube.extra_coords import ExtraCoords
 from ndcube.global_coords import GlobalCoords
-from ndcube.mixins import NDCubePlotMixin, NDCubeSlicingMixin
+from ndcube.mixins import NDCubeSlicingMixin
 from ndcube.ndcube_sequence import NDCubeSequence
 from ndcube.wcs.wrappers import CompoundLowLevelWCS
 
 __all__ = ['NDCubeABC', 'NDCubeBase', 'NDCube']
 
+class PlaceholderClass:
+    def plot(self, **kwargs):
+        raise ModuleNotFoundError("Plotting functionality requires sunpy, "
+                                  "which is not installed.")
+
+if sunpy_available:
+    from ndcube.mixins import NDCubePlotMixin
+    plotting_mixin = NDCubePlotMixin
+else:
+    plotting_mixin = PlaceholderClass
 
 class NDCubeMetaClass(abc.ABCMeta):
     """
@@ -580,7 +594,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         return NDCubeSequence(result_cubes, meta=self.meta)
 
 
-class NDCube(NDCubeBase, NDCubePlotMixin, astropy.nddata.NDArithmeticMixin):
+class NDCube(NDCubeBase, plotting_mixin, astropy.nddata.NDArithmeticMixin):
     """
     Class representing N-D data described by a single array and set of WCS transformations.
 

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -8,33 +8,20 @@ import gwcs
 import numpy as np
 try:
     import sunpy.coordinates  # pylint: disable=unused-import  # NOQA
-    sunpy_available = True
 except ImportError:
-    sunpy_available = False
+    pass
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
 
 from ndcube import utils
 from ndcube.extra_coords import ExtraCoords
 from ndcube.global_coords import GlobalCoords
-from ndcube.mixins import NDCubeSlicingMixin
+from ndcube.mixins import NDCubeSlicingMixin, NDCubePlotMixin
 from ndcube.ndcube_sequence import NDCubeSequence
 from ndcube.wcs.wrappers import CompoundLowLevelWCS
 
 __all__ = ['NDCubeABC', 'NDCubeBase', 'NDCube']
 
-
-class PlaceholderClass:
-    def plot(self, **kwargs):
-        raise ModuleNotFoundError("Plotting functionality requires sunpy, "
-                                  "which is not installed.")
-
-
-if sunpy_available:
-    from ndcube.mixins import NDCubePlotMixin
-    plotting_mixin = NDCubePlotMixin
-else:
-    plotting_mixin = PlaceholderClass
 
 class NDCubeMetaClass(abc.ABCMeta):
     """
@@ -596,7 +583,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         return NDCubeSequence(result_cubes, meta=self.meta)
 
 
-class NDCube(NDCubeBase, plotting_mixin, astropy.nddata.NDArithmeticMixin):
+class NDCube(NDCubeBase, NDCubePlotMixin, astropy.nddata.NDArithmeticMixin):
     """
     Class representing N-D data described by a single array and set of WCS transformations.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ docs =
     sunpy-sphinx-theme
     pytest-doctestplus
     sphinx-astropy
-plot =
+animate =
     sunpy>=2.0rc1
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ include_package_data = True
 python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
-  sunpy>=2.0rc1
   astropy>=4.1
   matplotlib>=3
   gwcs>=0.15
@@ -33,6 +32,8 @@ docs =
     sunpy-sphinx-theme
     pytest-doctestplus
     sphinx-astropy
+plot =
+    sunpy>=2.0rc1
 
 [tool:pytest]
 testpaths = "ndcube" "docs"

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ setenv =
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
 extras =
     test
+    plot
 deps =
     pytest-xdist
     docutils

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ setenv =
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
 extras =
     test
-    plot
+    animate
 deps =
     pytest-xdist
     docutils


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
In the interest of helping push the 2.0 release along I thought I'd take a crack at this - it's probably not quite the prettiest way to do it, but it seems to work. Likely still needs a couple test-related changes. Currently I have it only throwing a warning about the sunpy dependency if you actually try to use the `plot` method.

Fixes #149 