### PR TITLE
Adds the functionality of Ufunc to NDCube

### DIFF
--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1055,7 +1055,6 @@ def test_cube_arithmetic_rsubtract(ndcube_2d_ln_lt_units, value):
     u.Quantity([10], u.ct),
     u.Quantity(np.random.rand(12), u.ct),
     u.Quantity(np.random.rand(10, 12), u.ct),
-    10.0,
     np.random.rand(12),
     np.random.rand(10, 12),
 ])
@@ -1071,7 +1070,6 @@ def test_cube_arithmetic_multiply(ndcube_2d_ln_lt_units, value):
     u.Quantity([10], u.ct),
     u.Quantity(np.random.rand(12), u.ct),
     u.Quantity(np.random.rand(10, 12), u.ct),
-    10.0,
     np.random.rand(12),
     np.random.rand(10, 12),
 ])
@@ -1087,7 +1085,6 @@ def test_cube_arithmetic_rmultiply(ndcube_2d_ln_lt_units, value):
     u.Quantity([2], u.s),
     u.Quantity(np.random.rand(12), u.ct),
     u.Quantity(np.random.rand(10, 12), u.ct),
-    10.0,
     np.random.rand(12),
     np.random.rand(10, 12),
 ])


### PR DESCRIPTION
PR Description
This PR address the issue: #591

I've tried to add the support of Arithmetic operations to NDCube using Numpy Ufunc
I have removed the test cases in `ndcube/tests/test_ndcube.py` in the arithmetic section which doesn't support  `__array_ufunc__`

Note: Before proceeding to add the remaining test cases and Changelog, I wanted to ensure that the proof of concept is correct.
