### PR TITLE
Link ExtraCoords to the parent Cube

### DIFF
--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -204,7 +204,7 @@ If one does not exist for your coordinate, prepend the type with ``custom:``.
 
 .. code-block:: python
 
-  >>> my_cube.extra_coords.add('time', (2,), timestamps)  # TODO: Change the mapping to 0 Issue #342 resolved.
+  >>> my_cube.extra_coords.add('time', (0,), timestamps)
 
 An indefinite number of coordinates can be added in this way.
 The names of the coordinates can be accessed via the `~ndcube.ExtraCoords.keys` method.
@@ -303,7 +303,7 @@ The values of dropped coordinates at the position where the `~ndcube.NDCube` was
 
   >>> my_2d_cube = my_cube[:, :, 0]
   >>> my_2d_cube.array_axis_physical_types  # Note the wavelength axis is now gone.
-  [('custom:pos.helioprojective.lat', 'custom:pos.helioprojective.lon'),
+  [('custom:pos.helioprojective.lat', 'custom:pos.helioprojective.lon', 'time'),
    ('custom:pos.helioprojective.lat', 'custom:pos.helioprojective.lon')]
 
   >>> # The wavelength value at the slicing location is now in the GLobalCoords object.

--- a/docs/visualization.rst
+++ b/docs/visualization.rst
@@ -248,19 +248,16 @@ Then we show how to extract and plot the data.
   >>> common_axis = 0
   >>> base_time = Time('2000-01-01', format='fits', scale='utc')
   >>> timestamps0 = Time([base_time + TimeDelta(60 * i, format='sec') for i in range(data0.shape[common_axis])])
-  >>> extra_coords0 = ExtraCoords()
-  >>> extra_coords0.add('time', 2, timestamps0)
   >>> timestamps1 = Time([base_time + TimeDelta(60 * (i+1), format='sec') for i in range(data1.shape[common_axis])])
-  >>> extra_coords1 = ExtraCoords()
-  >>> extra_coords1.add('time', 2, timestamps1)
   >>> timestamps2 = Time([base_time + TimeDelta(60 * (i+1), format='sec') for i in range(data2.shape[common_axis])])
-  >>> extra_coords2 = ExtraCoords()
-  >>> extra_coords2.add('time', 2, timestamps2)
 
   >>> # Define the cubes
-  >>> cube0 = NDCube(data0, wcs=wcs, extra_coords=extra_coords0)
-  >>> cube1 = NDCube(data1, wcs=wcs, extra_coords=extra_coords1)
-  >>> cube2 = NDCube(data2, wcs=wcs, extra_coords=extra_coords2)
+  >>> cube0 = NDCube(data0, wcs=wcs)
+  >>> cube0.extra_coords.add('time', 2, timestamps0)
+  >>> cube1 = NDCube(data1, wcs=wcs)
+  >>> cube1.extra_coords.add('time', 2, timestamps1)
+  >>> cube2 = NDCube(data2, wcs=wcs)
+  >>> cube2.extra_coords.add('time', 2, timestamps2)
 
   >>> # Define the sequence
   >>> my_sequence = NDCubeSequence([cube0, cube1, cube2], common_axis=common_axis)

--- a/docs/visualization.rst
+++ b/docs/visualization.rst
@@ -253,11 +253,11 @@ Then we show how to extract and plot the data.
 
   >>> # Define the cubes
   >>> cube0 = NDCube(data0, wcs=wcs)
-  >>> cube0.extra_coords.add('time', 2, timestamps0)
+  >>> cube0.extra_coords.add('time', 0, timestamps0)
   >>> cube1 = NDCube(data1, wcs=wcs)
-  >>> cube1.extra_coords.add('time', 2, timestamps1)
+  >>> cube1.extra_coords.add('time', 0, timestamps1)
   >>> cube2 = NDCube(data2, wcs=wcs)
-  >>> cube2.extra_coords.add('time', 2, timestamps2)
+  >>> cube2.extra_coords.add('time', 0, timestamps2)
 
   >>> # Define the sequence
   >>> my_sequence = NDCubeSequence([cube0, cube1, cube2], common_axis=common_axis)

--- a/ndcube/conftest.py
+++ b/ndcube/conftest.py
@@ -44,8 +44,8 @@ def gen_ndcube_3d_l_ln_lt_ectime(wcs_3d_lt_ln_l, time_axis, time_base, global_co
     cube = NDCube(data_cube,
                   wcs_3d_lt_ln_l,
                   mask=mask,
-                  uncertainty=data_cube,
-                  extra_coords=extra_coords)
+                  uncertainty=data_cube)
+    cube._extra_coords = extra_coords
 
     if global_coords:
         cube._global_coords = global_coords
@@ -300,7 +300,9 @@ def ndcube_4d_mask(wcs_4d_t_l_lt_ln):
 def ndcube_4d_extra_coords(wcs_4d_t_l_lt_ln, simple_extra_coords_3d):
     shape = (5, 8, 10, 12)
     data_cube = data_nd(shape)
-    return NDCube(data_cube, wcs=wcs_4d_t_l_lt_ln, extra_coords=simple_extra_coords_3d)
+    cube = NDCube(data_cube, wcs=wcs_4d_t_l_lt_ln)
+    cube._extra_coords = simple_extra_coords_3d
+    return cube
 
 
 @pytest.fixture
@@ -326,13 +328,14 @@ def ndcube_3d_ln_lt_l(wcs_3d_l_lt_ln, simple_extra_coords_3d):
     wcs_3d_l_lt_ln.array_shape = shape
     data = data_nd(shape)
     mask = data > 0
-    return NDCube(
+    cube = NDCube(
         data,
         wcs_3d_l_lt_ln,
         mask=mask,
         uncertainty=data,
-        extra_coords=simple_extra_coords_3d
     )
+    cube._extra_coords = simple_extra_coords_3d
+    return cube
 
 
 @pytest.fixture
@@ -340,13 +343,14 @@ def ndcube_3d_rotated(wcs_3d_ln_lt_t_rotated, simple_extra_coords_3d):
     data_rotated = np.array([[[1, 2, 3, 4, 6], [2, 4, 5, 3, 1], [0, -1, 2, 4, 2], [3, 5, 1, 2, 0]],
                              [[2, 4, 5, 1, 3], [1, 5, 2, 2, 4], [2, 3, 4, 0, 5], [0, 1, 2, 3, 4]]])
     mask_rotated = data_rotated >= 0
-    return NDCube(
+    cube = NDCube(
         data_rotated,
         wcs_3d_ln_lt_t_rotated,
         mask=mask_rotated,
         uncertainty=data_rotated,
-        extra_coords=simple_extra_coords_3d
     )
+    cube._extra_coords = simple_extra_coords_3d
+    return cube
 
 
 @pytest.fixture

--- a/ndcube/mixins/ndslicing.py
+++ b/ndcube/mixins/ndslicing.py
@@ -19,39 +19,10 @@ class NDCubeSlicingMixin(NDSlicingMixin):
         if item is None or (isinstance(item, tuple) and None in item):
             raise IndexError("None indices not supported")
 
-        sliced_cube = super().__getitem__(item)
-        sliced_cube._global_coords._internal_coords = self._global_coords._internal_coords
-        return sliced_cube
-
-    def _slice(self, item):
-        """Construct a set of keyword arguments to initialise a new (sliced)
-        instance of the class. This method is called in
-        `astropy.nddata.mixins.NDSlicingMixin.__getitem__`.
-
-        This method extends the `~astropy.nddata.mixins.NDSlicingMixin` method
-        to add support for  ``extra_coords`` and overwrites the astropy
-        handling of wcs slicing.
-
-        Parameters
-        ----------
-        item : slice
-            The slice passed to ``__getitem__``. Note that the item parameter corresponds
-            to numpy ordering, keeping with the convention for NDCube.
-
-        Returns
-        -------
-        dict :
-            Containing all the attributes after slicing - ready to
-            use them to create ``self.__class__.__init__(**kwargs)`` in
-            ``__getitem__``.
-        """
-
         item = tuple(sanitize_slices(item, len(self.dimensions)))
-        kwargs = super()._slice(item)
+        sliced_cube = super().__getitem__(item)
 
-        # Store the original dimension of NDCube object before slicing
-        len(self.dimensions)
+        sliced_cube._global_coords._internal_coords = self.global_coords._internal_coords
+        sliced_cube._extra_coords = self.extra_coords[item]
 
-        kwargs['extra_coords'] = self.extra_coords[item]
-
-        return kwargs
+        return sliced_cube

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -137,7 +137,16 @@ class NDCubeLinkedDescriptor:
         self._property_name = None
 
     def __set_name__(self, owner, name):
+        """
+        This function is called when the class the descriptor is attached to is initialized.
+
+        The *class* and not the instance.
+        """
+        # property name is the name of the attribute on the parent class
+        # pointing at an instance of this descriptor.
         self._property_name = name
+        # attribute name is the name of the attribute on the parent class where
+        # the data is stored.
         self._attribute_name = f"_{name}"
 
     def __get__(self, obj, objtype=None):
@@ -155,7 +164,9 @@ class NDCubeLinkedDescriptor:
         elif issubclass(value, self._default_type):
             value = value(obj)
         else:
-            raise ValueError("wat")
+            raise ValueError(
+                f"Unable to set value for {self._property_name} it should "
+                f"be an instance or subclass of {self._default_type}")
 
         setattr(obj, self._attribute_name, value)
 
@@ -206,6 +217,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         Default is False.
 
     """
+    # Instances of Extra and Global coords are managed through descriptors
     _extra_coords = NDCubeLinkedDescriptor(ExtraCoords)
     _global_coords = NDCubeLinkedDescriptor(GlobalCoords)
 

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -128,6 +128,38 @@ class NDCubeABC(astropy.nddata.NDData, metaclass=NDCubeMetaClass):
         """
 
 
+class NDCubeLinkedDescriptor:
+    """
+    A descriptor which gives the property a reference to the cube to which it is attached.
+    """
+    def __init__(self, default_type):
+        self._default_type = default_type
+        self._property_name = None
+
+    def __set_name__(self, owner, name):
+        self._property_name = name
+        self._attribute_name = f"_{name}"
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return
+
+        if getattr(obj, self._attribute_name, None) is None and self._default_type is not None:
+            self.__set__(obj, self._default_type)
+
+        return getattr(obj, self._attribute_name)
+
+    def __set__(self, obj, value):
+        if isinstance(value, self._default_type):
+            value._ndcube = obj
+        elif issubclass(value, self._default_type):
+            value = value(obj)
+        else:
+            raise ValueError("wat")
+
+        setattr(obj, self._attribute_name, value)
+
+
 class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
     """
     Class representing N-D data described by a single array and set of WCS transformations.
@@ -174,9 +206,11 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         Default is False.
 
     """
+    _extra_coords = NDCubeLinkedDescriptor(ExtraCoords)
+    _global_coords = NDCubeLinkedDescriptor(GlobalCoords)
 
     def __init__(self, data, wcs=None, uncertainty=None, mask=None, meta=None,
-                 unit=None, extra_coords=None, copy=False, **kwargs):
+                 unit=None, copy=False, **kwargs):
 
         super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask,
                          meta=meta, unit=unit, copy=copy, **kwargs)
@@ -185,29 +219,19 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
         if self.wcs is None:
             raise TypeError("The WCS argument can not be None.")
 
-        # Format extra coords.
-        if not extra_coords:
-            # Get existing extra_coords if initializing from an NDCube
-            if hasattr(data, "extra_coords"):
-                extra_coords = data.extra_coords
-            else:
-                extra_coords = ExtraCoords()
-
-        if not isinstance(extra_coords, ExtraCoords):
-            raise TypeError("The extra_coords argument must be a ndcube.ExtraCoords object.")
+        # Get existing extra_coords if initializing from an NDCube
+        if hasattr(data, "extra_coords"):
+            extra_coords = data.extra_coords
+            if copy:
+                extra_coords = deepcopy(extra_coords)
+            self._extra_coords = extra_coords
 
         # Get existing global_coords if initializing from an NDCube
         if hasattr(data, "global_coords"):
             global_coords = data._global_coords
-        else:
-            global_coords = GlobalCoords(self)
-
-        if copy:
-            extra_coords = deepcopy(extra_coords)
-            global_coords = deepcopy(global_coords)
-
-        self._extra_coords = extra_coords
-        self._global_coords = global_coords
+            if copy:
+                global_coords = deepcopy(global_coords)
+            self._global_coords = global_coords
 
     @property
     def extra_coords(self):

--- a/ndcube/tests/test_extra_coords.py
+++ b/ndcube/tests/test_extra_coords.py
@@ -206,6 +206,8 @@ def test_skycoord_1_pixel(skycoord_1d_lut):
     assert sec.wcs.world_n_dim == 2
     assert sec.wcs.world_axis_names == ("lon", "lat")
 
+    assert isinstance(sec.wcs.pixel_to_world(0), SkyCoord)
+
 
 def test_skycoord_mesh_false(skycoord_2d_lut):
     cube = MagicMock()

--- a/ndcube/tests/test_extra_coords.py
+++ b/ndcube/tests/test_extra_coords.py
@@ -61,19 +61,15 @@ def test_empty_ec(wcs_1d_l):
 
 
 def test_exceptions(wcs_1d_l):
-    # Test fail when one of wcs or mapping specified
-    with pytest.raises(ValueError):
-        ExtraCoords(wcs=wcs_1d_l)
-
-    with pytest.raises(ValueError):
-        ExtraCoords(mapping=0)
-
     # Test unable to specify inconsistent dimensions and tables
     with pytest.raises(ValueError):
         ExtraCoords.from_lookup_tables(None, (0,), (0, 0))
 
     # Test unable to add to WCS EC
-    ec = ExtraCoords(wcs=wcs_1d_l, mapping=(0,))
+    ec = ExtraCoords()
+    ec.wcs = wcs_1d_l
+    ec.mapping = (0,)
+
     with pytest.raises(ValueError):
         ec.add(None, 0, None)
 
@@ -82,7 +78,10 @@ def test_exceptions(wcs_1d_l):
 
 
 def test_mapping_setter(wcs_1d_l, wave_lut):
-    ec = ExtraCoords(wcs=wcs_1d_l, mapping=(0,))
+    ec = ExtraCoords()
+    ec.wcs = wcs_1d_l
+    ec.mapping = (0,)
+
     with pytest.raises(AttributeError):
         ec.mapping = None
 
@@ -98,7 +97,10 @@ def test_mapping_setter(wcs_1d_l, wave_lut):
 
 
 def test_wcs_setter(wcs_1d_l, wave_lut):
-    ec = ExtraCoords(wcs=wcs_1d_l, mapping=(0,))
+    ec = ExtraCoords()
+    ec.wcs = wcs_1d_l
+    ec.mapping = (0,)
+
     with pytest.raises(AttributeError):
         ec.wcs = None
 
@@ -114,7 +116,9 @@ def test_wcs_setter(wcs_1d_l, wave_lut):
 
 
 def test_wcs_1d(wcs_1d_l):
-    ec = ExtraCoords(wcs=wcs_1d_l, mapping=(0,))
+    ec = ExtraCoords()
+    ec.wcs = wcs_1d_l
+    ec.mapping = (0,)
 
     assert ec.keys() == ('spectral',)
     assert ec.mapping == (0,)

--- a/ndcube/tests/test_lookup_table_coord.py
+++ b/ndcube/tests/test_lookup_table_coord.py
@@ -517,12 +517,12 @@ def test_mtc_dropped_quantity_table(lut_1d_time, lut_2d_distance_no_mesh):
     assert dwd
     assert all(len(value) == 2 for value in dwd.values())
 
-    assert dwd["world_axis_names"] == [None, None]
+    assert dwd["world_axis_names"] == ["", ""]
     assert all(isinstance(u, str) for u in dwd["world_axis_units"])
     assert dwd["world_axis_units"] == ["km", "km"]
     assert dwd["world_axis_physical_types"] == ["custom:SPATIAL", "custom:SPATIAL"]
-    assert dwd["world_axis_object_components"] == [("SPATIAL0", 0, "value"), ("SPATIAL1", 0, "value")]
-    assert wao_classes["SPATIAL0"][0] is u.Quantity
+    assert dwd["world_axis_object_components"] == [("SPATIAL", 0, "value"), ("SPATIAL1", 0, "value")]
+    assert wao_classes["SPATIAL"][0] is u.Quantity
     assert wao_classes["SPATIAL1"][0] is u.Quantity
     assert dwd["value"] == [0*u.km, 9*u.km]
 
@@ -566,6 +566,7 @@ def test_mtc_dropped_quantity_inside_table_no_mesh(lut_2d_distance_no_mesh):
 
     dwd = sub.dropped_world_dimensions
     assert isinstance(dwd, dict)
+    dwd.pop("world_axis_object_classes")
     assert not dwd
 
 

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -193,7 +193,7 @@ def test_axis_world_coords_complex_ec(ndcube_4d_ln_lt_l_t):
     data = np.arange(np.product(ec_shape)).reshape(ec_shape) * u.m / u.s
 
     # The lookup table has to be in world order so transpose it.
-    cube.extra_coords.add('velocity', (1, 2), data.T)
+    cube.extra_coords.add('velocity', (2, 1), data.T)
 
     coords = cube.axis_world_coords(wcs=cube.extra_coords)
     assert len(coords) == 1

--- a/ndcube/utils/misc.py
+++ b/ndcube/utils/misc.py
@@ -4,8 +4,6 @@ from functools import wraps
 import astropy.units as u
 from astropy.wcs.wcsapi import BaseHighLevelWCS
 
-from ndcube.extra_coords import ExtraCoords
-
 __all__ = ['sanitise_wcs', 'unique_sorted']
 
 
@@ -29,6 +27,9 @@ def sanitise_wcs(func):
     to the dimensionality of the array. It will finally verify that the object
     passed is a HighLevelWCS object, or an ExtraCoords object.
     """
+    # This needs to be here to prevent a circular import
+    from ndcube.extra_coords import ExtraCoords
+
     @wraps(func)
     def wcs_wrapper(*args, **kwargs):
         sig = inspect.signature(func)

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -74,9 +74,9 @@ def convert_between_array_and_pixel_axes(axis, naxes):
     """
     # Check type of input.
     if not isinstance(axis, np.ndarray):
-        raise TypeError("input must be of array type. Got type: {type(axis)}")
+        raise TypeError(f"input must be of array type. Got type: {type(axis)}")
     if axis.dtype.char not in np.typecodes['AllInteger']:
-        raise TypeError("input dtype must be of int type.  Got dtype: {axis.dtype})")
+        raise TypeError(f"input dtype must be of int type.  Got dtype: {axis.dtype})")
     # Convert negative indices to positive equivalents.
     axis[axis < 0] += naxes
     if any(axis > naxes - 1):


### PR DESCRIPTION
Once upon a time I decided to throw up a quick fix for #349. Then I realised that to fix that issue the `ExtraCoords` object needed to  know the dimensionality of the array, which means it needs a reference to the cube like `GlobalCoords`. So this PR addresses this by making the following changes:

* Change the constructor of `ExtraCoords` to take one optional argument `ndcube`.
* Remove the extra_coords kwarg from `NDCube` the canonical way to add coords to the `ExtraCoords` or `GlobalCoords` is `NDCube.xxxx_coords.add`.
* Write a descriptor for the `_extra_coords` and `_global_coords` attributes which when a coords object is assigned to the attribute sets the `._ndcube` attribute of the object. This means that all our internal code which sets the hidden attributes automatically ensures the parent reference is correct.
* Fix the cause of #349 which was `ExtraCoords.mapping` using array coordinates not pixel coordinates. Add a regression test for this as well.

This therefore fixes #349 and also fixes #417

It also closes #408 by deciding no for both `GlobalCoords` and `ExtraCoords`; however, it makes it real easy to change our minds in the future, by changing the descriptors to be not prefixed with `_`.