### PR TITLE
corrects bug 535

### DIFF
--- a/changelog/538.bugfix.rst
+++ b/changelog/538.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug #535 where `NDCollection` could not update when `aligned_axes` is `None`

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -258,15 +258,19 @@ class NDCollection(dict):
             new_data = list(collection.values())
             key_data_pairs = zip(new_keys, new_data)
             new_aligned_axes = collection.aligned_axes
+
         # Check aligned axes of new inputs are compatible with those in self.
         # As they've already been sanitized, only one set of aligned axes need be checked.
+        first_old_aligned_axes = self.aligned_axes[self._first_key] if self.aligned_axes is not None else None
+        first_new_aligned_axes = new_aligned_axes[new_keys[0]] if new_aligned_axes is not None else None
         collection_utils.assert_aligned_axes_compatible(
             self[self._first_key].dimensions, new_data[0].dimensions,
-            self.aligned_axes[self._first_key], new_aligned_axes[new_keys[0]]
+            first_old_aligned_axes, first_new_aligned_axes
         )
         # Update collection
         super().update(key_data_pairs)
-        self.aligned_axes.update(new_aligned_axes)
+        if first_old_aligned_axes is not None:  # since the above assertion passed, both are aligned_axes are not None
+            self.aligned_axes.update(new_aligned_axes)
 
     def __delitem__(self, key):
         super().__delitem__(key)

--- a/ndcube/tests/test_ndcollection.py
+++ b/ndcube/tests/test_ndcollection.py
@@ -132,6 +132,15 @@ def test_collection_update_collecton_input():
     helpers.assert_collections_equal(orig_collection, expected)
 
 
+def test_collection_update_without_aligned_axes():
+    orig_collection = NDCollection([("cube0", cube0), ("cube1", cube1)])
+    new_collection = NDCollection([("cube2", cube2)])
+    orig_collection.update(new_collection)
+
+    expected = NDCollection([("cube0", cube0), ("cube1", cube1), ("cube2", cube2)])
+    helpers.assert_collections_equal(orig_collection, expected)
+
+
 @pytest.mark.parametrize("collection, expected_aligned_dimensions", [
     (cube_collection, [4, 5]*u.pix),
     (seq_collection, np.array([2*u.pix, 3*u.pix, 4*u.pix, 5*u.pix], dtype=object))])

--- a/ndcube/utils/collection.py
+++ b/ndcube/utils/collection.py
@@ -150,10 +150,16 @@ def assert_aligned_axes_compatible(data_dimensions1, data_dimensions2, data_axes
         The aligned axes of data cube 2.
 
     """
-    # Confirm same number of aligned axes.
-    if len(data_axes1) != len(data_axes2):
-        raise ValueError("Number of aligned axes must be equal: "
-                         f"{len(data_axes1)} != {len(data_axes2)}")
-    # Confirm dimension lengths of each aligned axis is the same.
-    if not all(data_dimensions1[np.array(data_axes1)] == data_dimensions2[np.array(data_axes2)]):
-        raise ValueError("All corresponding aligned axes between cubes must be of same length.")
+    # there is a mismatch where one collection uses aligned_axes and the other does not
+    if (data_axes1 is None and data_axes2 is not None) or (data_axes1 is not None and data_axes2 is None):
+        raise ValueError("Both collections must use aligned_axes or both axes must not use aligned_axes."
+                         f"Currently {data_axes1} != {data_axes2}")
+
+    if data_axes1 is not None and data_axes2 is not None:  # aligned_axes are being used for both collections
+        # Confirm same number of aligned axes.
+        if len(data_axes1) != len(data_axes2):
+            raise ValueError("Number of aligned axes must be equal: "
+                             f"{len(data_axes1)} != {len(data_axes2)}")
+        # Confirm dimension lengths of each aligned axis is the same.
+        if not all(data_dimensions1[np.array(data_axes1)] == data_dimensions2[np.array(data_axes2)]):
+            raise ValueError("All corresponding aligned axes between cubes must be of same length.")

--- a/ndcube/utils/tests/test_utils_collection.py
+++ b/ndcube/utils/tests/test_utils_collection.py
@@ -15,7 +15,8 @@ def test_assert_aligned_axes_compatible(data_dimensions1, data_dimensions2,
 
 @pytest.mark.parametrize("data_dimensions1,data_dimensions2,data_axes1,data_axes2", [
     ([3., 4., 5.]*u.pix, [3., 5., 15.]*u.pix, (0, 1), (0, 1)),
-    ([3., 4., 5.]*u.pix, [3., 5., 15.]*u.pix, (0, 1), (0, 1, 2))])
+    ([3., 4., 5.]*u.pix, [3., 5., 15.]*u.pix, (0, 1), (0, 1, 2)),
+    ([3., 4., 5.]*u.pix, [3., 5., 15.]*u.pix, (0, 1), None)])
 def test_assert_aligned_axes_compatible_error(data_dimensions1, data_dimensions2,
                                               data_axes1, data_axes2):
     with pytest.raises(ValueError):


### PR DESCRIPTION
## PR Description

Bug #535 identifies that an NDCollection without aligned_axes cannot be updated. This was because the assertion for compatible axes did not consider the scenario where aligned_axes were not being used. Thus, I updated the `ncube.utils.colleciton.assert_aligned_axes_compatible` and the `ndcube.ndcollection.NDCollection.update` methods to take this into account by checking for this explicitly. Tests were added for this and passed successfully. 
