### PR TITLE
Update NDCollection copy() & pop() to Support None aligned_axes

### DIFF
--- a/ndcube/ndcollection.py
+++ b/ndcube/ndcollection.py
@@ -222,8 +222,12 @@ class NDCollection(dict):
         return collection_items, new_aligned_axes
 
     def copy(self):
-        return self.__class__(self.items(), tuple(self.aligned_axes.values()),
-                              meta=self.meta, sanitize_inputs=False)
+        # Aligned axes is not a required parameter and may be None
+        if self.aligned_axes is not None:
+            return self.__class__(self.items(), tuple(self.aligned_axes.values()),
+                                  meta=self.meta, sanitize_inputs=False)
+        else:
+            return self.__class__(self.items(), None, meta=self.meta, sanitize_inputs=False)
 
     def setdefault(self):
         """Not supported by `~ndcube.NDCollection`"""
@@ -244,8 +248,10 @@ class NDCollection(dict):
         """
         # Extract desired cube from collection.
         popped_cube = super().pop(key)
-        # Delete corresponding aligned axes
-        self.aligned_axes.pop(key)
+        # Aligned axes is not a required parameter and may be None
+        if self.aligned_axes is not None:
+            # Delete corresponding aligned axes
+            self.aligned_axes.pop(key)
         return popped_cube
 
     def update(self, *args):

--- a/ndcube/tests/test_ndcollection.py
+++ b/ndcube/tests/test_ndcollection.py
@@ -38,6 +38,7 @@ sequence20 = NDCubeSequence([cube2, cube0])
 aligned_axes = ((1, 2), (2, 0), (1, 2))
 keys = ("cube0", "cube1", "cube2")
 cube_collection = NDCollection([("cube0", cube0), ("cube1", cube1), ("cube2", cube2)], aligned_axes)
+unaligned_collection = NDCollection([("cube0", cube0), ("cube1", cube1), ("cube2", cube2)], aligned_axes=None)
 seq_collection = NDCollection([("seq0", sequence02), ("seq1", sequence20)], aligned_axes="all")
 
 
@@ -87,11 +88,13 @@ def test_slice_cube_from_collection(item, collection, expected):
 
 def test_collection_copy():
     helpers.assert_collections_equal(cube_collection.copy(), cube_collection)
+    helpers.assert_collections_equal(unaligned_collection.copy(), unaligned_collection)
 
 
 @pytest.mark.parametrize("collection,popped_key,expected_popped,expected_collection", [
     (cube_collection, "cube0", cube0, NDCollection([("cube1", cube1), ("cube2", cube2)],
-                                                   aligned_axes=aligned_axes[1:]))])
+                                                   aligned_axes=aligned_axes[1:])),
+    (unaligned_collection, "cube0", cube0, NDCollection([("cube1", cube1), ("cube2", cube2)]))])
 def test_collection_pop(collection, popped_key, expected_popped, expected_collection):
     popped_collection = collection.copy()
     output = popped_collection.pop(popped_key)


### PR DESCRIPTION
## PR Description

* Adds `None` check on `self.aligned_axes` to `NDCollection.copy()` and `NDCollection.pop()`
* Adds test data to represent collection with `None` aligned axes in `test_ndcollection.py`
* Updates tests for `copy()` and `pop()` to test with new test data

closes #641
