### PR TITLE
Pass `data_unit` kwarg through when visualizing > two dimensions

### DIFF
--- a/changelog/578.bugfix.rst
+++ b/changelog/578.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug where ``data_unit`` was not being correctly passed through to the underlying plotting
+function when animating a cube.

--- a/ndcube/visualization/mpl_plotter.py
+++ b/ndcube/visualization/mpl_plotter.py
@@ -86,7 +86,7 @@ class MatplotlibPlotter(BasePlotter):
             else:
                 ax = self._animate_cube(plot_wcs, plot_axes=plot_axes,
                                         axes_coordinates=axes_coordinates,
-                                        axes_units=axes_units, **kwargs)
+                                        axes_units=axes_units, data_unit=data_unit, **kwargs)
 
         return ax
 


### PR DESCRIPTION
This fixes a very minor bug where the `data_unit` kwarg was not being passed through to `_animate_cube`.