### PR TITLE
Support dropping coordinates out of ExtraCoords

### DIFF
--- a/changelog/411.feature.rst
+++ b/changelog/411.feature.rst
@@ -1,0 +1,1 @@
+Support exposing dropped dimensions when `.ExtraCoords` is sliced.

--- a/ndcube/extra_coords/extra_coords.py
+++ b/ndcube/extra_coords/extra_coords.py
@@ -375,3 +375,10 @@ class ExtraCoords(ExtraCoordsABC):
             return mtc.dropped_world_dimensions
 
         return dict()
+
+    def __str__(self):
+        elements = [f"{', '.join(table.names)} ({axes}): {table}" for axes, table in self._lookup_tables]
+        return f"ExtraCoords({', '.join(elements)})"
+
+    def __repr__(self):
+        return f"{object.__repr__(self)}\n{self}"

--- a/ndcube/extra_coords/extra_coords.py
+++ b/ndcube/extra_coords/extra_coords.py
@@ -361,7 +361,7 @@ class ExtraCoords(ExtraCoordsABC):
     @property
     def dropped_world_dimensions(self):
         """
-        Return a APE-14 a-like representation of any sliced out world dimensions.
+        Return an APE-14 like representation of any sliced out world dimensions.
         """
 
         if self._wcs:

--- a/ndcube/extra_coords/extra_coords.py
+++ b/ndcube/extra_coords/extra_coords.py
@@ -136,8 +136,8 @@ class ExtraCoords(ExtraCoordsABC):
         self._mapping = None
         # Lookup tables is a list of (pixel_dim, LookupTableCoord) to allow for
         # one pixel dimension having more than one lookup coord.
-        self._lookup_tables = tuple()
-        self._dropped_tables = tuple()
+        self._lookup_tables = list()
+        self._dropped_tables = list()
 
         # Set values using the setters for validation
         self.wcs = wcs
@@ -325,8 +325,8 @@ class ExtraCoords(ExtraCoordsABC):
                 new_lookup_tables.add((lut_axis, sliced_lut))
 
         new_extra_coords = type(self)()
-        new_extra_coords._lookup_tables = tuple(new_lookup_tables)
-        new_extra_coords._dropped_tables = tuple(dropped_tables)
+        new_extra_coords._lookup_tables = list(new_lookup_tables)
+        new_extra_coords._dropped_tables = list(dropped_tables)
         return new_extra_coords
 
     def _getitem_wcs(self, item):
@@ -369,7 +369,7 @@ class ExtraCoords(ExtraCoordsABC):
                 return self._wcs.dropped_world_dimensions
 
         if self._lookup_tables or self._dropped_tables:
-            mtc = MultipleTableCoordinate(*self._lookup_tables)
+            mtc = MultipleTableCoordinate(*[lt[1] for lt in self._lookup_tables])
             mtc._dropped_coords = self._dropped_tables
 
             return mtc.dropped_world_dimensions

--- a/ndcube/extra_coords/lookup_table_coord.py
+++ b/ndcube/extra_coords/lookup_table_coord.py
@@ -48,9 +48,6 @@ def _generate_tabular(lookup_table, interpolation='linear', points_unit=u.pix, *
         raise TypeError("lookup_table must be a Quantity.")  # pragma: no cover
 
     ndim = lookup_table.ndim
-    if ndim == 0:
-        lookup_table = u.Quantity([lookup_table])
-        ndim = lookup_table.ndim
     TabularND = tabular_model(ndim, name=f"Tabular{ndim}D")
 
     # The integer location is at the centre of the pixel.

--- a/ndcube/extra_coords/lookup_table_coord.py
+++ b/ndcube/extra_coords/lookup_table_coord.py
@@ -545,10 +545,21 @@ class MultipleTableCoordinate(BaseTableCoordinate):
         dropped_world_dimensions["world_axis_object_components"] += dropped_multi_table.frame._world_axis_object_components
         dropped_world_dimensions["world_axis_object_classes"].update(dropped_multi_table.frame._world_axis_object_classes)
 
-        for i, dropped in enumerate(self._dropped_coords):
-            coord = dropped.frame.coordinate_to_quantity(*dropped.table)
-            if dropped.frame.naxes > 1 or (isinstance(coord, (tuple, list)) and len(coord) == 1):
-                coord = coord[i]
-            dropped_world_dimensions["value"].append(coord)
+        for dropped in self._dropped_coords:
+            # If the table is a tuple (QuantityTableCoordinate) then we need to
+            # squish the input
+            if isinstance(dropped.table, tuple):
+                coord = dropped.frame.coordinate_to_quantity(*dropped.table)
+            else:
+                coord = dropped.frame.coordinate_to_quantity(dropped.table)
+
+            # We want the value in the output dict to be a flat list of values
+            # in the order of world_axis_object_components, so if we get a
+            # tuple of coordinates out of gWCS then append them to the list, if
+            # we only get one quantity out then append to the list.
+            if isinstance(coord, tuple):
+                dropped_world_dimensions["value"] += list(coord)
+            else:
+                dropped_world_dimensions["value"].append(coord)
 
         return dropped_world_dimensions

--- a/ndcube/extra_coords/lookup_table_coord.py
+++ b/ndcube/extra_coords/lookup_table_coord.py
@@ -215,10 +215,22 @@ class QuantityTableCoordinate(BaseTableCoordinate):
         super().__init__(*tables, mesh=mesh, names=names, physical_types=physical_types)
 
     def _slice_table(self, i, table, item, new_components, whole_slice):
+        """
+        Apply a slice, or part of a slice to one of the quantity arrays.
+
+        i is the index of the element in `self.table`
+        table is the element in `self.table`
+        item is the part of the slice to be applied to `table`
+        new_components is the dictionary to append the output to
+        whole_slice is the complete slice being applied to the whole Table object.
+        """
         # If mesh is True then we can drop a dimension
+        # If mesh is false then all the dimensions contained in this Table are
+        # coupled so we can never drop only one of them only this whole Table
+        # can be dropped.
         if isinstance(item, Integral) and (
                 isinstance(whole_slice, tuple) and
-                not(all(isinstance(i, Integral) for i in whole_slice))):
+                not(all(isinstance(k, Integral) for k in whole_slice))):
             dwd = new_components["dropped_world_dimensions"]
             dwd["value"].append(table[item])
             dwd["world_axis_names"].append(self.names[i] if self.names else None)

--- a/ndcube/global_coords/global_coords.py
+++ b/ndcube/global_coords/global_coords.py
@@ -108,10 +108,9 @@ class GlobalCoords(Mapping):
                 wcs_dropped = self._convert_dropped_to_internal(dropped_world)
                 all_coords.update(wcs_dropped)
 
-        # TODO: Implement dropped_world_dimensions on ExtraCoords
-        # ec_dropped = self._ndcube.extra_coords.dropped_world_dimensions
-        # if "value" in ec_dropped:
-        #     all_coords.update(self._convert_dropped_to_internal(ec_dropped))
+        ec_dropped = self._ndcube.extra_coords.dropped_world_dimensions
+        if "value" in ec_dropped:
+            all_coords.update(self._convert_dropped_to_internal(ec_dropped))
 
         return all_coords
 

--- a/ndcube/global_coords/global_coords.py
+++ b/ndcube/global_coords/global_coords.py
@@ -71,7 +71,7 @@ class GlobalCoords(Mapping):
 
             # convert lists to strings if a single coordinate
             physical_types = physical_types[0] if len(physical_types) == 1 else tuple(physical_types)
-            names = names[0] if len(names) == 1 else names
+            names = names[0] if len(set(names)) == 1 else names
 
             klass, ar, kw, *rest = classes[key]
             if len(rest) == 0:

--- a/ndcube/tests/test_extra_coords.py
+++ b/ndcube/tests/test_extra_coords.py
@@ -329,3 +329,20 @@ def test_slice_extra_twice(time_lut, wave_lut):
 
     assert u.allclose(sec['time'].wcs.pixel_to_world_values(list(range(0, 2))),
                       ec['time'].wcs.pixel_to_world_values(list(range(2, 4))))
+
+
+def test_slice_extra_1d_drop(time_lut, wave_lut):
+    ec = ExtraCoords()
+    ec.add("time", 0, time_lut)
+    ec.add("wavey", 1, wave_lut)
+
+    sec = ec[:, 3]
+    assert len(sec._lookup_tables) == 1
+
+    assert u.allclose(sec['time'].wcs.pixel_to_world_values(list(range(4))),
+                      ec['time'].wcs.pixel_to_world_values(list(range(4))))
+
+    dwd = sec.dropped_world_dimensions
+    dwd.pop("world_axis_object_classes")
+    assert dwd
+    assert dwd["world_axis_units"] == ["nm"]

--- a/ndcube/tests/test_global_coords.py
+++ b/ndcube/tests/test_global_coords.py
@@ -3,8 +3,11 @@ import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
 from astropy.coordinates.spectral_coordinate import SpectralCoord
+from astropy.wcs.wcsapi.high_level_api import HighLevelWCSMixin
+from astropy.wcs.wcsapi.low_level_api import BaseLowLevelWCS
 
 from ndcube.global_coords import GlobalCoords
+from ndcube.ndcube import NDCube
 
 
 @pytest.fixture
@@ -117,3 +120,117 @@ def test_dropped_to_global_ec_gwcs_fail(ndcube_4d_extra_coords):
     assert isinstance(gc["helioprojective"], SkyCoord)
     assert isinstance(gc["time"], u.Quantity)
     assert isinstance(gc["hello"], u.Quantity)
+
+
+class SerializedWCS(BaseLowLevelWCS, HighLevelWCSMixin):
+    """
+    WCS with serialized classes
+    """
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        return [np.asarray(pix) * 2 for pix in pixel_arrays]
+
+    def world_to_pixel_values(self, *world_arrays):
+        return [np.asarray(world) / 2 for world in world_arrays]
+
+    @property
+    def serialized_classes(self):
+        return True
+
+    @property
+    def pixel_n_dim(self):
+        return 2
+
+    @property
+    def world_n_dim(self):
+        return 2
+
+    @property
+    def axis_correlation_matrix(self):
+        return np.identity(2)
+
+    @property
+    def world_axis_physical_types(self):
+        return ['pos.eq.ra', 'pos.eq.dec']
+
+    @property
+    def world_axis_units(self):
+        return ['deg', 'deg']
+
+    @property
+    def world_axis_object_components(self):
+        return [('test', 0, 'value'), ('test2', 0, 'value')]
+
+    @property
+    def world_axis_object_classes(self):
+        return {'test': ('astropy.units.Quantity', (),
+                         {'unit': ('astropy.units.Unit', ('deg',), {})}),
+                'test2': ('astropy.units.Quantity', (),
+                          {'unit': ('astropy.units.Unit', ('deg',), {})})}
+
+
+def test_serialized_classes():
+    ndc = NDCube(np.zeros((10, 10)), wcs=SerializedWCS())
+    assert u.allclose(ndc[0, :].global_coords["pos.eq.dec"], 0*u.deg)
+
+
+class MultiCoord(list):
+    def __init__(self, *args):
+        super().__init__(args)
+
+    @property
+    def value(self):
+        return tuple(x.value() for x in self)
+
+
+class MultiCoordWCS(BaseLowLevelWCS, HighLevelWCSMixin):
+    """
+    WCS with serialized classes
+    """
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        return [np.asarray(pix) * 2 for pix in pixel_arrays]
+
+    def world_to_pixel_values(self, *world_arrays):
+        return [np.asarray(world) / 2 for world in world_arrays]
+
+    @property
+    def pixel_n_dim(self):
+        return 3
+
+    @property
+    def world_n_dim(self):
+        return 3
+
+    @property
+    def axis_correlation_matrix(self):
+        return np.array([[1, 1, 0],
+                         [1, 1, 0],
+                         [0, 0, 1]])
+
+    @property
+    def world_axis_physical_types(self):
+        return ['pos.eq.ra', 'pos.eq.dec', 'pos.distance.x']
+
+    @property
+    def world_axis_units(self):
+        return ['deg', 'deg', 'm']
+
+    @property
+    def world_axis_object_components(self):
+        return [('test', 0, 'value'),
+                ('test', 1, 'value'),
+                ('distance', 0, 'value')]
+
+    @property
+    def world_axis_object_classes(self):
+        return {'test': (MultiCoord, (), {}),
+                'distance': (u.Quantity, (), {'unit': 'm'})}
+
+
+def test_non_skycoord_multi_object():
+    ndc = NDCube(np.zeros((10, 20, 30)), wcs=MultiCoordWCS())
+    gc = ndc[:, 0, 0].global_coords
+    assert len(gc._all_coords) == 1
+    assert gc["pos.eq.ra"] == gc["pos.eq.dec"] == gc[("pos.eq.ra", "pos.eq.dec")] == [0, 0]
+    assert not set(gc.keys()).difference({("pos.eq.ra", "pos.eq.dec")})

--- a/ndcube/tests/test_lookup_table_coord.py
+++ b/ndcube/tests/test_lookup_table_coord.py
@@ -569,12 +569,25 @@ def test_mtc_dropped_quantity_inside_table_no_mesh(lut_2d_distance_no_mesh):
     assert not dwd
 
 
-def test_mtc_dropped_quantity_join(lut_1d_time, lut_2d_distance_no_mesh):
-    mtc = MultipleTableCoordinate(lut_1d_time, lut_2d_distance_no_mesh)
-    sub = mtc[:, 0, :]
+def test_mtc_dropped_quantity_join_drop_table(lut_1d_time, lut_3d_distance_mesh):
+    mtc = MultipleTableCoordinate(lut_1d_time, lut_3d_distance_mesh)
+    sub = mtc[:, 0, :, :]
 
     assert len(sub._table_coords) == 2
     assert len(sub._dropped_coords) == 0
+
+    pytest.importorskip("gwcs", minversion="0.16.2a1.dev17")
+
+    dwd = sub.dropped_world_dimensions
+    assert isinstance(dwd, dict)
+    dwd.pop("world_axis_object_classes")
+    assert all(isinstance(value, list) for value in dwd.values())
+    assert all(len(value) == 1 for value in dwd.values())
+
+    sub = mtc[0, 0, :, :]
+
+    assert len(sub._table_coords) == 1
+    assert len(sub._dropped_coords) == 1
 
     pytest.importorskip("gwcs", minversion="0.16.2a1.dev17")
 

--- a/ndcube/tests/test_lookup_table_coord.py
+++ b/ndcube/tests/test_lookup_table_coord.py
@@ -508,6 +508,8 @@ def test_mtc_dropped_quantity_table(lut_1d_time, lut_2d_distance_no_mesh):
     assert len(sub._table_coords) == 1
     assert len(sub._dropped_coords) == 1
 
+    pytest.importorskip("gwcs", minversion="0.16.2a1.dev17")
+
     dwd = sub.dropped_world_dimensions
     assert isinstance(dwd, dict)
     wao_classes = dwd.pop("world_axis_object_classes")
@@ -529,6 +531,8 @@ def test_mtc_dropped_quantity_inside_table(lut_3d_distance_mesh):
     sub = lut_3d_distance_mesh[:, 0, :]
 
     assert len(sub.table) == 2
+
+    pytest.importorskip("gwcs", minversion="0.16.2a1.dev17")
 
     dwd = sub.dropped_world_dimensions
     assert isinstance(dwd, dict)
@@ -558,6 +562,8 @@ def test_mtc_dropped_quantity_inside_table_no_mesh(lut_2d_distance_no_mesh):
 
     assert len(sub.table) == 2
 
+    pytest.importorskip("gwcs", minversion="0.16.2a1.dev17")
+
     dwd = sub.dropped_world_dimensions
     assert isinstance(dwd, dict)
     assert not dwd
@@ -569,6 +575,8 @@ def test_mtc_dropped_quantity_join(lut_1d_time, lut_2d_distance_no_mesh):
 
     assert len(sub._table_coords) == 2
     assert len(sub._dropped_coords) == 0
+
+    pytest.importorskip("gwcs", minversion="0.16.2a1.dev17")
 
     dwd = sub.dropped_world_dimensions
     assert isinstance(dwd, dict)

--- a/ndcube/tests/test_lookup_table_coord.py
+++ b/ndcube/tests/test_lookup_table_coord.py
@@ -292,7 +292,9 @@ def test_slicing_quantity_table_coordinate():
     assert u.allclose(qtc[2:8, 2:8].table[0], range(2, 8)*u.m)
     assert u.allclose(qtc[2:8, 2:8].table[1], range(2, 8)*u.m)
 
-    assert u.allclose(qtc[2, 2:8].table[0], 2*u.m)
+    # we have dropped one dimension
+    assert len(qtc[2, 2:8].table) == 1
+    assert u.allclose(qtc[2, 2:8].table[0], range(2, 8)*u.m)
 
     assert qtc.names == ['x', 'y']
     assert qtc.physical_types == ['pos:x', 'pos:y']
@@ -521,6 +523,44 @@ def test_mtc_dropped_quantity_table(lut_1d_time, lut_2d_distance_no_mesh):
     assert wao_classes["SPATIAL0"][0] is u.Quantity
     assert wao_classes["SPATIAL1"][0] is u.Quantity
     assert dwd["value"] == [0*u.km, 9*u.km]
+
+
+def test_mtc_dropped_quantity_inside_table(lut_3d_distance_mesh):
+    sub = lut_3d_distance_mesh[:, 0, :]
+
+    assert len(sub.table) == 2
+
+    dwd = sub.dropped_world_dimensions
+    assert isinstance(dwd, dict)
+    dwd.pop("world_axis_object_classes")
+    assert all(isinstance(value, list) for value in dwd.values())
+    assert dwd
+    assert all(len(value) == 1 for value in dwd.values())
+
+    sub = lut_3d_distance_mesh[:, 0, 0]
+
+    assert len(sub.table) == 1
+
+    dwd = sub.dropped_world_dimensions
+    assert isinstance(dwd, dict)
+    dwd.pop("world_axis_object_classes")
+    assert all(isinstance(value, list) for value in dwd.values())
+    assert dwd
+    assert all(len(value) == 2 for value in dwd.values())
+
+
+def test_mtc_dropped_quantity_inside_table_no_mesh(lut_2d_distance_no_mesh):
+    """
+    When not meshing, we don't drop a coord, as the coordinate for the sliced
+    out axis can still vary along the remaining coordinate.
+    """
+    sub = lut_2d_distance_no_mesh[:, 0]
+
+    assert len(sub.table) == 2
+
+    dwd = sub.dropped_world_dimensions
+    assert isinstance(dwd, dict)
+    assert not dwd
 
 
 def test_mtc_dropped_quantity_join(lut_1d_time, lut_2d_distance_no_mesh):

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -7,7 +7,7 @@ from astropy.time import Time
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
 
-from ndcube import NDCube
+from ndcube import ExtraCoords, NDCube
 from ndcube.tests import helpers
 
 
@@ -140,6 +140,8 @@ def test_slicing_preserves_global_coords(ndcube_3d_ln_lt_l):
 
 def test_slicing_removed_world_coords(ndcube_3d_ln_lt_l):
     ndc = ndcube_3d_ln_lt_l
+    # Run this test without extra coords
+    ndc._extra_coords = ExtraCoords()
     lat_key = "custom:pos.helioprojective.lat"
     lon_key = "custom:pos.helioprojective.lon"
     wl_key = "em.wl"


### PR DESCRIPTION
This PR implements book keeping dropping dimensions out of ExtraCoords.

TODO:

- [x] ~Handle passing name from ExtraCoords through to GlobalCoords~
- [ ] Fix https://github.com/spacetelescope/gwcs/issues/358
- [x] MOAR TESTS
- [x] Figure out why the tests are failing: it looks like it's because the input to all the subclasses of `gwcs.CoordinateFrame.coordinate_to_quantity` aren't consistent.


