### PR TITLE
Initial implementation for validating two WCS

### DIFF
--- a/changelog/433.trivial.rst
+++ b/changelog/433.trivial.rst
@@ -1,0 +1,1 @@
+Adds a function to compare the physical types of two WCS objects.

--- a/ndcube/utils/tests/test_utils_wcs.py
+++ b/ndcube/utils/tests/test_utils_wcs.py
@@ -157,3 +157,11 @@ def test_array_indices_for_world_objects_2(wcs_4d_lt_t_l_ln):
     array_indices = utils.wcs.array_indices_for_world_objects(wcs_4d_lt_t_l_ln, ('lon', 'time'))
     assert len(array_indices) == 2
     assert array_indices == ((0, 3), (2,))
+
+
+def test_compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_3d_l_lt_ln):
+    wcs_compatibility = utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_4d_t_l_lt_ln)
+    assert wcs_compatibility == True
+
+    wcs_compatibility = utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_3d_l_lt_ln)
+    assert wcs_compatibility == False

--- a/ndcube/utils/tests/test_utils_wcs.py
+++ b/ndcube/utils/tests/test_utils_wcs.py
@@ -161,6 +161,4 @@ def test_array_indices_for_world_objects_2(wcs_4d_lt_t_l_ln):
 
 def test_compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_3d_l_lt_ln):
     assert utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_4d_t_l_lt_ln) is True
-
-    wcs_compatibility = utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_3d_l_lt_ln)
-    assert wcs_compatibility is False
+    assert utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_3d_l_lt_ln) is False

--- a/ndcube/utils/tests/test_utils_wcs.py
+++ b/ndcube/utils/tests/test_utils_wcs.py
@@ -160,8 +160,7 @@ def test_array_indices_for_world_objects_2(wcs_4d_lt_t_l_ln):
 
 
 def test_compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_3d_l_lt_ln):
-    wcs_compatibility = utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_4d_t_l_lt_ln)
-    assert wcs_compatibility is True
+    assert utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_4d_t_l_lt_ln) is True
 
     wcs_compatibility = utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_3d_l_lt_ln)
     assert wcs_compatibility is False

--- a/ndcube/utils/tests/test_utils_wcs.py
+++ b/ndcube/utils/tests/test_utils_wcs.py
@@ -161,7 +161,7 @@ def test_array_indices_for_world_objects_2(wcs_4d_lt_t_l_ln):
 
 def test_compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_3d_l_lt_ln):
     wcs_compatibility = utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_4d_t_l_lt_ln)
-    assert wcs_compatibility == True
+    assert wcs_compatibility is True
 
     wcs_compatibility = utils.wcs.compare_wcs_physical_types(wcs_4d_t_l_lt_ln, wcs_3d_l_lt_ln)
-    assert wcs_compatibility == False
+    assert wcs_compatibility is False

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -437,8 +437,7 @@ def validate_wcs(source_wcs, target_wcs):
 
     Parameters
     ----------
-    source_wcs : `astropy.wcs.WCS` or any other object that implements
-                    `astropy.wcs.wcsapi.BaseHighLevelWCS` or `astropy.wcs.wcsapi.BaseLowLevelWCS`
+    source_wcs : `astropy.wcs.wcsapi.BaseHighLevelWCS` or `astropy.wcs.wcsapi.BaseLowLevelWCS`
         The WCS which is currently in use, usually `self.wcs`.
 
     target_wcs : `astropy.wcs.WCS` or any other object that implements

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -431,7 +431,7 @@ def array_indices_for_world_objects(wcs, axes=None):
     return tuple(ai for ai in array_indices if ai)
 
 
-def validate_wcs(source_wcs, target_wcs):
+def compare_wcs_physical_types(source_wcs, target_wcs):
     """
     Checks if two WCS objects are comptible with each other for reprojecting an NDCube on another.
 
@@ -440,9 +440,8 @@ def validate_wcs(source_wcs, target_wcs):
     source_wcs : `astropy.wcs.wcsapi.BaseHighLevelWCS` or `astropy.wcs.wcsapi.BaseLowLevelWCS`
         The WCS which is currently in use, usually `self.wcs`.
 
-    target_wcs : `astropy.wcs.WCS` or any other object that implements
-                    `astropy.wcs.wcsapi.BaseHighLevelWCS` or `astropy.wcs.wcsapi.BaseLowLevelWCS`
-        The WCS object on which the NDCube is to reprojected.
+    target_wcs : `astropy.wcs.wcsapi.BaseHighLevelWCS` or `astropy.wcs.wcsapi.BaseLowLevelWCS`
+        The WCS object on which the NDCube is to be reprojected.
 
     Returns
     -------

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -8,7 +8,7 @@ import numbers
 from collections import UserDict
 
 import numpy as np
-from astropy.wcs.wcsapi import low_level_api, BaseHighLevelWCS, BaseLowLevelWCS
+from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS, low_level_api
 
 __all__ = ['array_indices_for_world_objects', 'convert_between_array_and_pixel_axes',
            'calculate_world_indices_from_axes', 'wcs_ivoa_mapping',

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -458,7 +458,7 @@ def get_low_level_wcs(wcs, name='wcs'):
 
 def compare_wcs_physical_types(source_wcs, target_wcs):
     """
-    Checks if two WCS objects are comptible with each other for reprojecting an NDCube on another.
+    Checks to see if two WCS objects have the same physical types in the same order.
 
     Parameters
     ----------

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -431,6 +431,31 @@ def array_indices_for_world_objects(wcs, axes=None):
     return tuple(ai for ai in array_indices if ai)
 
 
+def get_low_level_wcs(wcs, name='wcs'):
+    """
+    Returns a low level WCS object from a low level or high level WCS.
+
+    Parameters
+    ----------
+    wcs: `astropy.wcs.wcsapi.BaseHighLevelWCS` or `astropy.wcs.wcsapi.BaseLowLevelWCS`
+        The input WCS for getting the low level WCS object.
+
+    name: `str`, optional
+        Any name for the wcs to be used in the exception that could be raised.
+
+    Returns
+    -------
+    wcs: `astropy.wcs.wcsapi.BaseLowLevelWCS`
+    """
+
+    if isinstance(wcs, BaseHighLevelWCS):
+        return wcs.low_level_wcs
+    elif isinstance(wcs, BaseLowLevelWCS):
+        return wcs
+    else:
+        raise(f'{name} must implement either BaseHighLevelWCS or BaseLowLevelWCS')
+
+
 def compare_wcs_physical_types(source_wcs, target_wcs):
     """
     Checks if two WCS objects are comptible with each other for reprojecting an NDCube on another.
@@ -448,15 +473,7 @@ def compare_wcs_physical_types(source_wcs, target_wcs):
     result : `bool`
     """
 
-    def convert_to_low_level(wcs, name='wcs'):
-        if isinstance(wcs, BaseHighLevelWCS):
-            return wcs.low_level_wcs
-        elif isinstance(wcs, BaseLowLevelWCS):
-            return wcs
-        else:
-            raise(f'{name} must implement either BaseHighLevelWCS or BaseLowLevelWCS')
-
-    source_wcs = convert_to_low_level(source_wcs, 'source_wcs')
-    target_wcs = convert_to_low_level(target_wcs, 'target_wcs')
+    source_wcs = get_low_level_wcs(source_wcs, 'source_wcs')
+    target_wcs = get_low_level_wcs(target_wcs, 'target_wcs')
 
     return source_wcs.world_axis_physical_types == target_wcs.world_axis_physical_types


### PR DESCRIPTION
### Description

Fixes #428.

An initial implementation of the validate function for checking if two WCS objects are compatible with each other to reproject an `NDCube` on top of another.

