### PR TITLE
Improve documentation for `ExtraCoords` methods and `physical_types`

### DIFF
--- a/changelog/451.doc.rst
+++ b/changelog/451.doc.rst
@@ -1,0 +1,1 @@
+Document accepted input to ``lookup_table`` in `.ExtraCoords` setting its ``physical_types``.

--- a/changelog/451.feature.rst
+++ b/changelog/451.feature.rst
@@ -1,0 +1,1 @@
+`.ExtraCoords.from_lookup_table` accepts (a seqence of) ``physical_types`` as kwarg to set the types of its ``lookup_tables``.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,9 @@ API Reference
 .. automodapi:: ndcube
    :inherited-members:
 
+.. automodapi:: ndcube.extra_coords.table_coord
+   :headings: ^#
+
 .. automodapi:: ndcube.mixins
 
 .. automodapi:: ndcube.utils

--- a/docs/tabular_coordinates.rst
+++ b/docs/tabular_coordinates.rst
@@ -16,27 +16,29 @@ Tabular Coordinates and WCSes
 =============================
 
 All coordinate information in ndcube is represented as a WCS.
-Even the `.ExtraCoords` class, which allows the user to add tabular data to axes, uses the `gwcs` library to store this information as a WCS.
+Even the `.ExtraCoords` class, which allows the user to add tabular data to axes, uses the
+`gwcs <https://gwcs.readthedocs.io/en/stable/>`_ library to store this information as a WCS.
 This enables ndcube's coordinate transformation and plotting functions to leverage the same infrastructure, irrespective of whether the coordinates are functional or tabular.
 
 The FITS WCS standard also supports tabular axes with the ``-TAB`` CTYPE.
 Support for reading files using this convention has (reasonably) recently been added to Astropy, so if you have a FITS file using this convention you should be able to load it into a `~astropy.wcs.WCS` object.
 If you wish to be able to serialise your NDCube object to FITS files you will need to manually construct a WCS object using the ``-TAB`` convention.
 
-The functionality provided by ndcube makes it easy to construct a `gwcs.WCS` object backed by lookup tables.
+The functionality provided by ndcube makes it easy to construct a `gwcs.wcs.WCS` object backed by lookup tables.
 At the time of writing there are some known issues with the support for generic lookup tables in gwcs.
 
 Constructing a WCS from Lookup Tables
 =====================================
 
 ndcube supports constructing lookup tables from `~astropy.coordinates.SkyCoord`,  `~astropy.time.Time` and `~astropy.units.Quantity` objects.
-These objects are wrapped in `.BaseTableCoordinate` objects which can be composed together into a multi-dimensional WCS.
+These objects are wrapped in `BaseTableCoordinate <.table_coord>` objects which can be composed together into a multi-dimensional WCS.
 
 .. note::
 
    Only one dimensional tables are currently supported. It is possible to construct higher dimensional lookup tables by "meshing" the inputs, which is described below.
 
-A simple example of constructing a WCS from a lookup table is the following temporal axis::
+A simple example of constructing a WCS from a lookup table in a `.TimeTableCoordinate`
+is the following temporal axis::
 
   >>> from astropy.time import Time
   >>> import astropy.units as u

--- a/ndcube/extra_coords/extra_coords.py
+++ b/ndcube/extra_coords/extra_coords.py
@@ -53,8 +53,8 @@ class ExtraCoordsABC(abc.ABC):
         array_dimension : `int` or `tuple` of `int`
             The pixel dimension(s), in the array, to which this lookup table corresponds.
         lookup_table : `object` or sequence of `object`
-            The lookup table. A `BaseTableCoordinate <.table_coord>` or anything that can
-            instantiate one of its subclasses, i.e. currently a `~astropy.time.Time`,
+            The lookup table. A `BaseTableCoordinate <.table_coord>` subclass or anything
+            that can instantiate one, i.e. currently a `~astropy.time.Time`,
             `~astropy.coordinates.SkyCoord`, or a (sequence of) `~astropy.units.Quantity`.
             Note, if this table is multi-dimensional it must (currently) be specified with
             its axes in world order, so transposed with respect to the data array.
@@ -157,13 +157,13 @@ class ExtraCoords(ExtraCoordsABC):
         pixel_dimensions : `tuple` of `int`
             The pixel dimensions (in the array) to which the ``lookup_tables``
             apply. Must be the same length as ``lookup_tables``.
-        lookup_tables : iterable of `object`, optional
+        lookup_tables : iterable of `object`
             The lookup tables which specify the world coordinates for the ``pixel_dimensions``.
-            Must be `BaseTableCoordinate <.table_coord>` or objects from which to
-            instantiate one of its subclasses.
-        physical_types: sequence of `str` or of sequences of `str`
+            Must be `BaseTableCoordinate <.table_coord>` subclass instances or objects from
+            which to instantiate them (see `.ExtraCoords.add`).
+        physical_types: sequence of `str` or of sequences of `str`, optional
             Descriptors of the `physical types <../data_classes.html#dimensions-and-physical-types>`_
-            associated with each axis in the tables. Must be the same length as ``lookup_tables``
+            associated with each axis in the tables. Must be the same length as ``lookup_tables``;
             and length of each element must match the number of dimensions in corresponding
             ``lookup_tables[i]``.
 

--- a/ndcube/extra_coords/extra_coords.py
+++ b/ndcube/extra_coords/extra_coords.py
@@ -56,8 +56,6 @@ class ExtraCoordsABC(abc.ABC):
             The lookup table. A `BaseTableCoordinate <.table_coord>` subclass or anything
             that can instantiate one, i.e. currently a `~astropy.time.Time`,
             `~astropy.coordinates.SkyCoord`, or a (sequence of) `~astropy.units.Quantity`.
-            Note, if this table is multi-dimensional it must (currently) be specified with
-            its axes in world order, so transposed with respect to the data array.
         physical_types: `str` or iterable of `str`, optional
             Descriptor(s) of the `physical type <../data_classes.html#dimensions-and-physical-types>`_
             associated with each axis; length must match the number of dimensions in
@@ -145,7 +143,7 @@ class ExtraCoords(ExtraCoordsABC):
     @classmethod
     def from_lookup_tables(cls, names, pixel_dimensions, lookup_tables, physical_types=None):
         """
-        Construct an ExtraCoords instance from lookup tables.
+        Construct a new ExtraCoords instance from lookup tables.
 
         This is a convience wrapper around `.add` which does not
         expose all the options available in that method.

--- a/ndcube/extra_coords/extra_coords.py
+++ b/ndcube/extra_coords/extra_coords.py
@@ -38,23 +38,30 @@ class ExtraCoordsABC(abc.ABC):
     """
     @abc.abstractmethod
     def add(self,
-            name: str,
+            name: Union[str, Iterable[str]],
             array_dimension: Union[int, Iterable[int]],
             lookup_table: Any,
+            physical_types: Union[str, Iterable[str]] = None,
             **kwargs):
         """
         Add a coordinate to this ``ExtraCoords`` based on a lookup table.
 
         Parameters
         ----------
-        name
-            The name for these world coordinate(s).
-        array_dimension
+        name : `str` or sequence of `str`
+            The name(s) for these world coordinate(s).
+        array_dimension : `int` or `tuple` of `int`
             The pixel dimension(s), in the array, to which this lookup table corresponds.
-        lookup_table
-            The lookup table. Note, if this table is multi-dimensional it must
-            (currently) be specified with its axes in world order, so
-            transposed with respect to the data array.
+        lookup_table : `object` or sequence of `object`
+            The lookup table. A `BaseTableCoordinate <.table_coord>` or anything that can
+            instantiate one of its subclasses, i.e. currently a `~astropy.time.Time`,
+            `~astropy.coordinates.SkyCoord`, or a (sequence of) `~astropy.units.Quantity`.
+            Note, if this table is multi-dimensional it must (currently) be specified with
+            its axes in world order, so transposed with respect to the data array.
+        physical_types: `str` or iterable of `str`, optional
+            Descriptor(s) of the `physical type <../data_classes.html#dimensions-and-physical-types>`_
+            associated with each axis; length must match the number of dimensions in
+            ``lookup_table``.
         """
 
     @abc.abstractmethod
@@ -136,7 +143,7 @@ class ExtraCoords(ExtraCoordsABC):
         self._ndcube = ndcube
 
     @classmethod
-    def from_lookup_tables(cls, names, pixel_dimensions, lookup_tables):
+    def from_lookup_tables(cls, names, pixel_dimensions, lookup_tables, physical_types=None):
         """
         Construct an ExtraCoords instance from lookup tables.
 
@@ -145,15 +152,20 @@ class ExtraCoords(ExtraCoordsABC):
 
         Parameters
         ----------
-        array_shape : `tuple` of `int`, optional
-            The shape of the array.
         names : `tuple` of `str`
             The names of the world coordinates.
         pixel_dimensions : `tuple` of `int`
             The pixel dimensions (in the array) to which the ``lookup_tables``
             apply. Must be the same length as ``lookup_tables``.
-        lookup_tables : `tuple` of `object`
+        lookup_tables : iterable of `object`, optional
             The lookup tables which specify the world coordinates for the ``pixel_dimensions``.
+            Must be `BaseTableCoordinate <.table_coord>` or objects from which to
+            instantiate one of its subclasses.
+        physical_types: sequence of `str` or of sequences of `str`
+            Descriptors of the `physical types <../data_classes.html#dimensions-and-physical-types>`_
+            associated with each axis in the tables. Must be the same length as ``lookup_tables``
+            and length of each element must match the number of dimensions in corresponding
+            ``lookup_tables[i]``.
 
         Returns
         -------
@@ -165,14 +177,20 @@ class ExtraCoords(ExtraCoordsABC):
                 "The length of pixel_dimensions and lookup_tables must match."
             )
 
+        if physical_types is None:
+            physical_types = len(lookup_tables) * [physical_types]
+        elif len(physical_types) != len(lookup_tables):
+            raise ValueError("The number of physical types and lookup_tables must match.")
+
         extra_coords = cls()
 
-        for name, pixel_dim, lookup_table in zip(names, pixel_dimensions, lookup_tables):
-            extra_coords.add(name, pixel_dim, lookup_table)
+        for name, pixel_dim, lookup_table, physical_type in zip(names, pixel_dimensions,
+                                                                lookup_tables, physical_types):
+            extra_coords.add(name, pixel_dim, lookup_table, physical_types=physical_type)
 
         return extra_coords
 
-    def add(self, name, array_dimension, lookup_table, **kwargs):
+    def add(self, name, array_dimension, lookup_table, physical_types=None, **kwargs):
         # docstring in ABC
 
         if self._wcs is not None:
@@ -185,13 +203,13 @@ class ExtraCoords(ExtraCoordsABC):
         if isinstance(lookup_table, BaseTableCoordinate):
             coord = lookup_table
         elif isinstance(lookup_table, Time):
-            coord = TimeTableCoordinate(lookup_table, **kwargs)
+            coord = TimeTableCoordinate(lookup_table, physical_types=physical_types, **kwargs)
         elif isinstance(lookup_table, SkyCoord):
-            coord = SkyCoordTableCoordinate(lookup_table, **kwargs)
+            coord = SkyCoordTableCoordinate(lookup_table, physical_types=physical_types, **kwargs)
         elif isinstance(lookup_table, (list, tuple)):
-            coord = QuantityTableCoordinate(*lookup_table, **kwargs)
+            coord = QuantityTableCoordinate(*lookup_table, physical_types=physical_types, **kwargs)
         elif isinstance(lookup_table, u.Quantity):
-            coord = QuantityTableCoordinate(lookup_table, **kwargs)
+            coord = QuantityTableCoordinate(lookup_table, physical_types=physical_types, **kwargs)
         else:
             raise TypeError(f"The input type {type(lookup_table)} isn't supported")
 

--- a/ndcube/extra_coords/table_coord.py
+++ b/ndcube/extra_coords/table_coord.py
@@ -184,7 +184,7 @@ class BaseTableCoordinate(abc.ABC):
 
 class QuantityTableCoordinate(BaseTableCoordinate):
     """
-    A lookup table made up of N Quantity objects.
+    A lookup table made up of ``N`` `~astropy.units.Quantity` objects.
 
     This class can either be instantiated with N ND arrays (i.e. the output of
     `numpy.meshgrid`) or N 1D arrays (i.e. the input to `numpy.meshgrid`).

--- a/ndcube/extra_coords/tests/test_extra_coords.py
+++ b/ndcube/extra_coords/tests/test_extra_coords.py
@@ -175,7 +175,9 @@ def test_two_1d_from_lut(time_lut):
 
 
 def test_two_1d_from_lookup_tables(time_lut):
-    """Add both ExtraCoords at once using `from_lookup_tables` with `physical_types`"""
+    """
+    Create ExtraCoords from both tables at once using `from_lookup_tables` with `physical_types`.
+    """
 
     exposure_lut = range(10) * u.s
 
@@ -187,6 +189,10 @@ def test_two_1d_from_lookup_tables(time_lut):
     pt.append("custom:time:duration")
     ec = ExtraCoords.from_lookup_tables(["time", "exposure_time"], (0, 0),
                                         [time_lut, exposure_lut], pt)
+
+    # This has created an "orphan" extra_coords with no NDCube connected.
+    with pytest.raises(AttributeError, match=r"'NoneType' object has no attribute 'dimensions'"):
+        assert ec.mapping == (0, 0)
 
     assert len(ec._lookup_tables) == 2
     assert isinstance(ec.wcs, gwcs.WCS)

--- a/ndcube/extra_coords/tests/test_extra_coords.py
+++ b/ndcube/extra_coords/tests/test_extra_coords.py
@@ -174,6 +174,29 @@ def test_two_1d_from_lut(time_lut):
     assert ec.wcs.world_axis_names == ("time", "exposure_time")
 
 
+def test_two_1d_from_lookup_tables(time_lut):
+    """Add both ExtraCoords at once using `from_lookup_tables` with `physical_types`"""
+
+    exposure_lut = range(10) * u.s
+
+    pt = ["custom:time:creation"]
+    with pytest.raises(ValueError, match=r"The number of physical types and lookup_tables"):
+        ec = ExtraCoords.from_lookup_tables(["time", "exposure_time"], (0, 0),
+                                            [time_lut, exposure_lut], pt)
+
+    pt.append("custom:time:duration")
+    ec = ExtraCoords.from_lookup_tables(["time", "exposure_time"], (0, 0),
+                                        [time_lut, exposure_lut], pt)
+
+    assert len(ec._lookup_tables) == 2
+    assert isinstance(ec.wcs, gwcs.WCS)
+    assert ec.wcs.pixel_n_dim == 2
+    assert ec.wcs.world_n_dim == 2
+    assert ec.wcs.world_axis_names == ("time", "exposure_time")
+    for i, physical_types in enumerate(pt):
+        assert ec._lookup_tables[i][1].physical_types == [physical_types]
+
+
 def test_skycoord(skycoord_1d_lut):
     cube = MagicMock()
     cube.dimensions = [10, 10] * u.pix

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
     # The devdeps factor is intended to be used to install the latest developer version.
     # of key dependencies.
     # Astropy is installed from the nightly wheels
-    devdeps: astropy>=4.3dev0,<4.3a0
+    devdeps: astropy>=5.0dev0,<5.0a0
     devdeps: git+https://github.com/sunpy/sunpy
     devdeps: git+https://github.com/spacetelescope/gwcs
 


### PR DESCRIPTION
### Description
This is addressing some of the open documentation issues, specifically #444 and other `TableCoordinate`-related interfaces discussed there.

First, this adds `ndcube.extra_coords.table_coord` to the API reference, as a proxy for `BaseTableCoordinate` and to provide links to its subclasses. Also trying to fix some other broken links in `tabular_coordinates.rst`.

`physical_types` is explicitly declared and documented as kwarg in `ExtraCoords.add` and `ExtraCoords.from_lookup_tables`; as a by-product the latter now also passes `physical_types` on.

Some of the x-refs with labels look a bit unsightly in the inline docstrings, but should render decently in the built docs.

I was trying to also label the intersphinx link for gwcs somehow like `gwcs <~gwcs>`, but that is not recognised as external reference – if anyone has an idea how to do this, or what the intersphinx reference to the toplevel gwcs docs would be, pointers welcome. But since it's only in a single place, putting in the explicit URL is probably OK.
