### PR TITLE
Allow passing units as strings to NDCube.to

### DIFF
--- a/changelog/605.bugfix.rst
+++ b/changelog/605.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes a bug where passing a string representation of a unit to `ndcube.NDCube.to` raised a `TypeError`.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -961,6 +961,7 @@ class NDCube(NDCubeBase):
         : `ǸDCube`
             A new instance with the new unit and data and uncertainties scales accordingly.
         """
+        new_unit = u.Unit(new_unit)
         return self * (self.unit.to(new_unit, **kwargs) * new_unit / self.unit)
 
     def rebin(self, bin_shape, operation=np.mean, operation_ignores_mask=False, handle_mask=np.all,

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1119,14 +1119,14 @@ def test_cube_arithmetic_multiply_notimplementederror(ndcube_2d_ln_lt_units):
         _ = ndcube_2d_ln_lt_units * ndcube_2d_ln_lt_units
 
 
-def test_to(ndcube_1d_l):
+@pytest.mark.parametrize('new_unit', [u.mJ, 'mJ'])
+def test_to(ndcube_1d_l, new_unit):
     cube = ndcube_1d_l
-    new_unit = u.mJ
     expected_factor = 1000
     output = cube.to(new_unit)
     assert np.allclose(output.data, cube.data * expected_factor)
     assert np.allclose(output.uncertainty.array, cube.uncertainty.array * expected_factor)
-    assert output.unit == new_unit
+    assert output.unit == u.Unit(new_unit)
 
 
 def test_to_dask(ndcube_2d_dask):


### PR DESCRIPTION
This PR fixes a bug where passing a string representation of a unit to `NDCube` raises the following `TypeError`,

```python-traceback
File ~/mambaforge/envs/coronal-rain-observables/lib/python3.10/site-packages/ndcube/ndcube.py:964, in NDCube.to(self, new_unit, **kwargs)
    946 def to(self, new_unit, **kwargs):
    947     """Convert instance to another unit.
    948 
    949     Converts the data, uncertainty and unit and returns a new instance
   (...)
    962         A new instance with the new unit and data and uncertainties scales accordingly.
    963     """
--> 964     return self * (self.unit.to(new_unit, **kwargs) * new_unit / self.unit)

TypeError: can't multiply sequence by non-int of type 'float'
```