### PR TITLE
Enable NDCollection aligned axes to be input as any int type.

### DIFF
--- a/changelog/495.bugfix.rst
+++ b/changelog/495.bugfix.rst
@@ -1,0 +1,1 @@
+Enable `~ndcube.NDCollection` to accept aligned axes inputs in any integer type.

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -42,12 +42,12 @@ def _sanitize_user_aligned_axes(data, aligned_axes):
     else:
         cube0_dims = data[0].dimensions[np.array(aligned_axes[0])]
     # If user entered a single int or string, convert to length 1 tuple of int.
-    if isinstance(aligned_axes, int):
+    if isinstance(aligned_axes, numbers.Integral):
         aligned_axes = (aligned_axes,)
     if not isinstance(aligned_axes, tuple):
         raise ValueError(aligned_axes_error_message)
     # Check type of each element.
-    axes_all_ints = all([isinstance(axis, int) for axis in aligned_axes])
+    axes_all_ints = all([isinstance(axis, numbers.Integral) for axis in aligned_axes])
     axes_all_tuples = all([isinstance(axis, tuple) for axis in aligned_axes])
     # If all elements are int, duplicate tuple so there is one for each cube.
     n_cubes = len(data)


### PR DESCRIPTION
Our first bugfix of 2.0!
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->
This PR fixes a bug which prevented `NDCollection` accepting aligned axes inputs in any integer type except a strict `int`.

Fixes #<Issue Number>
