### PR TITLE
aligned_axis_physical_types returns None when no aligned_axes

### DIFF
--- a/changelog/539.bugfix.rst
+++ b/changelog/539.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug where `aligned_axis_physical_types` caused `__str__`
+to error when `aligned_axes` was `None`.

--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -106,10 +106,10 @@ class NDCollection(dict):
         One tuple is retured for each axis as there can be more than one physical type
         associated with an aligned axis.  If there are no physical types associated
         with an aligned that is common to all collection members, an empty tuple is
-        returned for that axis.  If there are no aligned axes, raises a ValueError.
+        returned for that axis.
         """
         if self.aligned_axes is None:
-            raise ValueError("aligned_axes must be set to use this property.")
+            return None
         # Get array axis physical types for each aligned axis for all members of collection.
         collection_types = [np.array(cube.array_axis_physical_types,
                                      dtype=object)[np.array(self.aligned_axes[name])]


### PR DESCRIPTION
## PR Description

Danny pointed out that `__str__` will error out when `aligned_axes` is `None` because `aligned_axis_physical_types` would raise a `ValueError`. Thus, I changed so that instead of raising a `ValueError` in this scenario `aligned_axis_physical_types` will now just return `None`. 