### PR TITLE
Fix the unrendered code snippets in the docstrings

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -217,10 +217,10 @@ class NDCubeABC(astropy.nddata.NDDataBase):
 
         Examples
         --------
-        An example of cropping a region of interest on the Sun from a 3-D image-time cube:
-        >>> point1 = [SkyCoord(-50*u.deg, -40*u.deg, frame=frames.HeliographicStonyhurst), None]  # doctest: +SKIP
-        >>> point2 = [SkyCoord(0*u.deg, -6*u.deg, frame=frames.HeliographicStonyhurst), None]  # doctest: +SKIP
-        >>> NDCube.crop(point1, point2) # doctest: +SKIP
+        An example of cropping a region of interest on the Sun from a 3-D image-time cube
+            >>> point1 = [[-50*u.deg, -40*u.deg], None]  # doctest: +SKIP
+            >>> point2 = [[0*u.deg, -6*u.deg], None]  # doctest: +SKIP
+            >>> NDCube.crop_by_values(point1, point2) # doctest: +SKIP
 
         """
 
@@ -267,8 +267,8 @@ class NDCubeABC(astropy.nddata.NDDataBase):
 
         Examples
         --------
-        An example of cropping a region of interest on the Sun from a 3-D image-time cube:
-        >>> NDCube.crop_by_values((-600, -600, 0), (0, 0, 0), units=(u.arcsec, u.arcsec, u.s)) # doctest: +SKIP
+        An example of cropping a region of interest on the Sun from a 3-D image-time cube
+            >>> NDCube.crop_by_values((-600, -600, 0), (0, 0, 0), units=(u.arcsec, u.arcsec, u.s)) # doctest: +SKIP
         """
 
 


### PR DESCRIPTION
Fixes #640 

The example code snippets included in the docstrings are now being rendered correctly in the API docs.