### PR TITLE
Add convenience coordinate methods to NDCube

### DIFF
--- a/changelog/709.feature.rst
+++ b/changelog/709.feature.rst
@@ -1,0 +1,1 @@
+Add convenience methods, `~ndcube.NDCube.celestial`, `~ndcube.NDCube.time`, `~ndcube.NDCube.spectral`, `~ndcube.NDCube.stokes`, to return coordinates for array indices from relevant axes for common coordinate types.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1247,7 +1247,8 @@ class NDCube(NDCubeBase):
             raise ValueError("All axes are of length 1, therefore we will not squeeze NDCube to become a scalar. Use `axis=` keyword to specify a subset of axes to squeeze.")
         return self[tuple(item)]
 
-    def celestial(self, wcs=None):
+    @property
+    def celestial(self):
         """
         Returns celestial coordinates for all array indices in relevant axes.
 
@@ -1263,9 +1264,10 @@ class NDCube(NDCubeBase):
         -------
         : `astropy.coordinates.SkyCoord`
         """
-        return self._get_coords_by_word("pos", wcs)
+        return self._get_coords_by_word("pos")
 
-    def time(self, wcs=None):
+    @property
+    def time(self):
         """
         Returns time coordinates for all array indices in relevant axes.
 
@@ -1281,9 +1283,10 @@ class NDCube(NDCubeBase):
         -------
         : `astropy.time.Time`
         """
-        return self._get_coords_by_word("time", wcs)
+        return self._get_coords_by_word("time")
 
-    def spectral(self, wcs=None):
+    @property
+    def spectral(self):
         """
         Returns spectral coordinates from WCS.
 
@@ -1299,9 +1302,10 @@ class NDCube(NDCubeBase):
         -------
         : `astropy.coordinates.SpectralCoord` or `astropy.units.Quantity`
         """
-        return self._get_coords_by_word("em", wcs)
+        return self._get_coords_by_word("em")
 
-    def stokes(self, wcs=None):
+    @property
+    def stokes(self):
         """
         Returns stokes polarization for all array indices in relevant axes.
 
@@ -1317,26 +1321,39 @@ class NDCube(NDCubeBase):
         -------
         :
         """
-        return self._get_coords_by_word("stokes", wcs)
+        return self._get_coords_by_word("stokes")
 
-    def _get_coords_by_word(self, words, wcs):
+    def _get_coords_by_word(self, coord_words):
             """
             Returns coordinates from a WCS corresponding to a world axis physical type.
             """
-            if wcs is None:
-                wcs = self.wcs
-            elif isinstance(wcs, ExtraCoords):
-                wcs = wcs.wcs
-            if isinstance(words, str):
-                words = [words]
-            world_types = []
-            for world_type in wcs.world_axis_physical_types:
-                words_in_type = set(world_type.replace(":", ".").split("."))
-                if any(word in words_in_type for word in words):
-                    world_types.append(world_type)
-            if len(world_types) == 0:
+            if isinstance(coord_words, str):
+                coord_words = [coord_words]
+            # Check if words are in physical types of main WCS and extra coords.
+            wcs_phys_types = []
+            ec_phys_types = []
+            for wcs, physical_types in zip([self.wcs, self.extra_coords.wcs], [wcs_phys_types, ec_phys_types]):
+                if wcs is not None:
+                    for name in wcs.world_axis_physical_types:
+                        words = set(name.replace(":", ".").split("."))
+                        if any(word in words for word in coord_words):
+                            physical_types.append(name)
+            # Determine type of WCS to use based on whether the words were
+            # found in WCS and/or extra coords.
+            if len(wcs_phys_types) > 0:
+               if len(ec_phys_types) > 0:
+                   wcs = self.combined_wcs
+                   physical_types = wcs_phys_types + ec_phys_types
+               else:
+                   wcs = self.wcs
+                   physical_types = wcs_phys_types
+            elif len(ec_phys_types) > 0:
+                wcs = self.extra_coords
+                physical_types = ec_phys_types
+            else:
                 return None
-            coords = self.axis_world_coords(*world_types, wcs=wcs)
+            # Calculate coordinates.
+            coords = self.axis_world_coords(*physical_types, wcs=wcs)
             if len(coords) == 1:
                 coords = coords[0]
             return coords

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1206,28 +1206,28 @@ def test_ndcube_quantity(ndcube_2d_ln_lt_units):
     np.testing.assert_array_equal(cube.quantity, expected)
 
 
-def test_celestial(ndcube_4d_ln_l_t_lt):
-    cube = ndcube_4d_ln_l_t_lt
-    output = cube.celestial()
+def test_celestial(ndcube_3d_ln_lt_l_ec_time):
+    cube = ndcube_3d_ln_lt_l_ec_time
+    output = cube.celestial
     expected = cube.axis_world_coords("lon")[0]
     assert (output == expected).all()
 
 
-def test_time(ndcube_4d_ln_l_t_lt):
-    cube = ndcube_4d_ln_l_t_lt
-    output = cube.time()
-    expected = cube.axis_world_coords("time")[0]
+def test_time(ndcube_3d_ln_lt_l_ec_time):
+    cube = ndcube_3d_ln_lt_l_ec_time
+    output = cube.time
+    expected = cube.axis_world_coords("time", wcs=cube.extra_coords)[0]
     assert (output == expected).all()
 
 
-def test_spectral(ndcube_4d_ln_l_t_lt):
-    cube = ndcube_4d_ln_l_t_lt
-    output = cube.spectral()
+def test_spectral(ndcube_3d_ln_lt_l_ec_time):
+    cube = ndcube_3d_ln_lt_l_ec_time
+    output = cube.spectral
     expected = cube.axis_world_coords("em")[0]
     assert (output == expected).all()
 
 
-def test_no_stokes(ndcube_4d_ln_l_t_lt):
-    cube = ndcube_4d_ln_l_t_lt
-    output = cube.stokes()
+def test_no_stokes(ndcube_3d_ln_lt_l_ec_time):
+    cube = ndcube_3d_ln_lt_l_ec_time
+    output = cube.stokes
     assert output is None

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1204,3 +1204,30 @@ def test_ndcube_quantity(ndcube_2d_ln_lt_units):
     cube = ndcube_2d_ln_lt_units
     expected = u.Quantity(cube.data, cube.unit)
     np.testing.assert_array_equal(cube.quantity, expected)
+
+
+def test_celestial(ndcube_4d_ln_l_t_lt):
+    cube = ndcube_4d_ln_l_t_lt
+    output = cube.celestial()
+    expected = cube.axis_world_coords("lon")[0]
+    assert (output == expected).all()
+
+
+def test_time(ndcube_4d_ln_l_t_lt):
+    cube = ndcube_4d_ln_l_t_lt
+    output = cube.time()
+    expected = cube.axis_world_coords("time")[0]
+    assert (output == expected).all()
+
+
+def test_spectral(ndcube_4d_ln_l_t_lt):
+    cube = ndcube_4d_ln_l_t_lt
+    output = cube.spectral()
+    expected = cube.axis_world_coords("em")[0]
+    assert (output == expected).all()
+
+
+def test_no_stokes(ndcube_4d_ln_l_t_lt):
+    cube = ndcube_4d_ln_l_t_lt
+    output = cube.stokes()
+    assert output is None


### PR DESCRIPTION
## PR Description

This PR adds 4 methods for getting the certain common coordinate types for all array indices of relevant axes:
* `NDCube.celestial`
* `NDCube.time`
* `NDCube.spectral`
* `NDCube.stokes`

These are convenience methods for `NDCube.axis_world_coords`.  If the WCS does not contain the relevant axis, `None` is returned.
