### PR TITLE
NDCube.squeeze method

### DIFF
--- a/changelog/669.feature.rst
+++ b/changelog/669.feature.rst
@@ -1,0 +1,2 @@
+Added a new `~ndcube.NDCube.squeeze` method to `ndcube.NDCube`.
+It will remove all axes of length 1.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1187,41 +1187,35 @@ class NDCube(NDCubeBase):
 
         return new_cube
 
-    def squeeze(self, axis=None):
-        """Removes axes with length 1
-
-        Uses slicing to remove possibly redundant axes which 
-        have length 1.
+    def squeeze(self, *, axis=None):
+        """
+        Removes all axes with a length of 1.
 
         Parameters
         ----------
         axis: array-like, optional
             Specifies specific axes to be removed. If one of those axes
             has length larger than 1, an error is thrown. If not specified,
-            all axes length 1 get removed.
+            all axes of length 1 get removed.
 
         Returns
         -------
-        : `~ndcube.NDCube`
-            A new instance with the removed axes.
+        `~ndcube.NDCube`
+            A new NDCube instance with the removed axes.
         """
-        # Build item to drop squeezed axes.
         item = np.full(self.data.ndim, slice(None))
         shape = np.asarray(self.data.shape)
         if axis is None:
             item[shape == 1] = 0
         else:
-            # For simplicity sake, if axis is scalar make it a tuple.
+            # For simplicity’s sake, if the axis is scalar make it a tuple.
             if isinstance(axis, int):
                 axis = (axis,)
             axis = np.asarray(axis)
-            # If user tries to squeeze an axis that is not length-1, raise an error.
             if not (shape[axis] == 1).all():
-                raise ValueError("Cannot select an axis to squeeze out which has size not equal to one.")
+                raise ValueError("Cannot select any axis to squeeze out, as none of them has size equal to one.")
             item[axis] = 0
-        # As scalar NDCubes are not supported, raise error
-        # if operation would cause all axes to be squeezed.
+        # Scalar NDCubes are not supported, so we raise error as the operation would cause all the axes to be squeezed.
         if (item == 0).all():
-            raise ValueError("All axes length 1. Cannot squeeze NDCube to a scalar. Use axis= kwarg to specify a subset of axes to squeeze.")
-        # Drop squeezed axes by slicing cube.
+            raise ValueError("All axes are of length 1, therefore we will not squeeze NDCube to become a scalar. Use `axis=` keyword to specify a subset of axes to squeeze.")
         return self[tuple(item)]

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1,4 +1,5 @@
 import abc
+import numbers
 import textwrap
 import warnings
 from copy import deepcopy
@@ -1209,7 +1210,7 @@ class NDCube(NDCubeBase):
             item[shape == 1] = 0
         else:
             # For simplicity’s sake, if the axis is scalar make it a tuple.
-            if isinstance(axis, int):
+            if isinstance(axis, numbers.Integral):
                 axis = (axis,)
             axis = np.asarray(axis)
             if not (shape[axis] == 1).all():

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1186,3 +1186,46 @@ class NDCube(NDCubeBase):
             new_cube._extra_coords = self.extra_coords.resample(bin_shape, ndcube=new_cube)
 
         return new_cube
+
+    def squeeze(self, axis=None):
+        """Removes axes with length 1
+
+        Uses slicing to remove possibly redundant axes which 
+        have length 1.
+
+        Parameters
+        ----------
+        axis: array-like, optional
+            Specifies specific axes to be removed. If one of those axes
+            has length larger than 1, it gets ignored. If not specified,
+            all axes length 1 get removed.
+
+        Returns
+        -------
+        : `~ndcube.NDCube`
+            A new instance with the removed axes.
+        """
+        # List of positions for dimensions to be removed.
+        to_modify = []
+
+        # Checks which dimensions are to be removed.
+        for i, axis_length in enumerate(self.data.shape):
+
+            # Case in which no axis is specified.
+            if axis_length == 1 and axis is None:
+                to_modify.append(i)
+
+            # Case in which axis specified.
+            elif axis_length == 1 and axis is not None and i in axis:
+                to_modify.append(i)
+
+        # Create "mask" for the slicing.
+        arr = np.full(len(self.dimensions),slice(None))
+
+        # The "mask" contains slice(None) for the dimensions we ignore
+        # and 0 for the dimensions that are to be trimmed.
+        for i in to_modify:
+            arr[i] = 0
+
+        # We do the actual slicing.
+        return self[tuple(arr)]

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1187,7 +1187,7 @@ class NDCube(NDCubeBase):
 
         return new_cube
 
-    def squeeze(self, *, axis=None):
+    def squeeze(self, axis=None):
         """
         Removes all axes with a length of 1.
 

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1141,8 +1141,8 @@ def test_to_dask(ndcube_2d_dask):
 def test_squeeze(ndcube_4d_ln_l_t_lt):
     assert np.array_equal(ndcube_4d_ln_l_t_lt.squeeze().dimensions, ndcube_4d_ln_l_t_lt.dimensions)
     assert np.array_equal(ndcube_4d_ln_l_t_lt[:,:,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,:,0:1,:].squeeze().dimensions)
-    assert np.array_equal(ndcube_4d_ln_l_t_lt[:,:,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,:,0:1,:].squeeze(axis=2).dimensions)
-    assert np.array_equal(ndcube_4d_ln_l_t_lt[:,0,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,0:1,0:1,:].squeeze(axis=[1,2]).dimensions)
+    assert np.array_equal(ndcube_4d_ln_l_t_lt[:,:,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,:,0:1,:].squeeze(2).dimensions)
+    assert np.array_equal(ndcube_4d_ln_l_t_lt[:,0,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,0:1,0:1,:].squeeze([1,2]).dimensions)
 
 
 def test_squeeze_error(ndcube_4d_ln_l_t_lt):

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1139,16 +1139,15 @@ def test_to_dask(ndcube_2d_dask):
 
 
 def test_squeeze(ndcube_4d_ln_l_t_lt):
-    same = ndcube_4d_ln_l_t_lt.squeeze()
-    assert np.array_equal(same.dimensions, ndcube_4d_ln_l_t_lt.dimensions)
-    same = same[0:1,:,:,:]
-    with pytest.raises(ValueError, match="Cannot select an axis to squeeze out which has size not equal to one."):
+    assert np.array_equal(ndcube_4d_ln_l_t_lt.squeeze().dimensions, ndcube_4d_ln_l_t_lt.dimensions)
+    assert np.array_equal(ndcube_4d_ln_l_t_lt[:,:,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,:,0:1,:].squeeze().dimensions)
+    assert np.array_equal(ndcube_4d_ln_l_t_lt[:,:,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,:,0:1,:].squeeze(axis=2).dimensions)
+    assert np.array_equal(ndcube_4d_ln_l_t_lt[:,0,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,0:1,0:1,:].squeeze(axis=[1,2]).dimensions)
+
+
+def test_squeeze_error(ndcube_4d_ln_l_t_lt):
+    same = ndcube_4d_ln_l_t_lt.squeeze()[0:1,:,:,:]
+    with pytest.raises(ValueError, match="Cannot select any axis to squeeze out, as none of them has size equal to one."):
         same.squeeze([0,1])
-    same = same[:,:,0:1,:]
-    assert np.array_equal(same[0,:,0,:].dimensions, same.squeeze().dimensions)
-    assert np.array_equal(same[:,:,0,:].dimensions, same.squeeze(2).dimensions)
-    same = same[:,0:1,:,:]
-    assert np.array_equal(same[:,0,0,:].dimensions, same.squeeze([1,2]).dimensions)
-    same = same[:,:,:,0:1]
-    with pytest.raises(ValueError, match="All axes length 1. Cannot squeeze NDCube to a scalar.  Use axis= kwarg to specify a subset of axes to squeeze."):
-        same.squeeze()
+    with pytest.raises(ValueError, match="All axes are of length 1, therefore we will not squeeze NDCube to become a scalar. Use `axis=` keyword to specify a subset of axes to squeeze."):
+        same[0:1,0:1,0:1,0:1].squeeze()

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1136,3 +1136,14 @@ def test_to_dask(ndcube_2d_dask):
     assert isinstance(output.data, dask_type)
     assert isinstance(output.uncertainty.array, dask_type)
     assert isinstance(output.mask, dask_type)
+
+
+def test_squeeze(ndcube_4d_ln_l_t_lt):
+    same = ndcube_4d_ln_l_t_lt.squeeze()
+    assert np.array_equal(same.dimensions, ndcube_4d_ln_l_t_lt.dimensions)
+    same = same[0:1,:,:,:]
+    assert np.array_equal(same.dimensions, same.squeeze([1,2,3]).dimensions)
+    assert np.array_equal(same[0,:,:,:].dimensions, same.squeeze().dimensions)
+    same = same[:,:,0:1,:]
+    assert np.array_equal(same[0,:,0,:].dimensions, same.squeeze().dimensions)
+    assert np.array_equal(same[:,:,0,:].dimensions, same.squeeze([1,2]).dimensions)

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1142,8 +1142,13 @@ def test_squeeze(ndcube_4d_ln_l_t_lt):
     same = ndcube_4d_ln_l_t_lt.squeeze()
     assert np.array_equal(same.dimensions, ndcube_4d_ln_l_t_lt.dimensions)
     same = same[0:1,:,:,:]
-    assert np.array_equal(same.dimensions, same.squeeze([1,2,3]).dimensions)
-    assert np.array_equal(same[0,:,:,:].dimensions, same.squeeze().dimensions)
+    with pytest.raises(ValueError, match="Cannot select an axis to squeeze out which has size not equal to one."):
+        same.squeeze([0,1])
     same = same[:,:,0:1,:]
     assert np.array_equal(same[0,:,0,:].dimensions, same.squeeze().dimensions)
-    assert np.array_equal(same[:,:,0,:].dimensions, same.squeeze([1,2]).dimensions)
+    assert np.array_equal(same[:,:,0,:].dimensions, same.squeeze(2).dimensions)
+    same = same[:,0:1,:,:]
+    assert np.array_equal(same[:,0,0,:].dimensions, same.squeeze([1,2]).dimensions)
+    same = same[:,:,:,0:1]
+    with pytest.raises(ValueError, match="All axes length 1. Cannot squeeze NDCube to a scalar.  Use axis= kwarg to specify a subset of axes to squeeze."):
+        same.squeeze()

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1143,7 +1143,7 @@ def test_squeeze(ndcube_4d_ln_l_t_lt):
     assert np.array_equal(ndcube_4d_ln_l_t_lt[:,:,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,:,0:1,:].squeeze().dimensions)
     assert np.array_equal(ndcube_4d_ln_l_t_lt[:,:,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,:,0:1,:].squeeze(2).dimensions)
     assert np.array_equal(ndcube_4d_ln_l_t_lt[:,0,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,0:1,0:1,:].squeeze([1,2]).dimensions)
-assert np.array_equal(ndcube_4d_ln_l_t_lt[:,0:1,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,0:1,0:1,:].squeeze(2).dimensions)
+    assert np.array_equal(ndcube_4d_ln_l_t_lt[:,0:1,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,0:1,0:1,:].squeeze(2).dimensions)
 
 
 def test_squeeze_error(ndcube_4d_ln_l_t_lt):

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1143,6 +1143,7 @@ def test_squeeze(ndcube_4d_ln_l_t_lt):
     assert np.array_equal(ndcube_4d_ln_l_t_lt[:,:,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,:,0:1,:].squeeze().dimensions)
     assert np.array_equal(ndcube_4d_ln_l_t_lt[:,:,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,:,0:1,:].squeeze(2).dimensions)
     assert np.array_equal(ndcube_4d_ln_l_t_lt[:,0,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,0:1,0:1,:].squeeze([1,2]).dimensions)
+assert np.array_equal(ndcube_4d_ln_l_t_lt[:,0:1,0,:].dimensions, ndcube_4d_ln_l_t_lt[:,0:1,0:1,:].squeeze(2).dimensions)
 
 
 def test_squeeze_error(ndcube_4d_ln_l_t_lt):


### PR DESCRIPTION
Creates the NDCube.squeeze method as described in the issue, similar to the numpy equivalent.
This method removes (specified) axis with length 1.
Testing for the method is also included.
Resolves #616 