### PR TITLE
Resampled wcs

### DIFF
--- a/changelog/449.bugfix.rst
+++ b/changelog/449.bugfix.rst
@@ -1,1 +1,0 @@
-Ensure `~ndcube.wcs.wrappers.resampled_wcs.ResampledWCS` accounts for the fact that pixel indices represent pixel centers and so a shift is required when converted between pixel grids.

--- a/changelog/449.bugfix.rst
+++ b/changelog/449.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure `~ndcube.wcs.wrappers.resampled_wcs.ResampledWCS` accounts for the fact that pixel indices represent pixel centers and so a shift is required when converted between pixel grids.

--- a/changelog/449.feature.rst
+++ b/changelog/449.feature.rst
@@ -1,0 +1,1 @@
+Introduce optional offset between old and new pixel grids in `~ndcube.wcs.wrappers.resampled_wcs.ResampledLowLevelWCS`.

--- a/ndcube/wcs/wrappers/resampled_wcs.py
+++ b/ndcube/wcs/wrappers/resampled_wcs.py
@@ -21,8 +21,8 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
     def __init__(self, wcs, factor):
         self._wcs = wcs
         if np.isscalar(factor):
-            factor = np.array([factor] * self.pixel_n_dim)
-        self._factor = factor
+            factor = [factor] * self.pixel_n_dim
+        self._factor = np.array(factor)
 
     def _top_to_underlying_pixels(self, top_pixels):
         # Convert user-facing pixel indices to the pixel grid of underlying WCS.

--- a/ndcube/wcs/wrappers/resampled_wcs.py
+++ b/ndcube/wcs/wrappers/resampled_wcs.py
@@ -65,7 +65,7 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
 
     @property
     def pixel_shape(self):
-        return tuple(np.asarray(self._wcs.pixel_shape) / self._factor)
+        return tuple((np.asarray(self._wcs.pixel_shape) / self._factor).astype(int))
 
     @property
     def pixel_bounds(self):

--- a/ndcube/wcs/wrappers/resampled_wcs.py
+++ b/ndcube/wcs/wrappers/resampled_wcs.py
@@ -14,6 +14,7 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
     ----------
     wcs : `~astropy.wcs.wcsapi.BaseLowLevelWCS`
         The original WCS for which to reorder axes
+
     factor : int or float or iterable
         The factor by which to increase the pixel size for each pixel
         axis. If a scalar, the same factor is used for all axes.
@@ -36,7 +37,6 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
         # Subtractive factor makes sure the correct sub-pixel location is returned.
         factor_shape = list(self._factor.shape) + [1] * (underlying_pixels.ndim - 1)
         factor = self._factor.reshape(factor_shape)
-        #factor = self._factor
         return (underlying_pixels - (factor - 1) / 2) / factor
 
     def pixel_to_world_values(self, *pixel_arrays):

--- a/ndcube/wcs/wrappers/resampled_wcs.py
+++ b/ndcube/wcs/wrappers/resampled_wcs.py
@@ -43,8 +43,8 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
 
     def _underlying_to_top_pixels(self, underlying_pixels):
         # Convert pixel indices of underlying pixel grid to user-facing grid.
-        factor = self._pad_dims(self._factor, top_pixels.ndim)
-        offset = self._pad_dims(self._offset, top_pixels.ndim)
+        factor = self._pad_dims(self._factor, underlying_pixels.ndim)
+        offset = self._pad_dims(self._offset, underlying_pixels.ndim)
         return (underlying_pixels - offset) / factor
 
     def _pad_dims(self, arr, ndim):
@@ -65,7 +65,12 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
 
     @property
     def pixel_shape(self):
-        return tuple((np.asarray(self._wcs.pixel_shape) / self._factor).astype(int))
+        # Return pixel shape of resampled grid.
+        # Where shape is an integer, return an int type as its required for some uses.
+        underlying_shape = np.asarray(self._wcs.pixel_shape)
+        int_elements = np.mod(underlying_shape, self._factor) == 0
+        pixel_shape = underlying_shape / self._factor
+        return tuple(int(i) if is_int else i for i, is_int in zip(pixel_shape, int_elements))
 
     @property
     def pixel_bounds(self):

--- a/ndcube/wcs/wrappers/resampled_wcs.py
+++ b/ndcube/wcs/wrappers/resampled_wcs.py
@@ -53,7 +53,6 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
 
     @property
     def pixel_bounds(self):
-        if self._wcs.pixel_bounds is None:
-            return self._wcs.pixel_bounds
-        top_level_bounds = self._underlying_to_top_pixels(np.asarray(self._wcs.pixel_bounds))
-        return [tuple(bounds) for bounds in top_level_bounds]
+        return tuple((self._wcs.pixel_bounds[i][0] / self._factor[i],
+                      self._wcs.pixel_bounds[i][1] / self._factor[i])
+                     for i in range(self.pixel_n_dim))

--- a/ndcube/wcs/wrappers/resampled_wcs.py
+++ b/ndcube/wcs/wrappers/resampled_wcs.py
@@ -67,6 +67,8 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
     def pixel_shape(self):
         # Return pixel shape of resampled grid.
         # Where shape is an integer, return an int type as its required for some uses.
+        if self._wcs.pixel_shape is None:
+            return self._wcs.pixel_shape
         underlying_shape = np.asarray(self._wcs.pixel_shape)
         int_elements = np.mod(underlying_shape, self._factor) == 0
         pixel_shape = underlying_shape / self._factor

--- a/ndcube/wcs/wrappers/resampled_wcs.py
+++ b/ndcube/wcs/wrappers/resampled_wcs.py
@@ -18,22 +18,25 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
         The factor by which to increase the pixel size for each pixel
         axis. If a scalar, the same factor is used for all axes.
 
-    offset: `int` or `float` or iterable the same
+    offset: `int` or `float` or iterable of the same
         The location on the underlying pixel grid which corresponds
-        to zero on the top level pixel grid.
+        to zero on the top level pixel grid. If a scalar, the grid will be
+        shifted by the same amount in all dimensions.
     """
-    def __init__(self, wcs, factor, offset=None):
+    def __init__(self, wcs, factor, offset=0):
         self._wcs = wcs
         if np.isscalar(factor):
             factor = [factor] * self.pixel_n_dim
         self._factor = np.array(factor)
+        if len(self._factor) !=  self.pixel_n_dim:
+            raise ValueError(f"Length of factor must equal number of dimensions {self.pixel_n_dim}.")
         if offset is None:
             offset = 0
         if np.isscalar(offset):
             offset = [offset] * self.pixel_n_dim
         self._offset = np.array(offset)
-        if len(self._offset) != len(self._factor):
-            raise ValueError("offset must have same len as factor.")
+        if len(self._offset) != self.pixel_n_dim:
+            raise ValueError(f"Length of offset must equal number of dimensions {self.pixel_n_dim}.")
 
     def _top_to_underlying_pixels(self, top_pixels):
         # Convert user-facing pixel indices to the pixel grid of underlying WCS.
@@ -70,9 +73,11 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
         if self._wcs.pixel_shape is None:
             return self._wcs.pixel_shape
         underlying_shape = np.asarray(self._wcs.pixel_shape)
-        int_elements = np.mod(underlying_shape, self._factor) == 0
+        int_elements = np.isclose(np.mod(underlying_shape, self._factor), 0,
+                                  atol=np.finfo(float).resolution)
         pixel_shape = underlying_shape / self._factor
-        return tuple(int(i) if is_int else i for i, is_int in zip(pixel_shape, int_elements))
+        return tuple(int(np.rint(i)) if is_int else i for i, is_int
+                     in zip(pixel_shape, int_elements))
 
     @property
     def pixel_bounds(self):

--- a/ndcube/wcs/wrappers/resampled_wcs.py
+++ b/ndcube/wcs/wrappers/resampled_wcs.py
@@ -30,8 +30,6 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
         self._factor = np.array(factor)
         if len(self._factor) !=  self.pixel_n_dim:
             raise ValueError(f"Length of factor must equal number of dimensions {self.pixel_n_dim}.")
-        if offset is None:
-            offset = 0
         if np.isscalar(offset):
             offset = [offset] * self.pixel_n_dim
         self._offset = np.array(offset)
@@ -76,8 +74,8 @@ class ResampledLowLevelWCS(BaseWCSWrapper):
         int_elements = np.isclose(np.mod(underlying_shape, self._factor), 0,
                                   atol=np.finfo(float).resolution)
         pixel_shape = underlying_shape / self._factor
-        return tuple(int(np.rint(i)) if is_int else i for i, is_int
-                     in zip(pixel_shape, int_elements))
+        return tuple(int(np.rint(i)) if is_int else i
+                     for i, is_int in zip(pixel_shape, int_elements))
 
     @property
     def pixel_bounds(self):

--- a/ndcube/wcs/wrappers/resampled_wcs.py
+++ b/ndcube/wcs/wrappers/resampled_wcs.py
@@ -1,5 +1,4 @@
 import numpy as np
-from astropy.wcs.wcsapi import BaseHighLevelWCS
 from astropy.wcs.wcsapi.wrappers.base import BaseWCSWrapper
 
 __all__ = ['ResampledLowLevelWCS']

--- a/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
+++ b/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
@@ -135,7 +135,7 @@ def test_offset(celestial_wcs):
                          indirect=True)
 def test_factor_wrong_length_error(celestial_wcs):
     with pytest.raises(ValueError):
-        wcs = ResampledLowLevelWCS(celestial_wcs, [2] * 3)
+        ResampledLowLevelWCS(celestial_wcs, [2] * 3)
 
 
 @pytest.mark.parametrize('celestial_wcs',

--- a/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
+++ b/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
@@ -60,10 +60,11 @@ def test_2d(celestial_wcs):
     # Shapes and bounds should be floating-point if needed
     assert_allclose(wcs.pixel_shape, (15, 7/3))
     assert_allclose(wcs.array_shape, (7/3, 15))
+    print(celestial_wcs.pixel_bounds, wcs.pixel_bounds, [0.4, 3])
     assert_allclose(wcs.pixel_bounds, ((-2.5, 12.5), (1/3, 7/3)))
 
     pixel_scalar = (2.3, 4.3)
-    world_scalar = (12.16, 13.8)
+    world_scalar = (12.76, 15.8)
     assert_allclose(wcs.pixel_to_world_values(*pixel_scalar), world_scalar)
     assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
     assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)
@@ -71,8 +72,8 @@ def test_2d(celestial_wcs):
 
     pixel_array = (np.array([2.3, 2.4]),
                    np.array([4.3, 4.4]))
-    world_array = (np.array([12.16, 12.08]),
-                   np.array([13.8, 14.4]))
+    world_array = (np.array([12.76, 12.68]),
+                   np.array([15.8, 16.4]))
     assert_allclose(wcs.pixel_to_world_values(*pixel_array), world_array)
     assert_allclose(wcs.array_index_to_world_values(*pixel_array[::-1]), world_array)
     assert_allclose(wcs.world_to_pixel_values(*world_array), pixel_array)
@@ -103,7 +104,7 @@ def test_scalar_factor(celestial_wcs):
     wcs = ResampledLowLevelWCS(celestial_wcs, 2)
 
     pixel_scalar = (2.3, 4.3)
-    world_scalar = (4.8, 5.2)
+    world_scalar = (3.8, 6.2)
     assert_allclose(wcs.pixel_to_world_values(*pixel_scalar), world_scalar)
     assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
     assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)

--- a/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
+++ b/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
@@ -108,3 +108,21 @@ def test_scalar_factor(celestial_wcs):
     assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
     assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)
     assert_allclose(wcs.world_to_array_index_values(*world_scalar), [4, 2])
+
+
+@pytest.mark.parametrize('celestial_wcs',
+                         ['celestial_2d_ape14_wcs', 'celestial_2d_fitswcs'],
+                         indirect=True)
+def test_offset(celestial_wcs):
+    offset = 1
+    factor = 2
+    wcs = ResampledLowLevelWCS(celestial_wcs, factor, offset=offset)
+
+    pixel_scalar = (2.3, 4.3)
+    world_scalar = celestial_wcs.pixel_to_world_values(*[p * factor + offset
+                                                         for p in pixel_scalar])
+
+    assert_allclose(wcs.pixel_to_world_values(*pixel_scalar), world_scalar)
+    assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
+    assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)
+    assert_allclose(wcs.world_to_array_index_values(*world_scalar), [4, 2])

--- a/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
+++ b/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
@@ -1,3 +1,5 @@
+import numbers
+
 import numpy as np
 import pytest
 from astropy import units as u
@@ -126,3 +128,32 @@ def test_offset(celestial_wcs):
     assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
     assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)
     assert_allclose(wcs.world_to_array_index_values(*world_scalar), [4, 2])
+
+
+@pytest.mark.parametrize('celestial_wcs',
+                         ['celestial_2d_ape14_wcs'],
+                         indirect=True)
+def test_factor_wrong_length_error(celestial_wcs):
+    with pytest.raises(ValueError):
+        wcs = ResampledLowLevelWCS(celestial_wcs, [2] * 3)
+
+
+@pytest.mark.parametrize('celestial_wcs',
+                         ['celestial_2d_ape14_wcs'],
+                         indirect=True)
+def test_scalar_wrong_length_error(celestial_wcs):
+    with pytest.raises(ValueError):
+        wcs = ResampledLowLevelWCS(celestial_wcs, 2, offset=[1] * 3)
+
+
+@pytest.mark.parametrize('celestial_wcs',
+                         ['celestial_2d_ape14_wcs', 'celestial_2d_fitswcs'],
+                         indirect=True)
+def test_int_fraction_pixel_shape(celestial_wcs):
+    # Some fractional factors are not representable by exact floats, e.g. 1/3.
+    # However, it is still desirable for the pixel shape to return ints in these cases.
+    # This test checks that this is the case.
+    wcs = ResampledLowLevelWCS(celestial_wcs, 1/3)
+    assert wcs.pixel_shape == (18, 21)
+    for dim in wcs.pixel_shape:
+        assert isinstance(dim, numbers.Integral)

--- a/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
+++ b/ndcube/wcs/wrappers/tests/test_resampled_wcs.py
@@ -60,11 +60,10 @@ def test_2d(celestial_wcs):
     # Shapes and bounds should be floating-point if needed
     assert_allclose(wcs.pixel_shape, (15, 7/3))
     assert_allclose(wcs.array_shape, (7/3, 15))
-    print(celestial_wcs.pixel_bounds, wcs.pixel_bounds, [0.4, 3])
     assert_allclose(wcs.pixel_bounds, ((-2.5, 12.5), (1/3, 7/3)))
 
     pixel_scalar = (2.3, 4.3)
-    world_scalar = (12.76, 15.8)
+    world_scalar = (12.16, 13.8)
     assert_allclose(wcs.pixel_to_world_values(*pixel_scalar), world_scalar)
     assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
     assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)
@@ -72,8 +71,8 @@ def test_2d(celestial_wcs):
 
     pixel_array = (np.array([2.3, 2.4]),
                    np.array([4.3, 4.4]))
-    world_array = (np.array([12.76, 12.68]),
-                   np.array([15.8, 16.4]))
+    world_array = (np.array([12.16, 12.08]),
+                   np.array([13.8, 14.4]))
     assert_allclose(wcs.pixel_to_world_values(*pixel_array), world_array)
     assert_allclose(wcs.array_index_to_world_values(*pixel_array[::-1]), world_array)
     assert_allclose(wcs.world_to_pixel_values(*world_array), pixel_array)
@@ -104,7 +103,7 @@ def test_scalar_factor(celestial_wcs):
     wcs = ResampledLowLevelWCS(celestial_wcs, 2)
 
     pixel_scalar = (2.3, 4.3)
-    world_scalar = (3.8, 6.2)
+    world_scalar = (4.8, 5.2)
     assert_allclose(wcs.pixel_to_world_values(*pixel_scalar), world_scalar)
     assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
     assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

This PR updates `ResampledWCS` to account for the fact that pixel indices represent the centres of pixels and therefore a shift must be applied when converting between pixel grids.

Fixes #<Issue Number>
