### PR TITLE
Fix the use of `axes_units=` when using the NDCube animator

### DIFF
--- a/changelog/498.bugfix.rst
+++ b/changelog/498.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug which prevented the ``axes_units=`` kwarg from working when using the
+matplotlib animators.

--- a/ndcube/visualization/mpl_plotter.py
+++ b/ndcube/visualization/mpl_plotter.py
@@ -238,7 +238,7 @@ class MatplotlibPlotter(BasePlotter):
 
         coord_params = {}
         if axes_units is not None:
-            for axis_unit, coord_name in zip(axes_units, world_axis_physical_types):
+            for axis_unit, coord_name in zip(axes_units, wcs.world_axis_physical_types):
                 coord_params[coord_name] = {'format_unit': axis_unit}
 
         # TODO: Add support for transposing the array.

--- a/ndcube/visualization/tests/figure_hashes_mpl_332_ft_261_astropy_42_animators_100.json
+++ b/ndcube/visualization/tests/figure_hashes_mpl_332_ft_261_astropy_42_animators_100.json
@@ -18,7 +18,7 @@
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice0-kwargs0]": "eeaf0f6ba120d5dd730f66953a6b15f91533e8378b83608936eb5588f157574d",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice1-kwargs1]": "97683e58de61e6f15cc6efd6a84837d0bfada56aa2e274e1dcd39d71399372f4",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs2]": "5966170e7eed2dbadc950a4ef23bda8b9bf435a0ad6f44e2936c8f4b14fd1114",
-  "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs3]": "9ef2663fad5255ca299bd8cc32962dfbe7bad4b8cff338c6119c61497ece9ed4",
+  "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs3]": "a3478d495d89e5bc0ae72462a6d5d14a7350df599b22314a01ca923afc9ec80b",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs4]": "cb14f5dd8a7b4541e5fb2ac488305fad6c3a96460d9b7a36c840d050b8ae64a7",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice5-kwargs5]": "602f4243edd203744a5ce8a5a6f3323cb2427fce7312aeea4537a3f68f457492",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice6-kwargs6]": "5966170e7eed2dbadc950a4ef23bda8b9bf435a0ad6f44e2936c8f4b14fd1114",

--- a/ndcube/visualization/tests/figure_hashes_mpl_332_ft_261_astropy_dev_animators_dev.json
+++ b/ndcube/visualization/tests/figure_hashes_mpl_332_ft_261_astropy_dev_animators_dev.json
@@ -18,7 +18,7 @@
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice0-kwargs0]": "eeaf0f6ba120d5dd730f66953a6b15f91533e8378b83608936eb5588f157574d",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice1-kwargs1]": "97683e58de61e6f15cc6efd6a84837d0bfada56aa2e274e1dcd39d71399372f4",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs2]": "5966170e7eed2dbadc950a4ef23bda8b9bf435a0ad6f44e2936c8f4b14fd1114",
-  "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs3]": "9ef2663fad5255ca299bd8cc32962dfbe7bad4b8cff338c6119c61497ece9ed4",
+  "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs3]": "a3478d495d89e5bc0ae72462a6d5d14a7350df599b22314a01ca923afc9ec80b",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-None-kwargs4]": "cb14f5dd8a7b4541e5fb2ac488305fad6c3a96460d9b7a36c840d050b8ae64a7",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice5-kwargs5]": "602f4243edd203744a5ce8a5a6f3323cb2427fce7312aeea4537a3f68f457492",
   "test_plotting.test_animate_cube_from_slice[ln_lt_l_t-cslice6-kwargs6]": "5966170e7eed2dbadc950a4ef23bda8b9bf435a0ad6f44e2936c8f4b14fd1114",

--- a/ndcube/visualization/tests/test_plotting.py
+++ b/ndcube/visualization/tests/test_plotting.py
@@ -95,7 +95,7 @@ def test_animate_2D_cube(ndcube_2d_ln_lt):
                              ("ln_lt_l_t", np.s_[:, :, 0, :], {}),
                              ("ln_lt_l_t", np.s_[:, :, 0, :], {'plot_axes': [..., 'x']}),
                              ("ln_lt_l_t", None, {}),
-                             ("ln_lt_l_t", None, {"plot_axes": [0, 0, 'x', 'y']}),
+                             ("ln_lt_l_t", None, {"plot_axes": [0, 0, 'x', 'y'], "axes_units": [None, None, u.pm, None]}),
                              ("ln_lt_l_t", None, {"plot_axes": [0, 'x', 0, 'y']}),
                              ("ln_lt_l_t", np.s_[0, :, :, :], {}),
                              ("ln_lt_l_t", np.s_[:, :, :, :], {}),


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

`world_axis_physical types` is undefined. It breaks things.
