### PR TITLE
Add fast method to lookup/estimate WCS limits in world coordinates

### DIFF
--- a/changelog/474.feature.rst
+++ b/changelog/474.feature.rst
@@ -1,0 +1,1 @@
+Add a fast method `~ndcube.NDCube.axis_world_coords_limits` to find wcs extension in world coordinates.

--- a/ndcube/conftest.py
+++ b/ndcube/conftest.py
@@ -190,6 +190,56 @@ def wcs_3d_lt_ln_l():
 
 
 @pytest.fixture
+def wcs_3d_l_ra_dec():
+    header = {
+        'CTYPE1': 'WAVE    ',
+        'CUNIT1': 'Angstrom',
+        'CDELT1': 0.2,
+        'CRPIX1': 0,
+        'CRVAL1': 10,
+
+        'CTYPE2': 'RA---TAN',
+        'CUNIT2': 'deg',
+        'CDELT2': 0.1,
+        'CRPIX2': 200,
+        'CRVAL2': 90.5,
+
+        'CTYPE3': 'DEC--TAN',
+        'CUNIT3': 'deg',
+        'CDELT3': 0.08,
+        'CRPIX3': 150,
+        'CRVAL3': 30.4,
+    }
+
+    return WCS(header=header)
+
+
+@pytest.fixture
+def wcs_3d_l_ra_pol():
+    header = {
+        'CTYPE1': 'WAVE    ',
+        'CUNIT1': 'Angstrom',
+        'CDELT1': 0.2,
+        'CRPIX1': 0,
+        'CRVAL1': 10,
+
+        'CTYPE2': 'RA---TAN',
+        'CUNIT2': 'deg',
+        'CDELT2': 0.1,
+        'CRPIX2': 200,
+        'CRVAL2': 90.5,
+
+        'CTYPE3': 'DEC--TAN',
+        'CUNIT3': 'deg',
+        'CDELT3': 0.08,
+        'CRPIX3': 150,
+        'CRVAL3': 80.4,
+    }
+
+    return WCS(header=header)
+
+
+@pytest.fixture
 def wcs_2d_lt_ln():
     spatial = {
         'CTYPE1': 'HPLT-TAN',
@@ -434,6 +484,38 @@ def ndcube_3d_ln_lt_l_ec_time(wcs_3d_l_lt_ln, time_and_simple_extra_coords_2d):
     )
     cube._extra_coords = time_and_simple_extra_coords_2d
     cube._extra_coords._ndcube = cube
+    return cube
+
+
+@pytest.fixture
+def ndcube_3d_l_ra_dec(wcs_3d_l_ra_dec, simple_extra_coords_3d):
+    shape = (400, 300, 10)
+    wcs_3d_l_ra_dec.array_shape = shape
+    data = data_nd(shape)
+    mask = data > 0
+    cube = NDCube(
+        data,
+        wcs_3d_l_ra_dec,
+        mask=mask,
+        uncertainty=data,
+    )
+    cube._extra_coords = simple_extra_coords_3d
+    return cube
+
+
+@pytest.fixture
+def ndcube_3d_l_ra_pol(wcs_3d_l_ra_pol, simple_extra_coords_3d):
+    shape = (400, 300, 10)
+    wcs_3d_l_ra_pol.array_shape = shape
+    data = data_nd(shape)
+    mask = data > 0
+    cube = NDCube(
+        data,
+        wcs_3d_l_ra_pol,
+        mask=mask,
+        uncertainty=data,
+    )
+    cube._extra_coords = simple_extra_coords_3d
     return cube
 
 

--- a/ndcube/conftest.py
+++ b/ndcube/conftest.py
@@ -537,8 +537,8 @@ def ndcube_3d_rotated(wcs_3d_ln_lt_t_rotated, simple_extra_coords_3d):
 @pytest.fixture
 def ndcube_3d_l_ln_lt_ectime(wcs_3d_lt_ln_l):
     return gen_ndcube_3d_l_ln_lt_ectime(wcs_3d_lt_ln_l,
-                                        1,
-                                        Time('2000-01-01', format='fits', scale='utc'))
+                                        1, Time('2000-01-01', format='fits', scale='utc'))
+
 
 
 @pytest.fixture

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -375,6 +375,21 @@ def test_axis_world_coords_radec(ndcube_3d_l_ra_dec):
     assert u.allclose(coords[1].ra, [63.64277, 104.777] * u.deg)
     assert u.allclose(coords[1].dec, [17.6213, 49.5710] * u.deg)  # [17.6213, 48.7533] at corners
 
+    coords = ndcube_3d_l_ra_dec.axis_world_coords_limits(wcs=ndcube_3d_l_ra_dec.combined_wcs)
+    assert isinstance(coords[1], SkyCoord)
+    assert u.allclose(coords[0], [1.02e-09, 1.20e-09] * u.m)
+    assert u.allclose(coords[2], [0, 3] * u.pix)
+
+    coords = ndcube_3d_l_ra_dec.axis_world_coords_limits(wcs=ndcube_3d_l_ra_dec.extra_coords)
+    assert len(coords) == 1
+    assert u.allclose(coords[0], [0, 3] * u.pix)
+
+    # pytest.xfail("NaNs in ExtraCoords(?)")
+    # this returns an array of len 10 filled up with NaN, does not seem right...
+    coords = ndcube_3d_l_ra_dec.axis_world_coords(wcs=ndcube_3d_l_ra_dec.extra_coords)
+    assert len(coords) == 1
+    assert u.allclose(coords[0][:4], [0, 1, 2, 3] * u.pix)
+
 
 def test_axis_world_coords_rapol(ndcube_3d_l_ra_pol):
     coords = ndcube_3d_l_ra_pol.axis_world_coords()
@@ -434,6 +449,19 @@ def test_axes_world_coords_sky_only(ndcube_2d_ln_lt):
                                            12, 16, 20] * u.arcsec, atol=1e-5 * u.arcsec)
     assert u.allclose(coords[0].Ty[0, :], [-8, -6, -4, -2, 0, 2, 4, 6, 8, 10,
                                            12, 14] * u.arcsec, atol=1e-5 * u.arcsec)
+
+    coords = ndcube_2d_ln_lt.axis_world_coords_limits()
+
+    assert len(coords) == 1
+    assert isinstance(coords[0], SkyCoord)
+    # coords_values are wrapping around 360 deg in lon, yielding bad limits!
+    assert u.allclose(coords[0].Tx, [0, -4] * u.arcsec, atol=1e-5 * u.arcsec)
+    assert u.allclose(coords[0].Ty, [-8, 14] * u.arcsec, atol=1e-5 * u.arcsec)
+
+    coords = ndcube_2d_ln_lt.axis_world_coords_limits(max_size=5)
+
+    assert u.allclose(coords[0].Tx, [0, -4] * u.arcsec, atol=1e-5 * u.arcsec)
+    assert u.allclose(coords[0].Ty, [-8, 14] * u.arcsec, atol=1e-5 * u.arcsec)
 
 
 def test_axis_world_coords_values_all(ndcube_3d_ln_lt_l):

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -191,6 +191,12 @@ def test_axis_world_coords_wave_ec(ndcube_3d_l_ln_lt_ectime):
     assert isinstance(coords[0], u.Quantity)
     assert coords[0].shape == (5,)
 
+    coords = cube.axis_world_coords_limits('em.wl')
+    assert u.allclose(coords, [1.02e-09, 1.20e-09] * u.m)
+
+    coords = cube.axis_world_coords_limits('em.wl', max_size=20)
+    assert u.allclose(coords, [1.02e-09, 1.20e-09] * u.m)
+
 
 def test_axis_world_coords_empty_ec(ndcube_3d_l_ln_lt_ectime):
     cube = ndcube_3d_l_ln_lt_ectime
@@ -286,6 +292,22 @@ def test_axis_world_coords_all_4d_split(ndcube_4d_ln_l_t_lt):
     assert u.allclose(coords[2], [2.0e-11, 4.0e-11, 6.0e-11, 8.0e-11, 1.0e-10,
                                   1.2e-10, 1.4e-10, 1.6e-10, 1.8e-10, 2.0e-10] * u.m)
 
+    coords = ndcube_4d_ln_l_t_lt.axis_world_coords_limits()
+    assert len(coords) == 3
+    assert isinstance(coords[0], SkyCoord)
+    assert u.allclose(coords[0].Tx, [0.0, -5.0] * u.deg / 3600)
+    assert u.allclose(coords[0].Ty, [20.0, 160.0] * u.deg / 3600)
+
+    assert isinstance(coords[1], Time)
+    assert u.allclose(coords[1].value - 58849, np.array([24.0, 288.0]) / 86400)
+
+    assert isinstance(coords[2], u.Quantity)
+    assert u.allclose(coords[2], [2.0e-11, 2.0e-10] * u.m)
+
+    coords = ndcube_4d_ln_l_t_lt.axis_world_coords_limits(max_size=1)
+    assert u.allclose(coords[0].Tx, [0.0, -5.0] * u.deg / 3600)
+    assert u.allclose(coords[0].Ty, [20.0, 160.0] * u.deg / 3600)
+
 
 @pytest.mark.parametrize('wapt', (
     ('custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat', 'em.wl'),
@@ -318,6 +340,65 @@ def test_axis_world_coords_all(ndcube_3d_ln_lt_l):
     assert u.allclose(coords[1].Ty, [[-19.99999991, -14.99999996, -9.99999998],
                                      [-19.99999984, -14.9999999, -9.99999995]] * u.arcsec)
 
+    coords = ndcube_3d_ln_lt_l.axis_world_coords_limits()
+    assert u.allclose(coords[0], [1.02e-09, 1.08e-09] * u.m)
+    assert u.allclose(coords[1].Tx, [10, 20] * u.arcsec)
+    assert u.allclose(coords[1].Ty, [-20, -10] * u.arcsec)
+
+    coords = ndcube_3d_ln_lt_l.axis_world_coords_limits(max_size=1)
+    assert u.allclose(coords[0], [1.02e-09, 1.08e-09] * u.m)
+    assert u.allclose(coords[1].Tx, [10, 20] * u.arcsec)
+    assert u.allclose(coords[1].Ty, [-20, -10] * u.arcsec)
+
+
+def test_axis_world_coords_radec(ndcube_3d_l_ra_dec):
+    coords = ndcube_3d_l_ra_dec.axis_world_coords()
+    assert len(coords) == 2
+    assert isinstance(coords[0], u.Quantity)
+    assert u.allclose(coords[0], np.arange(1.02e-09, 1.22e-09, 2.0e-11) * u.m)
+
+    assert isinstance(coords[1], SkyCoord)
+    assert coords[1].shape == (400, 300)
+
+    coords = ndcube_3d_l_ra_dec.axis_world_coords_limits()
+    assert u.allclose(coords[0], [1.02e-09, 1.20e-09] * u.m)
+    assert u.allclose(coords[1].ra, [63.64277, 104.777] * u.deg)
+    assert u.allclose(coords[1].dec, [17.6213, 49.64235] * u.deg)
+
+    coords = ndcube_3d_l_ra_dec.axis_world_coords_limits(max_size=10000)
+    assert u.allclose(coords[0], [1.02e-09, 1.20e-09] * u.m)
+    assert u.allclose(coords[1].ra, [63.64277, 104.777] * u.deg)
+    assert u.allclose(coords[1].dec, [17.6213, 49.5710] * u.deg)
+
+    coords = ndcube_3d_l_ra_dec.axis_world_coords_limits(max_size=10)
+    assert u.allclose(coords[0], [1.02e-09, 1.20e-09] * u.m)
+    assert u.allclose(coords[1].ra, [63.64277, 104.777] * u.deg)
+    assert u.allclose(coords[1].dec, [17.6213, 49.5710] * u.deg)  # [17.6213, 48.7533] at corners
+
+
+def test_axis_world_coords_rapol(ndcube_3d_l_ra_pol):
+    coords = ndcube_3d_l_ra_pol.axis_world_coords()
+    assert len(coords) == 2
+    assert isinstance(coords[0], u.Quantity)
+
+    assert isinstance(coords[1], SkyCoord)
+    assert coords[1].shape == (400, 300)
+
+    coords = ndcube_3d_l_ra_pol.axis_world_coords_limits()
+    assert u.allclose(coords[0], [1.02e-09, 1.20e-09] * u.m)
+    assert u.allclose(coords[1].ra, [1.4523e-3, 359.9992] * u.deg)
+    assert u.allclose(coords[1].dec, [61.8572, 89.98945] * u.deg)
+
+    coords = ndcube_3d_l_ra_pol.axis_world_coords_limits(max_size=10000)
+    assert u.allclose(coords[0], [1.02e-09, 1.20e-09] * u.m)
+    assert u.allclose(coords[1].ra, [26.1484, 333.4424] * u.deg)
+    assert u.allclose(coords[1].dec, [61.8572, 89.98945] * u.deg)
+
+    coords = ndcube_3d_l_ra_pol.axis_world_coords_limits(max_size=10)
+    assert u.allclose(coords[0], [1.02e-09, 1.20e-09] * u.m)
+    assert u.allclose(coords[1].ra, [26.1484, 333.4424] * u.deg)
+    assert u.allclose(coords[1].dec, [61.8572, 80.429] * u.deg)
+
 
 def test_axis_world_coords_wave(ndcube_3d_ln_lt_l):
     coords = ndcube_3d_ln_lt_l.axis_world_coords('em.wl')
@@ -338,6 +419,10 @@ def test_axis_world_coords_sky(ndcube_3d_ln_lt_l, wapt):
                                      [19.99999994, 19.99999994, 19.99999994]] * u.arcsec)
     assert u.allclose(coords[0].Ty, [[-19.99999991, -14.99999996, -9.99999998],
                                      [-19.99999984, -14.9999999, -9.99999995]] * u.arcsec)
+
+    coords = ndcube_3d_ln_lt_l.axis_world_coords_limits(wapt)
+    assert u.allclose(coords[0].Tx, [10, 20] * u.arcsec)
+    assert u.allclose(coords[0].Ty, [-20, -10] * u.arcsec)
 
 
 def test_axes_world_coords_sky_only(ndcube_2d_ln_lt):


### PR DESCRIPTION
Adding a method `~ndcube.NDCube.axis_world_coords_limits` to return the extension (minimum/maximum in all axes) in world coordinates as laid out in https://github.com/sunpy/ndcube/issues/413#issuecomment-900311068. This returns the appropriate limits as `SkyCoord`, `SpectralCoord` objects in the same format as `axis_world_coords`, to be built into the `__str__` representation:
```python
>>> cube.axis_world_coords_limits(max_size=1000)
(<SkyCoord (ICRS): (ra, dec) in deg
     [( 89.44873826, 22.18535743), (169.21775477, 84.43524424)]>,
 <SpectralCoord 
    (target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
                 (90.05, 30.1, 1000.)
              (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
                 (0., 0., 0.)>)
   [1.02e-09, 3.00e-09] m>)
```
The function is largely a clone of `axis_world_coords`, but adding a `max_size` parameter above which the call to the full `_generate_world_coords` evaluation is replaced by estimating the limits from only a subset of pixel coordinates.
My timings indicate that below WCS sizes of some 10000 the former has negligible impact, from some 100000 it approaches 0.1 seconds, so that's probably the limit that `__str__` or `__repr__` should set when calling it.

TODO etc.:

- I've included basic tests for different dimensionality (just noting that `2d` is still missing); not sure if/which of the split/spliced test cases need to be covered in addition. Something for `extra_coords` and `combined_wcs` should probably be added, although that is not the core purpose of this function.
- I'd like to return a status flag indicating if the exact/brute force method or an approximation has been used; wondering if this could be stored in a new `NDCubeBase` property. While at that, it's probably worth discussing if the entire `(axes_coords, )` for the limits should simply be cached in a property as well (only to be updated whenever `axis_world_coords_limits` with higher precision/`max_size`), so `__str__` would only need to read that back.
- As the test for the WCS extending over the pole highlights, simply evaluating `min()` and `max()` will just return the pixel closest to the pole for `SkyCoord.dec.max()` (which lies somewhere along a `crpix[i]` axis in this example), and whatever pixels fall closest to the meridian on both sides for `SkyCoord.ra` minmax. Both are of course not representative of the WCS extension on the sky in any way, but I don't have a good idea how to find a better representation in this case. Maybe falling back to the pixel corners would be an option; shifting RA to a range [-180 deg, 180 deg] would also be helpful.