### PR TITLE
[2.0] "fix" reproject 0.9 issues

### DIFF
--- a/changelog/564.bugfix.rst
+++ b/changelog/564.bugfix.rst
@@ -1,0 +1,2 @@
+Limit maximum reproject version due to API changes. ndcube 2.1 will support the
+new reproject keyword arguments.

--- a/ndcube/extra_coords/tests/test_extra_coords.py
+++ b/ndcube/extra_coords/tests/test_extra_coords.py
@@ -471,9 +471,11 @@ def test_dropped_dimension_reordering():
 
 
 def test_length1_extra_coord(wave_lut):
+    # This test hits a bug that existed in gwcs less than 0.16.1
+    pytest.importorskip("gwcs", minversion="0.16.1")
     ec = ExtraCoords()
     ec.add("wavey", 0, wave_lut)
     item = slice(1, 2)
     sec = ec[item]
-    assert (sec.wcs.pixel_to_world(0)[0] == wave_lut[item]).all()
+    assert (sec.wcs.pixel_to_world(0) == wave_lut[item]).all()
     assert (sec.wcs.world_to_pixel(wave_lut[item])[0] == [0]).all()

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ plotting =
     matplotlib>=3.2
     mpl_animators>=1.0
 reproject =
-    reproject>=0.7.1
+    reproject>=0.7.1,<0.10
 
 [options.packages.find]
 exclude = ndcube._dev

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,9 @@ passenv =
     NO_PROXY
     CIRCLECI
 deps =
-    # We need this for some packages.
-    setuptools
+    # To avoid warnings we only test with 0.8.
+    # We only support <0.9
+    reproject<0.9
 
     # The devdeps factor is intended to be used to install the latest developer version.
     # of key dependencies.


### PR DESCRIPTION
This is a brute force silencing of issues with reproject on the 2.0 branch and #548 fixes them "properly" for 2.1