### PR TITLE
Converting units to wcs.world_axis_units in crop_by_values

### DIFF
--- a/changelog/497.bugfix.rst
+++ b/changelog/497.bugfix.rst
@@ -1,0 +1,1 @@
+Patch to convert quantity objects passed to `crop_by_coords` to the units given in the `wcs.world_axis_units`

--- a/changelog/497.bugfix.rst
+++ b/changelog/497.bugfix.rst
@@ -1,1 +1,1 @@
-Patch to convert quantity objects passed to `crop_by_coords` to the units given in the `wcs.world_axis_units`
+Patch to convert quantity objects passed to ``crop_by_coords`` to the units given in the ``wcs.world_axis_units``.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 
 import astropy.nddata
 import astropy.units as u
+from astropy.units import UnitsError
 import numpy as np
 
 try:
@@ -543,13 +544,11 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                             f"index: {i}; coord type: {type(value)}; unit: {unit}")
                     points[i][j] = u.Quantity(value, unit=unit)
                 elif value is not None:
-                    unit = value.unit
-                if not (value is None or unit.is_equivalent(wcs.world_axis_units[j])):
-                    raise ValueError(f"Unit '{unit}' of coordinate object {j} in point {i} is "
-                                     f"incompatible with WCS unit '{wcs.world_axis_units[j]}'")
-
-                if value is not None:
-                    points[i][j] = points[i][j].to(wcs.world_axis_units[j])
+                    try:
+                        points[i][j] = points[i][j].to(wcs.world_axis_units[j])
+                    except UnitsError:
+                        raise UnitsError(f"Unit '{unit}' of coordinate object {j} in point {i} is "
+                                         f"incompatible with WCS unit '{wcs.world_axis_units[j]}'")
                     
         return utils.cube.get_crop_item_from_points(points, wcs, True)
 

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -548,6 +548,9 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                     raise ValueError(f"Unit '{unit}' of coordinate object {j} in point {i} is "
                                      f"incompatible with WCS unit '{wcs.world_axis_units[j]}'")
 
+                if value is not None:
+                    points[i][j] = points[i][j].to(wcs.world_axis_units[j])
+                    
         return utils.cube.get_crop_item_from_points(points, wcs, True)
 
     def __str__(self):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -549,7 +549,7 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                     except UnitsError:
                         raise UnitsError(f"Unit '{unit}' of coordinate object {j} in point {i} is "
                                          f"incompatible with WCS unit '{wcs.world_axis_units[j]}'")
-                    
+
         return utils.cube.get_crop_item_from_points(points, wcs, True)
 
     def __str__(self):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -7,8 +7,8 @@ from collections.abc import Mapping
 
 import astropy.nddata
 import astropy.units as u
-from astropy.units import UnitsError
 import numpy as np
+from astropy.units import UnitsError
 
 try:
     # Import sunpy coordinates if available to register the frames and WCS functions with astropy

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -543,12 +543,12 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
                             "the corresponding unit must be a valid astropy Unit or unit string."
                             f"index: {i}; coord type: {type(value)}; unit: {unit}")
                     points[i][j] = u.Quantity(value, unit=unit)
-                elif value is not None:
+                if value is not None:
                     try:
                         points[i][j] = points[i][j].to(wcs.world_axis_units[j])
-                    except UnitsError:
-                        raise UnitsError(f"Unit '{unit}' of coordinate object {j} in point {i} is "
-                                         f"incompatible with WCS unit '{wcs.world_axis_units[j]}'")
+                    except UnitsError as err:
+                        raise UnitsError(f"Unit '{points[i][j].unit}' of coordinate object {j} in point {i} is "
+                                         f"incompatible with WCS unit '{wcs.world_axis_units[j]}'") from err
 
         return utils.cube.get_crop_item_from_points(points, wcs, True)
 

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -516,7 +516,7 @@ def test_crop_by_values_with_units(ndcube_4d_ln_lt_l_t):
 
 
 def test_crop_by_values_with_equivalent_units(ndcube_2d_ln_lt):
-    # test cropping when passed units that are not identical to the cube wcs.world_axis_units 
+    # test cropping when passed units that are not identical to the cube wcs.world_axis_units
     intervals = ndcube_2d_ln_lt.wcs.array_index_to_world_values([0, 3], [1, 6])
     lower_corner = [(coord[0]*u.deg).to(u.arcsec) for coord in intervals]
     upper_corner = [(coord[-1]*u.deg).to(u.arcsec) for coord in intervals]
@@ -524,6 +524,7 @@ def test_crop_by_values_with_equivalent_units(ndcube_2d_ln_lt):
     output = ndcube_2d_ln_lt.crop_by_values(lower_corner, upper_corner)
     helpers.assert_cubes_equal(output, expected)
 
+    
 def test_crop_by_values_with_nones(ndcube_4d_ln_lt_l_t):
     cube = ndcube_4d_ln_lt_l_t
     lower_corner = [None] * 4

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -7,11 +7,11 @@ import pytest
 from astropy.coordinates import SkyCoord, SpectralCoord
 from astropy.io import fits
 from astropy.time import Time
+from astropy.units import UnitsError
 from astropy.wcs import WCS
 from astropy.wcs.utils import wcs_to_celestial_frame
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
-from astropy.units import UnitsError
 
 from ndcube import ExtraCoords, NDCube
 from ndcube.tests import helpers

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -524,7 +524,7 @@ def test_crop_by_values_with_equivalent_units(ndcube_2d_ln_lt):
     output = ndcube_2d_ln_lt.crop_by_values(lower_corner, upper_corner)
     helpers.assert_cubes_equal(output, expected)
 
-    
+
 def test_crop_by_values_with_nones(ndcube_4d_ln_lt_l_t):
     cube = ndcube_4d_ln_lt_l_t
     lower_corner = [None] * 4

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -515,6 +515,15 @@ def test_crop_by_values_with_units(ndcube_4d_ln_lt_l_t):
     helpers.assert_cubes_equal(output, expected)
 
 
+def test_crop_by_values_with_equivalent_units(ndcube_2d_ln_lt):
+    # test cropping when passed units that are not identical to the cube wcs.world_axis_units 
+    intervals = ndcube_2d_ln_lt.wcs.array_index_to_world_values([0, 3], [1, 6])
+    lower_corner = [(coord[0]*u.deg).to(u.arcsec) for coord in intervals]
+    upper_corner = [(coord[-1]*u.deg).to(u.arcsec) for coord in intervals]
+    expected = ndcube_2d_ln_lt[0:4, 1:7]
+    output = ndcube_2d_ln_lt.crop_by_values(lower_corner, upper_corner)
+    helpers.assert_cubes_equal(output, expected)
+
 def test_crop_by_values_with_nones(ndcube_4d_ln_lt_l_t):
     cube = ndcube_4d_ln_lt_l_t
     lower_corner = [None] * 4

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -11,6 +11,7 @@ from astropy.wcs import WCS
 from astropy.wcs.utils import wcs_to_celestial_frame
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
+from astropy.units import UnitsError
 
 from ndcube import ExtraCoords, NDCube
 from ndcube.tests import helpers
@@ -576,7 +577,7 @@ def test_crop_by_values_with_wrong_units(ndcube_4d_ln_lt_l_t):
     lower_corner[1] *= u.m
     upper_corner[1] *= u.m
     lower_corner[2] *= u.km
-    with pytest.raises(ValueError, match=r"Unit 'km' of coordinate object 2 in point 0 is "
+    with pytest.raises(UnitsError, match=r"Unit 'km' of coordinate object 2 in point 0 is "
                                          r"incompatible with WCS unit 'deg'"):
         ndcube_4d_ln_lt_l_t.crop_by_values(lower_corner, upper_corner, units=units)
 


### PR DESCRIPTION

### Description

Following #496 this PR patches an issue with the conversion of quantity input units to the `wcs.world_axis_units` of the ndcube when using `crop_by_values`
