### PR TITLE
Add unit conversion method to NDCube.

### DIFF
--- a/changelog/586.feature.rst
+++ b/changelog/586.feature.rst
@@ -1,0 +1,1 @@
+Add `ndcube.NDCube.to` to convert cube to new unit.

--- a/ndcube/conftest.py
+++ b/ndcube/conftest.py
@@ -5,6 +5,7 @@ predicable NDCube objects.
 import logging
 
 import astropy.units as u
+import dask.array
 import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
@@ -475,6 +476,19 @@ def ndcube_2d_ln_lt_units(wcs_2d_lt_ln):
 
 
 @pytest.fixture
+def ndcube_2d_dask(wcs_2d_lt_ln):
+    shape = (8, 4)
+    chunks = 2
+    data = data_nd(shape).astype(float)
+    da = dask.array.from_array(data, chunks=chunks)
+    mask = np.zeros(shape, dtype=bool)
+    da_mask = dask.array.from_array(mask, chunks=chunks)
+    uncert = data * 0.1
+    da_uncert = StdDevUncertainty(dask.array.from_array(uncert, chunks=chunks))
+    return NDCube(da, wcs=wcs_2d_lt_ln, uncertainty=da_uncert, mask=da_mask, unit=u.J)
+
+
+@pytest.fixture
 def ndcube_2d(request):
     """
     This is a meta fixture for parametrizing all the 2D ndcubes.
@@ -499,6 +513,8 @@ def ndcube_1d_l(wcs_1d_l):
     "ndcube_3d_ln_lt_l",
     "ndcube_3d_rotated",
     "ndcube_2d_ln_lt",
+    "ndcube_2d_ln_lt_units",
+    "ndcube_2d_dask",
     "ndcube_1d_l",
 ])
 def all_ndcubes(request):

--- a/ndcube/conftest.py
+++ b/ndcube/conftest.py
@@ -8,6 +8,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
+from astropy.nddata import StdDevUncertainty
 from astropy.time import Time, TimeDelta
 from astropy.wcs import WCS
 
@@ -485,7 +486,8 @@ def ndcube_2d(request):
 def ndcube_1d_l(wcs_1d_l):
     shape = (10,)
     data_cube = data_nd(shape)
-    return NDCube(data_cube, wcs=wcs_1d_l)
+    return NDCube(data_cube, wcs=wcs_1d_l,
+                  uncertainty=StdDevUncertainty(data_cube*0.1), unit=u.J)
 
 
 @pytest.fixture(params=[

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -805,7 +805,6 @@ class NDCube(NDCubeBase):
     def _new_instance_from_op(self, new_data, new_unit, new_uncertainty):
         # This implicitly assumes that the arithmetic operation does not alter
         # the WCS, mask, or metadata.
-        new_uncertainty = deepcopy(self.uncertainty)
         new_cube = type(self)(new_data,
                               unit=new_unit,
                               wcs=self.wcs,

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -709,26 +709,6 @@ class NDCubeBase(NDCubeSlicingMixin, NDCubeABC):
 
         return resampled_cube
 
-    def to(self, new_unit, **kwargs):
-        """Convert instance to another unit.
-
-        Converts the data, uncertainty and unit and returns a new instance
-        with other attributes unchanged.
-
-        Parameters
-        ----------
-        new_unit: `astropy.unit.Unit`
-            The unit to convert to.
-        kwargs:
-            Passed to the unit conversion method, self.unit.to.
-
-        Returns
-        -------
-        : `ǸDCube`
-            A new instance with the new unit and data and uncertainties scales accordingly.
-        """
-        return self * (self.unit.to(new_unit, **kwargs) * new_unit / self.unit)
-
 
 class NDCube(NDCubeBase):
     """
@@ -895,3 +875,23 @@ class NDCube(NDCubeBase):
 
     def __truediv__(self, value):
         return self.__mul__(1/value)
+
+    def to(self, new_unit, **kwargs):
+        """Convert instance to another unit.
+
+        Converts the data, uncertainty and unit and returns a new instance
+        with other attributes unchanged.
+
+        Parameters
+        ----------
+        new_unit: `astropy.unit.Unit`
+            The unit to convert to.
+        kwargs:
+            Passed to the unit conversion method, self.unit.to.
+
+        Returns
+        -------
+        : `ǸDCube`
+            A new instance with the new unit and data and uncertainties scales accordingly.
+        """
+        return self * (self.unit.to(new_unit, **kwargs) * new_unit / self.unit)

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -802,11 +802,10 @@ class NDCube(NDCubeBase):
 
         return self.plotter.plot(*args, **kwargs)
 
-    def _new_instance_from_op(self, new_data, new_unit, new_uncertainty=None):
+    def _new_instance_from_op(self, new_data, new_unit, new_uncertainty):
         # This implicitly assumes that the arithmetic operation does not alter
         # the WCS, mask, or metadata.
-        if new_uncertainty is None:
-            new_uncertainty = deepcopy(self.uncertainty)
+        new_uncertainty = deepcopy(self.uncertainty)
         new_cube = type(self)(new_data,
                               unit=new_unit,
                               wcs=self.wcs,
@@ -820,7 +819,8 @@ class NDCube(NDCubeBase):
         return new_cube
 
     def __neg__(self):
-        return self._new_instance_from_op(-self.data, self.unit)
+        return self._new_instance_from_op(-self.data, deepcopy(self.unit),
+                                          deepcopy(self.uncertainty))
 
     def __add__(self, value):
         if hasattr(value, 'unit'):
@@ -839,7 +839,7 @@ class NDCube(NDCubeBase):
             raise TypeError("Cannot add a unitless object to an NDCube with a unit.")
         else:
             new_data = self.data + value
-        return self._new_instance_from_op(new_data, self.unit)
+        return self._new_instance_from_op(new_data, deepcopy(self.unit), deepcopy(self.uncertainty))
 
     def __radd__(self, value):
         return self.__add__(value)

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 import astropy.units as u
 import astropy.wcs
+import dask.array
 import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord, SpectralCoord
@@ -830,16 +831,6 @@ def test_reproject_exact_incompatible_wcs(ndcube_4d_ln_l_t_lt, wcs_4d_lt_t_l_ln,
                                              shape_out=(5, 10, 12, 8))
 
 
-def test_to(ndcube_1d_l):
-    cube = ndcube_1d_l
-    new_unit = u.mJ
-    expected_factor = 1000
-    output = cube.to(new_unit)
-    assert np.allclose(output.data, cube.data * expected_factor)
-    assert np.allclose(output.uncertainty.array, cube.uncertainty.array * expected_factor)
-    assert output.unit == new_unit
-
-
 def test_plot_docstring():
     cube = NDCube([], astropy.wcs.WCS())
 
@@ -969,3 +960,21 @@ def test_cube_arithmetic_add_notimplementederror(ndcube_2d_ln_lt_units):
 def test_cube_arithmetic_multiply_notimplementederror(ndcube_2d_ln_lt_units):
     with pytest.raises(TypeError):
         _ = ndcube_2d_ln_lt_units * ndcube_2d_ln_lt_units
+
+
+def test_to(ndcube_1d_l):
+    cube = ndcube_1d_l
+    new_unit = u.mJ
+    expected_factor = 1000
+    output = cube.to(new_unit)
+    assert np.allclose(output.data, cube.data * expected_factor)
+    assert np.allclose(output.uncertainty.array, cube.uncertainty.array * expected_factor)
+    assert output.unit == new_unit
+
+
+def test_to_dask(ndcube_2d_dask):
+    output = ndcube_2d_dask.to(u.mJ)
+    dask_type = dask.array.core.Array
+    assert isinstance(output.data, dask_type)
+    assert isinstance(output.uncertainty.array, dask_type)
+    assert isinstance(output.mask, dask_type)

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -830,6 +830,16 @@ def test_reproject_exact_incompatible_wcs(ndcube_4d_ln_l_t_lt, wcs_4d_lt_t_l_ln,
                                              shape_out=(5, 10, 12, 8))
 
 
+def test_to(ndcube_1d_l):
+    cube = ndcube_1d_l
+    new_unit = u.mJ
+    expected_factor = 1000
+    output = cube.to(new_unit)
+    assert np.allclose(output.data, cube.data * expected_factor)
+    assert np.allclose(output.uncertainty.array, cube.uncertainty.array * expected_factor)
+    assert output.unit == new_unit
+
+
 def test_plot_docstring():
     cube = NDCube([], astropy.wcs.WCS())
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ tests =
     pytest-astropy
     pytest-mpl>=0.12
     sunpy>=4.0.0
+    dask
 docs =
     matplotlib
     pytest-doctestplus>=0.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ passenv =
     NO_PROXY
     CIRCLECI
 deps =
+    dask
     # The devdeps factor is intended to be used to install the latest developer version.
     # of key dependencies.
     # Astropy is installed from the nightly wheels


### PR DESCRIPTION
- [x] Move `NDCubeBase.to` to `NDCube.to` as it relied on `__mul__` which is on `NDCube`.
- [x] Add test a fixture using a dask array and check that the data array type is still dask after the operation.
- [x] Add dask to test dependencies