### PR TITLE
Fix typo in doc reference

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -457,13 +457,13 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
     @utils.misc.sanitise_wcs
     def crop(self, lower_corner, upper_corner, wcs=None):
-        # The docstring is defined in NDCubeBase
+        # The docstring is defined in NDCubeABC
         lower_corner, upper_corner = utils.misc.sanitize_corners(lower_corner, upper_corner)
         return self._crop(lower_corner, upper_corner, wcs, False)
 
     @utils.misc.sanitise_wcs
     def crop_by_values(self, lower_corner, upper_corner, units=None, wcs=None):
-        # The docstring is defined in NDCubeBase
+        # The docstring is defined in NDCubeABC
         # Sanitize inputs.
         lower_corner, upper_corner = utils.misc.sanitize_corners(lower_corner, upper_corner)
         n_coords = len(lower_corner)


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

Fixes typo in `NDCube.crop()` and `NDCube.crop_by_values()`.

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->