### PR TITLE
Implement SpectralCoordTableCoordinate

### DIFF
--- a/ndcube/extra_coords/lookup_table_coord.py
+++ b/ndcube/extra_coords/lookup_table_coord.py
@@ -5,12 +5,13 @@ import astropy.units as u
 import gwcs
 import gwcs.coordinate_frames as cf
 import numpy as np
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, SpectralCoord
 from astropy.modeling import models
 from astropy.modeling.models import tabular_model
 from astropy.time import Time
 
-__all__ = ['TimeTableCoordinate', 'SkyCoordTableCoordinate', 'QuantityTableCoordinate']
+__all__ = ['TimeTableCoordinate', 'SkyCoordTableCoordinate',
+           'QuantityTableCoordinate']
 
 
 def _generate_generic_frame(naxes, unit, names=None, physical_types=None):
@@ -303,6 +304,35 @@ class SkyCoordTableCoordinate(BaseTableCoordinate):
         components = tuple(getattr(sc.data, comp) for comp in sc.data.components)
         return _model_from_quantity(components, mesh=self.mesh)
 
+
+class SpectralCoordTableCoordinate(BaseTableCoordinate):
+    """
+    A lookup table created from a `~astropy.coordinates.SpectralCoord`.
+    """
+    def __init__(self, *tables, names=None, physical_types=None):
+        if not len(tables) == 1 and isinstance(tables[0], Time):
+            raise ValueError("TimeLookupTable can only be constructed from a single Time object.")
+
+        if isinstance(names, str):
+            names = [names]
+        if names is not None and len(names) != 1:
+             raise ValueError("A SpectralCoord may only have one name.")
+         if physical_types is not None and len(physical_types) != 1:
+             raise ValueError("A SpectralCoord table may only have one physical type.")
+
+    def __getitem__(self, item):
+
+    @property
+    def frame(self):
+        """
+        Generate the Frame for this LookupTable.
+        """
+        sc = self.table
+        return cf.SpectralFrame()
+
+    @property
+    def model(self):
+        pass
 
 class TimeTableCoordinate(BaseTableCoordinate):
     """

--- a/ndcube/extra_coords/lookup_table_coord.py
+++ b/ndcube/extra_coords/lookup_table_coord.py
@@ -317,7 +317,7 @@ class SpectralCoordTableCoordinate(BaseTableCoordinate):
         if isinstance(names, str):
             names = [names]
         if names is not None and len(names) != 1:
-             raise ValueError("A SpectralCoord may only have one name.")
+            raise ValueError("A SpectralCoord may only have one name.")
         if physical_types is not None and len(physical_types) != 1:
             raise ValueError("A SpectralCoord table may only have one physical type.")
 
@@ -349,6 +349,7 @@ class SpectralCoordTableCoordinate(BaseTableCoordinate):
     @property
     def model(self):
         return _model_from_quantity(self.table)
+
 
 class TimeTableCoordinate(BaseTableCoordinate):
     """


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Not done, but intended to close #389 - I'm opening a PR at this point to get feedback and input. I'm not that familiar with gWCS and reference frames so I've honestly mostly bumbled my way through this so far based on the other lookup table classes. Things I'm unclear on:
- I think that the information that `SpectralCoord` stores in its `observer` attribute corresponds to what `SpectralFrame` wants for its `reference_frame` parameter, but I haven't found much documentation for SpectralFrame to confirm this.
- Right now `SpectralCoordTableCoordinate.model` errors out with `ValueError: Lookup table must have at least one dimension`. I haven't spent enough time to fully comprehend what the model machinery is doing here to fix this. I suspect it might be related to point 3:
- You mentioned that gWCS might need work to support returning a `SpectralCoord`. I see from testing that I'm getting back what appears to be a `Quantity` when slicing an instance of the new class, rather than getting back a `SpectralCoord` as one gets e.g. a `SkyCoord` when slicing a `SkyCoordTableCoord`. It's not immediately clear to me where (in `SpectralFrame` / somewhere else in gWCS / in the lookup table code itself) is the place to fix this.

Unfortunately at this point I need to switch over to working on a big task for `specutils` that's due next week, but if you can add some clarity on any of the above, @Cadair, I could probably do some more work on this soon.