### PR TITLE
DOC: Remove broken link from old mailing list

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1008,10 +1008,6 @@ class NDCube(NDCubeBase):
         new_cube: `~ndcube.NDCube`
             The resolution-degraded cube.
 
-        References
-        ----------
-        https://mail.scipy.org/pipermail/numpy-discussion/2010-July/051760.html
-
         Notes
         -----
         **Rebining Algorithm**


### PR DESCRIPTION
This is breaking our linkcheck in `specutils`.

Fixes https://github.com/astropy/specutils/issues/1075

cc @rosteen 