### PR TITLE
Fix bug in get_dependent_world_axes util

### DIFF
--- a/changelog/471.bugfix.rst
+++ b/changelog/471.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in `~ndcube.utils.wcs.get_dependent_world_axes` where an erroneous matrix transpose caused an error for non-square axis correlation matrices and wrong results for diagonally non-symmetric ones.

--- a/ndcube/utils/tests/test_utils_wcs.py
+++ b/ndcube/utils/tests/test_utils_wcs.py
@@ -76,7 +76,6 @@ def test_pixel_axis_to_physical_types(test_wcs):
     output = utils.wcs.pixel_axis_to_physical_types(0, test_wcs)
     expected = np.array(['custom:pos.helioprojective.lon',
                          'custom:pos.helioprojective.lat', 'time'])
-    print(output, expected)
     assert all(output == expected)
 
 
@@ -109,7 +108,6 @@ def test_get_dependent_array_axes(axis_correlation_matrix):
 def test_get_dependent_world_axes(axis_correlation_matrix):
     output = utils.wcs.get_dependent_world_axes(3, axis_correlation_matrix)
     expected = np.array([0, 1, 3])
-    print(output, expected)
     assert all(output == expected)
 
 

--- a/ndcube/utils/tests/test_utils_wcs.py
+++ b/ndcube/utils/tests/test_utils_wcs.py
@@ -112,14 +112,15 @@ def test_get_dependent_array_axes(axis_correlation_matrix):
 
 def test_get_dependent_world_axes(axis_correlation_matrix):
     output = utils.wcs.get_dependent_world_axes(3, axis_correlation_matrix)
-    expected = np.array([0, 3])
+    expected = np.array([0, 1, 3])
     print(output, expected)
     assert all(output == expected)
 
 
 def test_get_dependent_physical_types(test_wcs):
     output = utils.wcs.get_dependent_physical_types("time", test_wcs)
-    expected = np.array(['custom:pos.helioprojective.lon', 'time'])
+    expected = np.array(['custom:pos.helioprojective.lon',
+                         'custom:pos.helioprojective.lat', 'time'])
     assert all(output == expected)
 
 

--- a/ndcube/utils/tests/test_utils_wcs.py
+++ b/ndcube/utils/tests/test_utils_wcs.py
@@ -34,14 +34,10 @@ def axis_correlation_matrix():
 
 
 def _axis_correlation_matrix():
-    shape = (4, 4)
-    acm = np.zeros(shape, dtype=bool)
-    for i in range(min(shape)):
-        acm[i, i] = True
-    acm[0, 1] = True
-    acm[1, 0] = True
-    acm[-1, 0] = True
-    return acm
+    return np.array([[True, True, False, False],
+                     [True, True, False, False],
+                     [False, False, True, False],
+                     [True, False, False, True]], dtype=bool)
 
 
 @pytest.fixture

--- a/ndcube/utils/wcs.py
+++ b/ndcube/utils/wcs.py
@@ -308,7 +308,7 @@ def get_dependent_world_axes(world_axis, axis_correlation_matrix):
     # which world coordinates are linked to which other world coordinates.
     # To do this we take a row from the matrix and find if there are
     # any entries in common with all other rows in the matrix.
-    pixel_dep = axis_correlation_matrix[world_axis:world_axis + 1].T
+    pixel_dep = axis_correlation_matrix[world_axis:world_axis + 1]
     dependent_world_axes = np.sort(np.nonzero((pixel_dep & axis_correlation_matrix).any(axis=1))[0])
     return dependent_world_axes
 


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
This PR fixes a bug found in `get_dependent_world_axes`.  This was caused by an errant matrix transposition which caused an error for non-square axis correlation matrices and led to wrong answers for diagonally non-symmetric ones.

Fixes #<Issue Number>
