### PR TITLE
Rough attempt at ignoring units for rebin

### DIFF
--- a/changelog/744.bugfix.rst
+++ b/changelog/744.bugfix.rst
@@ -1,0 +1,1 @@
+:meth:`ndcube.NDcube.rebin` ``bin_shape`` argument now accepts a `astropy.units.Quantity` as input if the units are convertible to pixels.

--- a/changelog/744.bugfix.rst
+++ b/changelog/744.bugfix.rst
@@ -1,1 +1,1 @@
-:meth:`ndcube.NDcube.rebin` ``bin_shape`` argument now accepts a `astropy.units.Quantity` as input if the units are convertible to pixels.
+:meth:`ndcube.NDCube.rebin` ``bin_shape`` argument now accepts a `astropy.units.Quantity` as input if the units are convertible to pixels.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1024,7 +1024,7 @@ class NDCube(NDCubeBase):
             Must be the same length as number of dimensions in data.
             Each element must be in int. If they are not they will be rounded
             to the nearest int. If provided as a `~astropy.units.Quantity` the
-            units are ignored, just the values are used as the shape.
+            units have to be convertible to pixels.
         operation : function
             Function applied to the data to derive values of the bins.
             Default is `numpy.mean`
@@ -1124,7 +1124,7 @@ class NDCube(NDCubeBase):
         # Sanitize input.
         new_unit = new_unit or self.unit
         if isinstance(bin_shape, u.Quantity):
-            bin_shape = bin_shape.to_value()
+            bin_shape = bin_shape.to_value(u.pixel)
         # Make sure the input bin dimensions are integers.
         bin_shape = np.rint(bin_shape).astype(int)
         if np.all(bin_shape == 1):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1019,7 +1019,7 @@ class NDCube(NDCubeBase):
 
         Parameters
         ----------
-        bin_shape : array-like, astropy.units.Quantity
+        bin_shape : array-like, `astropy.units.Quantity`
             The number of pixels in a bin in each dimension.
             Must be the same length as number of dimensions in data.
             Each element must be in int. If they are not they will be rounded

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1019,7 +1019,7 @@ class NDCube(NDCubeBase):
 
         Parameters
         ----------
-        bin_shape : array-like
+        bin_shape : array-like, astropy.units.Quantity
             The number of pixels in a bin in each dimension.
             Must be the same length as number of dimensions in data.
             Each element must be in int. If they are not they will be rounded
@@ -1122,6 +1122,8 @@ class NDCube(NDCubeBase):
         """
         # Sanitize input.
         new_unit = new_unit or self.unit
+        if isinstance(bin_shape, u.Quantity):
+            bin_shape = bin_shape.value
         # Make sure the input bin dimensions are integers.
         bin_shape = np.rint(bin_shape).astype(int)
         if np.all(bin_shape == 1):

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1023,7 +1023,8 @@ class NDCube(NDCubeBase):
             The number of pixels in a bin in each dimension.
             Must be the same length as number of dimensions in data.
             Each element must be in int. If they are not they will be rounded
-            to the nearest int.
+            to the nearest int. If provided as a `~astropy.units.Quantity` the
+            units are ignored, just the values are used as the shape.
         operation : function
             Function applied to the data to derive values of the bins.
             Default is `numpy.mean`
@@ -1123,7 +1124,7 @@ class NDCube(NDCubeBase):
         # Sanitize input.
         new_unit = new_unit or self.unit
         if isinstance(bin_shape, u.Quantity):
-            bin_shape = bin_shape.value
+            bin_shape = bin_shape.to_value()
         # Make sure the input bin dimensions are integers.
         bin_shape = np.rint(bin_shape).astype(int)
         if np.all(bin_shape == 1):

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -863,12 +863,13 @@ def test_rebin_dask(ndcube_2d_dask):
     assert isinstance(output.mask, dask_type)
 
 
-def test_rebin_binshape_quantity(ndcube_3d_l_ln_lt_ectime):
-    # Confirm rebin binshape argument handles being a astropy unit
+def test_rebin_bin_shape_quantity(ndcube_3d_l_ln_lt_ectime):
+    # Confirm rebin's bin_shape argument handles being a astropy unit
     cube = ndcube_3d_l_ln_lt_ectime[:, 1:]
     cube._extra_coords = ExtraCoords(cube)
     bin_shape = (10, 2, 1) * u.pix
-    cube.rebin(bin_shape)
+    output = cube.rebin(bin_shape)
+    np.testing.assert_allclose(output.shape, cube.shape / bin_shape.to_value())
 
 
 def test_rebin_no_ec(ndcube_3d_l_ln_lt_ectime):

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -863,6 +863,14 @@ def test_rebin_dask(ndcube_2d_dask):
     assert isinstance(output.mask, dask_type)
 
 
+def test_rebin_binshape_quantity(ndcube_3d_l_ln_lt_ectime):
+    # Confirm rebin binshape argument handles being a astropy unit
+    cube = ndcube_3d_l_ln_lt_ectime[:, 1:]
+    cube._extra_coords = ExtraCoords(cube)
+    bin_shape = (10, 2, 1) * u.pix
+    cube.rebin(bin_shape)
+
+
 def test_rebin_no_ec(ndcube_3d_l_ln_lt_ectime):
     # Confirm rebin does not try to handle extra coords when there aren't any.
     cube = ndcube_3d_l_ln_lt_ectime[:, 1:]

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -1,3 +1,4 @@
+import re
 from inspect import signature
 from textwrap import dedent
 
@@ -870,6 +871,8 @@ def test_rebin_bin_shape_quantity(ndcube_3d_l_ln_lt_ectime):
     bin_shape = (10, 2, 1) * u.pix
     output = cube.rebin(bin_shape)
     np.testing.assert_allclose(output.shape, cube.shape / bin_shape.to_value())
+    with pytest.raises(u.UnitConversionError, match=re.escape("'m' (length) and 'pix' are not convertible")):
+        cube.rebin((10, 2, 1) * u.m)
 
 
 def test_rebin_no_ec(ndcube_3d_l_ln_lt_ectime):


### PR DESCRIPTION
One way to do it.

Context:
sunpy.map.superpixel requireds astropy units as input.

rebin does not enforce this but a lot of superpixel code has units attached, so making that work with those would be a better idea than making users drop the pixel units.

