### PR TITLE
Use np.all instead of all

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1124,7 +1124,7 @@ class NDCube(NDCubeBase):
         new_unit = new_unit or self.unit
         # Make sure the input bin dimensions are integers.
         bin_shape = np.rint(bin_shape).astype(int)
-        if all(bin_shape == 1):
+        if np.all(bin_shape == 1):
             return self
         # Ensure bin_size has right number of entries and each entry is an
         # integer fraction of the array shape in each dimension.


### PR DESCRIPTION
This line errors if ``binshape`` is a quantity. 

```python
(Pdb) bin_shape
<Quantity [2, 2] pix>
(Pdb) bin_shape == 1
False
(Pdb) all(bin_shape == 1)
*** TypeError: 'bool' object is not iterable
```