### PR TITLE
Add Mask class and holding and combining multiple masks

### DIFF
--- a/ndcube/mask.py
+++ b/ndcube/mask.py
@@ -1,0 +1,172 @@
+import copy
+import textwrap
+
+all = ["Mask"]
+
+
+class Mask:
+    """A class for holding and combining boolean mask arrays.
+
+    Each mask can be activated or deactivated and thereby included or excluded
+    from the combined mask. See the activate/deactive methods.
+
+    Parameters
+    ----------
+    masks: dict-like or parseable by `dict`
+        The names and arrays of each mask.
+        Each mask array must be the same shape and of boolean type.
+
+    meta: dict-like
+        Any metadata associated with the masks.
+    """
+    def __init__(self, masks, meta=None):
+        self._masks = dict(masks)
+        shape = self.shape
+        for mask in self._masks.values():
+            if mask.shape != shape:
+                print(mask.shape, shape)
+                raise ValueError("All masks must have same shape.")
+                self._masks[key] = mask.astype(bool)
+        self.meta = meta
+        self._active = dict((key, True) for key in self)
+
+    @property
+    def active_masks(self):
+        """Return the names of active masks"""
+        return tuple(key for key, active in self._active.items() if active)
+
+    @property
+    def mask(self):
+        """Return the combined mask.
+
+        The active masks are compared element-wise. Any element which has a value
+        of True is any active mask is given a value of True in the combined mask.
+        """
+        return sum(self[key] for key in self if self.is_active(key)) > 0
+
+    @property
+    def names(self):
+        """Return the names of all masks, whether active or not."""
+        return tuple(self._masks.keys())
+
+    @property
+    def shape(self):
+        """Return the shape of the masks.
+
+        Note all masks by definition have the same shape.
+        """
+        return self._masks[list(self._masks.keys())[0]].shape
+
+    def add(self, name, mask, activate=True, overwrite=False):
+        """Add a new mask.
+
+        Parameters
+        ----------
+        name: `str`
+            Name of the new mask.
+
+        mask: array-like of boolean type.
+            The mask values.  Must be same shape are masks already present.
+
+        activate: `bool`
+            Whether the mask should be activate or not. Default=True
+
+        overwrite: `bool`
+            If False, an error will be raise if there is already a mask with the same name.
+            Otherwise the mask info will be overwritten.
+        """
+        if name in self and overwrite is not True:
+            raise ValueError(
+                "A mask with this name already exists. Set overwrite=True to overwrite the mask.")
+        if mask.shape != self.shape:
+            raise ValueError(
+                f"New mask must have same shape as masks already present: {self.shape}.")
+        self._masks[name] = mask
+        self._active[name] = bool(activate)
+
+    def remove(self, name):
+        """Remove a mask.
+
+        Parameters
+        ----------
+        name: `str`
+            The name of the mask to remove.
+        """
+        del self._masks[name]
+        del self._active[name]
+
+    def activate(self, names=None, all_masks=False):
+        """Activate a mask.
+
+        Only active masks are included in the calculation of the combined mask.
+
+        Parameters
+        ----------
+        names: `str` or iterable of `str`  (optional)
+            The name or names of the masks to activate.
+            must be set if all_masks=False.
+
+        all_masks: `bool`
+            If True, the names input will be ignored and all masks will be activated.
+        """
+        self._set_active_status(True, names, all_masks)
+
+    def deactivate(self, names=None, all_masks=False):
+        """Deactivate a mask.
+
+        Only active masks are included in the calculation of the combined mask.
+
+        Parameters
+        ----------
+        names: `str` or iterable of `str`  (optional)
+            The name or names of the masks to deactivate.
+            must be set if all_masks=False.
+
+        all_masks: `bool`
+            If True, the names input will be ignored and all masks will be deactivated.
+        """
+        self._set_active_status(False, names, all_masks)
+
+    def _set_active_status(self, activate, names, all_masks):
+        if not (names or all_masks):
+            raise ValueError("If mask names not provided, all_masks must be True.")
+        if all_masks:
+            names = self._active.keys()
+        elif isinstance(names, str):
+            names = (names,)
+        activate = bool(activate)
+        for key in names:
+            self._active[key] = activate
+
+    def is_active(self, key):
+        """Return True is mask is active, False otherwise."""
+        return self._active[key]
+
+    def __getitem__(self, item):
+        if isinstance(item, str):
+            return self._masks[item]
+        sliced_mask = type(self)([(key, mask[item]) for key, mask in self._masks.items()])
+        sliced_mask.meta = copy.deepcopy(self.meta)
+        sliced_mask._active = dict(self._active)
+        return sliced_mask
+
+    def __str__(self):
+        return textwrap.dedent(f"""\
+                Mask
+                ----
+                Component Masks:\t{self.mask_names}
+                Active Masks:\t{self.active_masks}
+                Mask:
+                {self.mask}""")
+
+    def __repr__(self):
+        return f"{object.__repr__(self)}\n{str(self)}"
+
+    def __iter__(self):
+        return iter(self._masks)
+
+    def __contains__(self, name):
+        return name in self._masks
+
+    def __len__(self):
+        return len(self._masks)

--- a/ndcube/tests/test_mask.py
+++ b/ndcube/tests/test_mask.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pytest
+
+from ndcube.mask import Mask
+
+
+@pytest.fixture
+def mask_simple():
+    m =  Mask([("a", np.array([True, False, False])),
+               ("b", np.array([True, False, False])),
+               ("c", np.array([True, True, False]))])
+    m.deactivate("b")
+    return m
+
+
+def test_active_masks(mask_simple):
+    assert mask_simple.active_masks == ("a", "c")
+
+
+def test_mask(mask_simple):
+    expected = np.array([True, True, False])
+    assert all(mask_simple.mask == expected)
+
+
+def test_names(mask_simple):
+    assert mask_simple.names == ("a", "b", "c")
+
+
+def test_shape(mask_simple):
+    assert mask_simple.shape == (3,)
+
+
+def test_add(mask_simple):
+    m = mask_simple
+    d = np.array([True] * m.shape[0])
+    e = np.array([False] * m.shape[0])
+    m.add("d", d, activate=True)
+    assert "d" in m
+    assert all(m["d"] == d)
+    assert m.is_active("d")
+    m.add("e", e, activate=False)
+    assert m.is_active("e") is False
+
+
+def test_remove(mask_simple):
+    m = mask_simple
+    name = "a"
+    m.remove(name)
+    assert name not in m
+    assert name not in m.active_masks
+
+
+def test_activate(mask_simple):
+    m = mask_simple
+    name = "b"
+    assert m.is_active(name) is False
+    m.activate(name)
+    assert m.is_active(name) is True
+
+
+def test_deactivate(mask_simple):
+    m = mask_simple
+    name = "c"
+    assert m.is_active(name) is True
+    m.deactivate(name)
+    assert m.is_active(name) is False
+
+
+def test_is_active(mask_simple):
+    m = mask_simple
+    assert m.is_active("a") is True
+    assert m.is_active("b") is False
+
+
+def test_index_by_string(mask_simple):
+    assert all(mask_simple["a"] == np.array([True, False, False]))
+
+
+def test_slice(mask_simple):
+    m = mask_simple
+    item = slice(1, None)
+    output = m[item]
+    expected = Mask([("a", np.array([False, False])),
+                     ("b", np.array([False, False])),
+                     ("c", np.array([True, False]))])
+    expected.deactivate("b")
+    assert_masks_equal(output, expected)
+
+
+def test_contains(mask_simple):
+    m = mask_simple
+    assert "a" in m
+    assert "d" not in m
+
+
+def test_len(mask_simple):
+    assert len(mask_simple) == 3
+
+
+def assert_masks_equal(mask1, mask2):
+    assert mask1.names == mask2.names
+    assert mask1._active.keys() == mask2._active.keys()
+    assert mask1.active_masks == mask2.active_masks
+    for key in mask1:
+        assert all(mask1[key] == mask2[key])


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

This `Mask` class enables multiple masks to be stored which can be combined via the logical OR principle, i.e. if any pixel has a `True` value in any component mask, the value in the combined mask will be `True`.  This facilitates masking an `NDCube` based on different criteria, e.g.:
* pixels outside FOV
* bad data, e.g. cosmic ray hits, dust in optical path, etc.
* regions/features of interest
* etc.

Component masks can be activated and deactivated via `Mask.activate`/`Mask.deactivate`.  This allows users to be more nuanced in their identification of good/bad data and to switch more quickly between different masking criteria, e.g. include/exclude different regions of interest.  Component masks can added and removed via `Mask.add`/`Mask.remove`, and combined via `Mask.mask`.

Inspection methods/properties include `Mask.is_active(name)` (returns `True` is the `name` mask is active, `False` otherwise), `Mask.active_masks` (returns a `tuple` of the names of active masks) and `Mask.shape` (returning the shape if the masks).

Fixes #257 
