### PR TITLE
JOSS Review Corrections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ******
-ncdube
+ndcube
 ******
 
 |Latest Version| |codecov| |matrix| |Powered by NumFOCUS| |Powered by SunPy|

--- a/joss_paper/paper.bib
+++ b/joss_paper/paper.bib
@@ -27,6 +27,7 @@
   booktitle = {Proceedings of Workshop on Machine Learning Systems ({{LearningSys}}) in the Thirty-First Annual Conference on Neural Information Processing Systems ({{NIPS}})},
   author = {Okuta, Ryosuke and Unno, Yuya and Nishino, Daisuke and Hido, Shohei and Loomis, Crissman},
   year = {2017}
+  url = {http://learningsys.org/nips17/assets/papers/paper_16.pdf}
 }
 
 @Manual{dask,
@@ -91,7 +92,7 @@
 }
 
 @software{jdaviz,
-  author       = {JDADF Developers and
+  author       = {JDADF-Developers and
                   Averbukh, Jesse and
                   Bradley, Larry and
                   Buikhuizen, Mario and

--- a/joss_paper/paper.bib
+++ b/joss_paper/paper.bib
@@ -7,19 +7,61 @@
   url = {https://github.com/astropy/astropy-APEs/blob/main/APE14.rst}
 }
 
-@article{astropy,
-    author = {{Astropy Collaboration}},
-    title = "{Astropy: A community Python package for astronomy}",
-    journal = {Astronomy and Astrophysics},
-    archivePrefix = "arXiv",
-    eprint = {1307.6212},
-    primaryClass = "astro-ph.IM",
-    keywords = {methods: data analysis, methods: miscellaneous, virtual observatory tools},
-    year = 2013,
-    month = oct,
-    volume = 558,
-    doi = {10.1051/0004-6361/201322068},
-    url = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A}
+@ARTICLE{astropy2013,
+       author = {{Astropy Collaboration} and {Robitaille}, Thomas P. and {Tollerud}, Erik J. and {Greenfield}, Perry and {Droettboom}, Michael and {Bray}, Erik and {Aldcroft}, Tom and {Davis}, Matt and {Ginsburg}, Adam and {Price-Whelan}, Adrian M. and {Kerzendorf}, Wolfgang E. and {Conley}, Alexander and {Crighton}, Neil and {Barbary}, Kyle and {Muna}, Demitri and {Ferguson}, Henry and {Grollier}, Fr{\'e}d{\'e}ric and {Parikh}, Madhura M. and {Nair}, Prasanth H. and {Unther}, Hans M. and {Deil}, Christoph and {Woillez}, Julien and {Conseil}, Simon and {Kramer}, Roban and {Turner}, James E.~H. and {Singer}, Leo and {Fox}, Ryan and {Weaver}, Benjamin A. and {Zabalza}, Victor and {Edwards}, Zachary I. and {Azalee Bostroem}, K. and {Burke}, D.~J. and {Casey}, Andrew R. and {Crawford}, Steven M. and {Dencheva}, Nadia and {Ely}, Justin and {Jenness}, Tim and {Labrie}, Kathleen and {Lim}, Pey Lian and {Pierfederici}, Francesco and {Pontzen}, Andrew and {Ptak}, Andy and {Refsdal}, Brian and {Servillat}, Mathieu and {Streicher}, Ole},
+        title = "{Astropy: A community Python package for astronomy}",
+      journal = {\aap},
+     keywords = {methods: data analysis, methods: miscellaneous, virtual observatory tools, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2013,
+        month = oct,
+       volume = {558},
+          eid = {A33},
+        pages = {A33},
+          doi = {10.1051/0004-6361/201322068},
+archivePrefix = {arXiv},
+       eprint = {1307.6212},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2013A&A...558A..33A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{astropy2018,
+       author = {{Astropy Collaboration} and {Price-Whelan}, A.~M. and {Sip{\H{o}}cz}, B.~M. and {G{\"u}nther}, H.~M. and {Lim}, P.~L. and {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and {Craig}, M.~W. and {Dencheva}, N. and {Ginsburg}, A. and {VanderPlas}, J.~T. and {Bradley}, L.~D. and {P{\'e}rez-Su{\'a}rez}, D. and {de Val-Borro}, M. and {Aldcroft}, T.~L. and {Cruz}, K.~L. and {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Ardelean}, C. and {Babej}, T. and {Bach}, Y.~P. and {Bachetti}, M. and {Bakanov}, A.~V. and {Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P. and {Baumbach}, A. and {Berry}, K.~L. and {Biscani}, F. and {Boquien}, M. and {Bostroem}, K.~A. and {Bouma}, L.~G. and {Brammer}, G.~B. and {Bray}, E.~M. and {Breytenbach}, H. and {Buddelmeijer}, H. and {Burke}, D.~J. and {Calderone}, G. and {Cano Rodr{\'\i}guez}, J.~L. and {Cara}, M. and {Cardoso}, J.~V.~M. and {Cheedella}, S. and {Copin}, Y. and {Corrales}, L. and {Crichton}, D. and {D'Avella}, D. and {Deil}, C. and {Depagne}, {\'E}. and {Dietrich}, J.~P. and {Donath}, A. and {Droettboom}, M. and {Earl}, N. and {Erben}, T. and {Fabbro}, S. and {Ferreira}, L.~A. and {Finethy}, T. and {Fox}, R.~T. and {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and {Goldstein}, D.~A. and {Gommers}, R. and {Greco}, J.~P. and {Greenfield}, P. and {Groener}, A.~M. and {Grollier}, F. and {Hagen}, A. and {Hirst}, P. and {Homeier}, D. and {Horton}, A.~J. and {Hosseinzadeh}, G. and {Hu}, L. and {Hunkeler}, J.~S. and {Ivezi{\'c}}, {\v{Z}}. and {Jain}, A. and {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S. and {Kern}, N.~S. and {Kerzendorf}, W.~E. and {Khvalko}, A. and {King}, J. and {Kirkby}, D. and {Kulkarni}, A.~M. and {Kumar}, A. and {Lee}, A. and {Lenz}, D. and {Littlefair}, S.~P. and {Ma}, Z. and {Macleod}, D.~M. and {Mastropietro}, M. and {McCully}, C. and {Montagnac}, S. and {Morris}, B.~M. and {Mueller}, M. and {Mumford}, S.~J. and {Muna}, D. and {Murphy}, N.~A. and {Nelson}, S. and {Nguyen}, G.~H. and {Ninan}, J.~P. and {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and {Parejko}, J.~K. and {Parley}, N. and {Pascual}, S. and {Patil}, R. and {Patil}, A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and {Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and {Sakurikar}, P. and {Seifert}, M. and {Sherbert}, L.~E. and {Sherwood-Taylor}, H. and {Shih}, A.~Y. and {Sick}, J. and {Silbiger}, M.~T. and {Singanamalla}, S. and {Singer}, L.~P. and {Sladen}, P.~H. and {Sooley}, K.~A. and {Sornarajah}, S. and {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V. and {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and {Zabalza}, V. and {Astropy Contributors}},
+        title = "{The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package}",
+      journal = {\aj},
+     keywords = {methods: data analysis, methods: miscellaneous, methods: statistical, reference systems, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2018,
+        month = sep,
+       volume = {156},
+       number = {3},
+          eid = {123},
+        pages = {123},
+          doi = {10.3847/1538-3881/aabc4f},
+archivePrefix = {arXiv},
+       eprint = {1801.02634},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018AJ....156..123A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{astropy2022,
+       author = {{Astropy Collaboration} and {Price-Whelan}, Adrian M. and {Lim}, Pey Lian and {Earl}, Nicholas and {Starkman}, Nathaniel and {Bradley}, Larry and {Shupe}, David L. and {Patil}, Aarya A. and {Corrales}, Lia and {Brasseur}, C.~E. and {N{\"o}the}, Maximilian and {Donath}, Axel and {Tollerud}, Erik and {Morris}, Brett M. and {Ginsburg}, Adam and {Vaher}, Eero and {Weaver}, Benjamin A. and {Tocknell}, James and {Jamieson}, William and {van Kerkwijk}, Marten H. and {Robitaille}, Thomas P. and {Merry}, Bruce and {Bachetti}, Matteo and {G{\"u}nther}, H. Moritz and {Aldcroft}, Thomas L. and {Alvarado-Montes}, Jaime A. and {Archibald}, Anne M. and {B{\'o}di}, Attila and {Bapat}, Shreyas and {Barentsen}, Geert and {Baz{\'a}n}, Juanjo and {Biswas}, Manish and {Boquien}, M{\'e}d{\'e}ric and {Burke}, D.~J. and {Cara}, Daria and {Cara}, Mihai and {Conroy}, Kyle E. and {Conseil}, Simon and {Craig}, Matthew W. and {Cross}, Robert M. and {Cruz}, Kelle L. and {D'Eugenio}, Francesco and {Dencheva}, Nadia and {Devillepoix}, Hadrien A.~R. and {Dietrich}, J{\"o}rg P. and {Eigenbrot}, Arthur Davis and {Erben}, Thomas and {Ferreira}, Leonardo and {Foreman-Mackey}, Daniel and {Fox}, Ryan and {Freij}, Nabil and {Garg}, Suyog and {Geda}, Robel and {Glattly}, Lauren and {Gondhalekar}, Yash and {Gordon}, Karl D. and {Grant}, David and {Greenfield}, Perry and {Groener}, Austen M. and {Guest}, Steve and {Gurovich}, Sebastian and {Handberg}, Rasmus and {Hart}, Akeem and {Hatfield-Dodds}, Zac and {Homeier}, Derek and {Hosseinzadeh}, Griffin and {Jenness}, Tim and {Jones}, Craig K. and {Joseph}, Prajwel and {Kalmbach}, J. Bryce and {Karamehmetoglu}, Emir and {Ka{\l}uszy{\'n}ski}, Miko{\l}aj and {Kelley}, Michael S.~P. and {Kern}, Nicholas and {Kerzendorf}, Wolfgang E. and {Koch}, Eric W. and {Kulumani}, Shankar and {Lee}, Antony and {Ly}, Chun and {Ma}, Zhiyuan and {MacBride}, Conor and {Maljaars}, Jakob M. and {Muna}, Demitri and {Murphy}, N.~A. and {Norman}, Henrik and {O'Steen}, Richard and {Oman}, Kyle A. and {Pacifici}, Camilla and {Pascual}, Sergio and {Pascual-Granado}, J. and {Patil}, Rohit R. and {Perren}, Gabriel I. and {Pickering}, Timothy E. and {Rastogi}, Tanuj and {Roulston}, Benjamin R. and {Ryan}, Daniel F. and {Rykoff}, Eli S. and {Sabater}, Jose and {Sakurikar}, Parikshit and {Salgado}, Jes{\'u}s and {Sanghi}, Aniket and {Saunders}, Nicholas and {Savchenko}, Volodymyr and {Schwardt}, Ludwig and {Seifert-Eckert}, Michael and {Shih}, Albert Y. and {Jain}, Anany Shrey and {Shukla}, Gyanendra and {Sick}, Jonathan and {Simpson}, Chris and {Singanamalla}, Sudheesh and {Singer}, Leo P. and {Singhal}, Jaladh and {Sinha}, Manodeep and {Sip{\H{o}}cz}, Brigitta M. and {Spitler}, Lee R. and {Stansby}, David and {Streicher}, Ole and {{\v{S}}umak}, Jani and {Swinbank}, John D. and {Taranu}, Dan S. and {Tewary}, Nikita and {Tremblay}, Grant R. and {de Val-Borro}, Miguel and {Van Kooten}, Samuel J. and {Vasovi{\'c}}, Zlatan and {Verma}, Shresth and {de Miranda Cardoso}, Jos{\'e} Vin{\'\i}cius and {Williams}, Peter K.~G. and {Wilson}, Tom J. and {Winkel}, Benjamin and {Wood-Vasey}, W.~M. and {Xue}, Rui and {Yoachim}, Peter and {Zhang}, Chen and {Zonca}, Andrea and {Astropy Project Contributors}},
+        title = "{The Astropy Project: Sustaining and Growing a Community-oriented Open-source Project and the Latest Major Release (v5.0) of the Core Package}",
+      journal = {\apj},
+     keywords = {Astronomy software, Open source software, Astronomy data analysis, 1855, 1866, 1858, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2022,
+        month = aug,
+       volume = {935},
+       number = {2},
+          eid = {167},
+        pages = {167},
+          doi = {10.3847/1538-4357/ac7c74},
+archivePrefix = {arXiv},
+       eprint = {2206.14220},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2022ApJ...935..167A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @inproceedings{cupy,

--- a/joss_paper/paper.bib
+++ b/joss_paper/paper.bib
@@ -198,9 +198,37 @@ Transformations in Python: The NDCube 2 & Astropy APE-14 WCS APIs}",
   url = {https://github.com/astropy/specutils}
 }
 
+@ARTICLE{sunpy,
+       author = {{Mumford}, Stuart and {Freij}, Nabil and {Christe}, Steven and {Ireland}, Jack and {Mayer}, Florian and {Hughitt}, V. and {Shih}, Albert and {Ryan}, Daniel and {Liedtke}, Simon and {P{\'e}rez-Su{\'a}rez}, David and {Chakraborty}, Pritish and {K}, Vishnunarayan and {Inglis}, Andrew and {Pattnaik}, Punyaslok and {Sip{\H{o}}cz}, Brigitta and {Sharma}, Rishabh and {Leonard}, Andrew and {Stansby}, David and {Hewett}, Russell and {Hamilton}, Alex and {Hayes}, Laura and {Panda}, Asish and {Earnshaw}, Matt and {Choudhary}, Nitin and {Kumar}, Ankit and {Chanda}, Prateek and {Haque}, Md and {Kirk}, Michael and {Mueller}, Michael and {Konge}, Sudarshan and {Srivastava}, Rajul and {Jain}, Yash and {Bennett}, Samuel and {Baruah}, Ankit and {Barnes}, Will and {Charlton}, Michael and {Maloney}, Shane and {Chorley}, Nicky and {Himanshu} and {Modi}, Sanskar and {Mason}, James and {Naman} and {Campos Rozo}, Jose Ivan and {Manley}, Larry and {Chatterjee}, Agneet and {Evans}, John and {Malocha}, Michael and {Bobra}, Monica and {Ghosh}, Sourav and {Airmansmith} and {Sta{\'n}czak}, Dominik and {De Visscher}, Ruben and {Verma}, Shresth and {Agrawal}, Ankit and {Buddhika}, Dumindu and {Sharma}, Swapnil and {Park}, Jongyeob and {Bates}, Matt and {Goel}, Dhruv and {Taylor}, Garrison and {Cetusic}, Goran and {Jacob} and {Inchaurrandieta}, Mateo and {Dacie}, Sally and {Dubey}, Sanjeev and {Sharma}, Deepankar and {Bray}, Erik and {Rideout}, Jai and {Zahniy}, Serge and {Meszaros}, Tomas and {Bose}, Abhigyan and {Chicrala}, Andr{\'e} and {Ankit} and {Guennou}, Chlo{\'e} and {D'Avella}, Daniel and {Williams}, Daniel and {Ballew}, Jordan and {Murphy}, Nick and {Lodha}, Priyank and {Robitaille}, Thomas and {Krishan}, Yash and {Hill}, Andrew and {Eigenbrot}, Arthur and {Mampaey}, Benjamin and {Wiedemann}, Bernhard and {Molina}, Carlos and {Ke{\c{s}}kek}, Duygu and {Habib}, Ishtyaq and {Letts}, Joseph and {Baz{\'a}n}, Juanjo and {Arbolante}, Quinn and {Gomillion}, Reid and {Kothari}, Yash and {Sharma}, Yash and {Stevens}, Abigail and {Price-Whelan}, Adrian and {Mehrotra}, Ambar and {Kustov}, Arseniy and {Stone}, Brandon and {Dang}, Trung and {Arias}, Emmanuel and {Dover}, Fionnlagh and {Verstringe}, Freek and {Kumar}, Gulshan and {Mathur}, Harsh and {Babuschkin}, Igor and {Wimbish}, Jaylen and {Buitrago-Casas}, Juan and {Krishna}, Kalpesh and {Hiware}, Kaustubh and {Mangaonkar}, Manas and {Mendero}, Matthew and {Schoentgen}, Micka{\"e}l and {Gyenge}, Norbert and {Streicher}, Ole and {Mekala}, Rajasekhar and {Mishra}, Rishabh and {Srikanth}, Shashank and {Jain}, Sarthak and {Yadav}, Tannmay and {Wilkinson}, Tessa and {Pereira}, Tiago and {Agrawal}, Yudhik and {Jamescalixto} and {Yasintoda} and {Murray}, Sophie},
+        title = "{SunPy: A Python package for Solar Physics}",
+      journal = {The Journal of Open Source Software},
+     keywords = {Python, C, Astronomy, Solar physics, IDL},
+         year = 2020,
+        month = feb,
+       volume = {5},
+       number = {46},
+          eid = {1832},
+        pages = {1832},
+          doi = {10.21105/joss.01832},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2020JOSS....5.1832M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @article{sunraster,
     author = {{Ryan}, Daniel and {et al}},
     title = "{sunraster: Manipulating Solar Slit-spectrograph Observations in Python}",
     year = {in prep.},
     journal = {Journal of Open Source Software},
+}
+
+@article{xarray,
+  title     = {xarray: {N-D} labeled arrays and datasets in {Python}},
+  author    = {Hoyer, S. and J. Hamman},
+  journal   = {Journal of Open Research Software},
+  volume    = {5},
+  number    = {1},
+  year      = {2017},
+  publisher = {Ubiquity Press},
+  doi       = {10.5334/jors.148},
+  url       = {https://doi.org/10.5334/jors.148}
 }

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -93,12 +93,15 @@ Its data classes link data and their coordinates and provide analysis
 methods to manipulate them self-consistently.
 These aim to provide simple and intuitive ways of handling coordinate-aware data,
 analogous to how users handle coordinate-agnostic data with arrays.
-ndcube leverages AstroPy's WCS API [APE-14; @ape14], a standardized API for the
-World Coordinate System (WCS) framework that is used throughout astronomy.
-Previously, each WCS implementation had its own Python API, making workflows and
-derived tools non-transferable between implementations.
-Now however, ndcube supports any WCS implementation, e.g. FITS-WCS, gWCS, etc.,
-so long as it's wrapped in an AstroPy-WCS-API-compliant object.
+ndcube requires that coordinate transformations be be expressed via the World
+Coordinate System (WCS), a coordinate framework commonly used throughout
+astronomy.
+The WCS framework has multiple implementations, e.g. FITS-WCS, gWCS, etc.,
+each with a different incompatible API, which makes workflows and derived tools
+non-transferable between implementations.
+ndcube overcomes this challenge by leveraging AstroPy's WCS API [APE-14; @ape14]
+which can be wrapped around underlying WCS implementations, thereby creating an
+implementation-agnostic API for interacting with the WCS coordinate transformations
 ndcube's data-WCS coupling allows users to analyze their data more easily and
 reliably, thus helping to boost their scientific output.
 
@@ -131,7 +134,7 @@ Tools that do support WCS-based coordinate-aware data analysis, such as the SunP
 combinations of dimensions, physical types, coordinate systems and WCS implementations.
 This limits their broader utility and makes the combined analysis of different types
 of data more difficult.
-It also inhibits collaboration by putting technical barriers between sub-fields of
+It also inhibits collaboration by erecting technical barriers between sub-fields of
 astronomy.
 
 ndcube overcomes these challenges via its design policy that all functionalities and

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -114,8 +114,8 @@ standardized and powerful way to relate array axes to the physical coordinate ty
 they represent.
 However, while there exist Python packages for handling N-D array operations --
 e.g. numpy [@numpy], dask [@dask], etc. -- and others for supporting WCS coordinate
-transformations -- e.g. astropy [@astropy], gWCS [@gWCS] -- currently only ndcube is
-treats them in a combined, self-consistent way.
+transformations -- e.g. astropy [@astropy], gWCS [@gWCS] -- currently only ndcube treats
+them in a combined, self-consistent way.
 
 
 # The Role of ndcube and its Features

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -116,10 +116,28 @@ temporal, spectral, etc.) and their projections onto a data array (e.g. right as
 and declination, helioprojective latitude and longitude, etc.) make it a succinct,
 standardized and powerful way to relate array axes to the physical coordinate types
 they represent.
-However, while there exist Python packages for handling N-D array operations --
+
+There are mature Python packages for handling N-D array operations --
 e.g. numpy [@numpy], dask [@dask], etc. -- and others for supporting WCS coordinate
-transformations -- e.g. astropy [@astropy], gWCS [@gWCS] -- currently only ndcube treats
-them in a combined, self-consistent way.
+transformations -- e.g. astropy [@astropy], gWCS [@gWCS].
+However, none treat data and coordinates in a combined, self-consistent way.
+The closest alternative to ndcube is xarray [@xarray].
+However xarray has been developed for the requirements and conventions of the
+geosciences which, although similar to those of astronomy in concept, are sufficiently
+different in construction to cause significant friction.
+Crucially, xarray does not currently support WCS coordinate transformations.
+Tools that do support WCS-based coordinate-aware data analysis, such as the SunPy
+[@sunpy] Map class for 2-D images of the Sun, tend to have APIs specific to particular
+combinations of dimensions, physical types, coordinate systems and WCS implementations.
+This limits their broader utility and makes the combined analysis of different types
+of data more difficult.
+It also inhibits collaboration by putting technical barriers between sub-fields of
+astronomy.
+
+ndcube overcomes these challenges via its design policy that all functionalities and
+APIs must be agnostic to the number of dimensions and coordinate types they represent.
+Moreover, ndcube's employment of the AstroPy WCS API makes it agnostic to the
+underlying WCS implementation, e.g. FITS-WCS, gWCS, etc.
 
 
 # The Role of ndcube and its Features

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -122,7 +122,7 @@ they represent.
 
 There are mature Python packages for handling N-D array operations --
 e.g. numpy [@numpy], dask [@dask], etc. -- and others for supporting WCS coordinate
-transformations -- e.g. astropy [@astropy], gWCS [@gWCS].
+transformations -- e.g. astropy [@astropy2013, @astropy2018, @astropy2022], gWCS [@gWCS].
 However, none treat data and coordinates in a combined, self-consistent way.
 The closest alternative to ndcube is xarray [@xarray].
 However xarray has been developed for the requirements and conventions of the
@@ -190,8 +190,8 @@ distributed computing [@dask], cupy for GPU operations [@cupy], etc.
 transformations.
 This means `NDCube` can support any WCS implementation, e.g. FITS-WCS, gWCS, etc.,
 so long as it's supplied in an AstroPy-WCS-API-compliant object.
-The components of an `NDCube` are supplied by the following kwargs and accessed via
-attributes of the same name.
+The components of an `NDCube` are supplied by the following keyword arguments and
+accessed via attributes of the same name.
 
 - `data`: The data array.  (Required)
 - `wcs`: The primary set of coordinate transformations. (Required)
@@ -293,16 +293,16 @@ A network benefit of ndcube is that it standardizes the APIs for handling
 astronomical coordinate-aware N-D data.
 Adoption across astronomy and heliophysics helps scientists to more easily work
 with data from different missions and sub-communities.
-This can help facilitate synergies between new combinations of data, foster
-inter-field collaborations, and promote scientific innovation.
+This can simplify multi-instrument data analysis, foster inter-field collaborations,
+and promote scientific innovation.
 
 
 # Acknowledgements
 
 We acknowledge financial support for ndcube from NASA's Heliophysics Data
-Environment Enhancement program the Daniel K. Inouye Solar Telescope, and
+Environment Enhancement program, the Daniel K. Inouye Solar Telescope, and
 Solar Orbiter/SPICE (grant 80NSSC19K1000).
-We also acknowledge the SunPy and Python in Heliophysics communities for their
-contributions and support.
+We also acknowledge the SunPy, Python in Heliophysics, and AstroPy communities for
+their contributions and support.
 
 # References

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -93,8 +93,12 @@ Its data classes link data and their coordinates and provide analysis
 methods to manipulate them self-consistently.
 These aim to provide simple and intuitive ways of handling coordinate-aware data,
 analogous to how users handle coordinate-agnostic data with arrays.
-ndcube leverages Astropy's WCS API [APE-14; @ape14], a standardized API for the
+ndcube leverages AstroPy's WCS API [APE-14; @ape14], a standardized API for the
 World Coordinate System (WCS) framework that is used throughout astronomy.
+Previously, each WCS implementation had its own Python API, making workflows and
+derived tools non-transferable between implementations.
+Now however, ndcube supports any WCS implementation, e.g. FITS-WCS, gWCS, etc.,
+so long as it's wrapped in an AstroPy-WCS-API-compliant object.
 ndcube's data-WCS coupling allows users to analyze their data more easily and
 reliably, thus helping to boost their scientific output.
 
@@ -161,8 +165,10 @@ The array can be any object that exposes `.dtype` and `.shape` attributes and ca
 be sliced by the standard Python slicing API.
 Thus `NDCube` not only supports numpy arrays but also others such as dask for
 distributed computing [@dask], cupy for GPU operations [@cupy], etc.
-Meanwhile the WCS transformations must be provided in an AstroPy-WCS-API-compliant
-object.
+`NDCube` leverages the AstroPy WCS API for interacting and manipulating the WCS
+transformations.
+This means `NDCube` can support any WCS implementation, e.g. FITS-WCS, gWCS, etc.,
+so long as it's supplied in an AstroPy-WCS-API-compliant object.
 The components of an `NDCube` are supplied by the following kwargs and accessed via
 attributes of the same name.
 
@@ -179,8 +185,8 @@ Coordinate Classes.
 cropping (by real world coordinates), reprojecting to new WCS transformations,
 visualization, rebinning data, arithmetic operations, and more.
 All these methods manipulate the data, coordinates, and supporting data (e.g.
-uncertainties) simultaneously and self-consistently, thus relieving users of
-well-defined, but tedious and error-prone tasks.
+uncertainties) simultaneously and self-consistently.
+This relieves users of well-defined, but tedious and error-prone tasks.
 
 `NDCubeSequence` is designed to handle multiple `NDCube` instances that are arranged
 in some order.
@@ -191,9 +197,10 @@ API to `NDCube`.
 Alternatively, the cubes can be ordered along one of the cubes' axes, e.g. a
 sequence of tiles in an image mosaic where each cube represents an adjacent region
 of the sky.
-`NDCubeSequence` provides separate APIs for both the (N+1)-D and extended N-D
-paradigms, enabling users to switch between them without reformatting or copying the
-underlying data.
+`NDCubeSequence` provides APIs for both the (N+1)-D and extended N-D paradigms,
+that are simultanesouly available on each `NDCubeSequence` instance.
+This enables users to switch between the paradigms without reformatting or copying
+the underlying data.
 `NDCubeSequence` also provides various methods to help with data analysis.
 These APIs are similar to `NDCube` wherever possible, e.g. slicing, visualization,
 etc., to minimize friction between analyzing single and multiple cubes.
@@ -231,12 +238,12 @@ transformations to those in the primary WCS and used interchangeably.
 
 By contrast, `GlobalCoords` supports scalar coordinates that apply to the whole
 `NDCube` rather than any of its axes, e.g. the timestamp of a 2-D image.
-WCS requires that all coordinates are associated with at least one array
-axis, hence the need for `GlobalCoords`.
+Scalar coordinates are not supported by WCS because it requires all coordinates
+to be associated with at least one array axis, hence the need for `GlobalCoords`.
 When an axis is dropped from an `NDCube` via slicing, the values of the dropped
 coordinates at the relevant location along the dropped axis are automatically
 added to the associated `GlobalCoords` object, e.g. the timestamp of a 2-D image
-sliced from a space-space-time cube.
+sliced from a 3-D space-space-time cube.
 Thus coordinate information is never lost due to slicing.
 
 `NDCube` objects are always instantiated with associated `ExtraCoords` and
@@ -247,8 +254,9 @@ For a more in depth dicussion of `ExtraCoords` and `GlobalCoords`, see @ndcube.
 
 # Community Applications of ndcube
 
-The importance of the ndcube package is demonstrated by the fact that it already
-supports a variety of current ground-based and satellite observatories.
+The importance of the ndcube package is demonstrated by the fact that it is
+already a dependency of various software tools that support current ground-based
+and satellite observatories.
 These include the James Webb Space Telescope (JWST), Solar Orbiter,
 the Interface Region Imaging Spectrograph (IRIS), Hinode, and the
 Daniel K. Inouye Solar Telescope (DKIST) via the

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -93,15 +93,15 @@ Its data classes link data and their coordinates and provide analysis
 methods to manipulate them self-consistently.
 These aim to provide simple and intuitive ways of handling coordinate-aware data,
 analogous to how users handle coordinate-agnostic data with arrays.
-ndcube requires that coordinate transformations be be expressed via the World
+ndcube requires that coordinate transformations be expressed via the World
 Coordinate System (WCS), a coordinate framework commonly used throughout
 astronomy.
 The WCS framework has multiple implementations, e.g. FITS-WCS, gWCS, etc.,
 each with a different incompatible API, which makes workflows and derived tools
 non-transferable between implementations.
-ndcube overcomes this challenge by leveraging AstroPy's WCS API [APE-14; @ape14]
-which can be wrapped around underlying WCS implementations, thereby creating an
-implementation-agnostic API for interacting with the WCS coordinate transformations
+ndcube overcomes this by leveraging AstroPy's WCS API [APE-14; @ape14]
+which can be wrapped around underlying WCS implementations, thereby enabling ndcube
+to support any WCS implementation with the same API.
 ndcube's data-WCS coupling allows users to analyze their data more easily and
 reliably, thus helping to boost their scientific output.
 


### PR DESCRIPTION
## PR Description

This PR makes changes requested as part of JOSS review.

To Do

@timj 's comments

- [x] Fix typo at https://github.com/sunpy/ndcube/blob/main/README.rst?plain=1#L2
- [x] Fix authorship of jdviz paper
- [x]  Include URL to cupy paper in bibtex reference
- [x] Fix typo on bottom of first page: "is treats them"
- [x] Elaborate on state of the field in the paper
- [x] Make more explicit mention of support for gWCS

@maxnoe 's comments (From #610)

- [x] l. 43: a *standarized* framework (missing d in standardized)
- [x] l. 71: "kwargs" not sure if this is a bit too much "python jargon". Simply write out keyword arguments?
- [x] l. 141: "facilitate synergies between new combinations of data" This sounds a bit too buzzwordy for me. Maybe: "Makes it easier to combine data from multiple instruments" ? 
- [x] l. 145: missing comma before "the Daniel K. Inouye Solar Telescope" ?
- [x] l. 149: Wouldn't it be more appropriate to cite the latest astropy paper instead of the first?
- [x] l 156: Error in authorlist "Developers, J" → "JDAVIZ Developers"
