### PR TITLE
Fix handling of coercing bare SkyCoord to a list

### DIFF
--- a/changelog/400.bugfix.rst
+++ b/changelog/400.bugfix.rst
@@ -1,2 +1,2 @@
-Fix bug in NDCube.axis_world_coords_values when axes_coords is initially a 
+Fix bug in NDCube.axis_world_coords_values when axes_coords is initially a
 bare astropy coordinate object rather than a list/tuple of coordinate objects.

--- a/changelog/400.bugfix.rst
+++ b/changelog/400.bugfix.rst
@@ -1,0 +1,2 @@
+Fix bug in NDCube.axis_world_coords_values when axes_coords is initially a 
+bare astropy coordinate object rather than a list/tuple of coordinate objects.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -322,8 +322,12 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         # TODO: this isinstance check is to mitigate https://github.com/spacetelescope/gwcs/pull/332
         if wcs.world_n_dim == 1 and not isinstance(axes_coords, tuple):
             axes_coords = [axes_coords]
-        # Ensure it's a list not a tuple
-        axes_coords = list(axes_coords)
+        # Ensure it's a list not a tuple or bare SkyCoords object
+        if type(axes_coords) != list:
+            if type(axes_coords) == tuple:
+                axes_coords = list(axes_coords)
+            else:
+                axes_coords = [axes_coords,]
 
         object_names = np.array([wao_comp[0] for wao_comp in wcs.low_level_wcs.world_axis_object_components])
         unique_obj_names = utils.misc.unique_sorted(object_names)

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -322,12 +322,12 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         # TODO: this isinstance check is to mitigate https://github.com/spacetelescope/gwcs/pull/332
         if wcs.world_n_dim == 1 and not isinstance(axes_coords, tuple):
             axes_coords = [axes_coords]
-        # Ensure it's a list not a tuple or bare SkyCoords object
+        # Ensure it's a list, not a tuple or bare SkyCoords object
         if type(axes_coords) != list:
             if type(axes_coords) == tuple:
                 axes_coords = list(axes_coords)
             else:
-                axes_coords = [axes_coords,]
+                axes_coords = [axes_coords]
 
         object_names = np.array([wao_comp[0] for wao_comp in wcs.low_level_wcs.world_axis_object_components])
         unique_obj_names = utils.misc.unique_sorted(object_names)

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -323,8 +323,8 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         if wcs.world_n_dim == 1 and not isinstance(axes_coords, tuple):
             axes_coords = [axes_coords]
         # Ensure it's a list, not a tuple or bare SkyCoords object
-        if type(axes_coords) != list:
-            if type(axes_coords) == tuple:
+        if not isinstance(axes_coords, list):
+            if isinstance(axes_coords, tuple):
                 axes_coords = list(axes_coords)
             else:
                 axes_coords = [axes_coords]

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -293,6 +293,17 @@ def test_axis_world_coords_sky(ndcube_3d_ln_lt_l, wapt):
                                      [-19.99999984, -14.9999999, -9.99999995]] * u.arcsec)
 
 
+def test_axes_world_coords_sky_only(ndcube_2d_ln_lt):
+    coords = ndcube_2d_ln_lt.axis_world_coords()
+
+    assert len(coords) == 1
+    assert isinstance(coords[0], SkyCoord)
+    assert u.allclose(coords[0].Tx[:, 0], [-16, -12, -8, -4, 0, 4, 8,
+                                           12, 16, 20] * u.arcsec, atol=1e-5 * u.arcsec)
+    assert u.allclose(coords[0].Ty[0, :], [-8, -6, -4, -2, 0, 2, 4, 6, 8, 10,
+                                           12, 14] * u.arcsec, atol=1e-5 * u.arcsec)
+
+
 def test_axis_world_coords_values_all(ndcube_3d_ln_lt_l):
     coords = ndcube_3d_ln_lt_l.axis_world_coords_values()
     assert len(coords) == 3


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #375 by ensuring that if `axes_coords` is a bare SkyCoord (or other coordinate) rather than a list or tuple, it's put into a single-element list instead of creating a list of smaller SkyCoords.
