### PR TITLE
Remove test for invalid header

### DIFF
--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -592,15 +592,6 @@ def test_reproject_with_header(ndcube_4d_ln_l_t_lt, wcs_4d_lt_t_l_ln):
     _ = ndcube_4d_ln_l_t_lt.reproject_to(target_wcs_header, shape_out)
 
 
-def test_reproject_invalid_header(ndcube_4d_ln_l_t_lt, wcs_4d_lt_t_l_ln):
-    target_wcs_header = wcs_4d_lt_t_l_ln.low_level_wcs.to_header()
-    target_wcs_header['CDELT3'] = None
-    shape_out = (5, 20, 12, 8)
-
-    with pytest.raises(Exception):
-        _ = ndcube_4d_ln_l_t_lt.reproject_to(target_wcs_header, shape_out)
-
-
 def test_reproject_return_footprint(ndcube_4d_ln_l_t_lt, wcs_4d_lt_t_l_ln):
     target_wcs_header = wcs_4d_lt_t_l_ln.low_level_wcs.to_header()
     target_wcs_header['CDELT3'] = 0.1   # original value = 0.2

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,14 @@ from setuptools.config import read_configuration
 ################################################################################
 extras = read_configuration("setup.cfg")['options']['extras_require']
 
-# Dev is everything
-extras['dev'] = list(chain(*extras.values()))
 
 # All is everything but tests and docs
-exclude_keys = ("tests", "docs", "dev")
+exclude_keys = ("tests", "docs")
 ex_extras = dict(filter(lambda i: i[0] not in exclude_keys, extras.items()))
 # Concatenate all the values together for 'all'
 extras['all'] = list(chain.from_iterable(ex_extras.values()))
+# Dev is everything
+extras['dev'] = list(chain(*extras.values()))
 
 setup(
     extras_require=extras,


### PR DESCRIPTION
This test was really asserting a warning (which was being promoted to an error). I don't think we really need it we can just delegate this behaviour to the WCS constructor.