### PR TITLE
Revert "Skip a test until astropy 6.1.3 is released"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,6 @@ commands =
     online: --remote-data=any \
     figure: -m "mpl_image_compare" --mpl --remote-data=any --mpl-generate-summary=html --mpl-baseline-path=https://raw.githubusercontent.com/sunpy/sunpy-figure-tests/ndcube-main/figures/{envname}/ \
     {toxinidir}/docs \
-    -k 'not ndcube.mixins.ndslicing.NDCubeSlicingMixin' \  # Skip a troublesome test until astropy 6.1.3 is released
     {posargs}
 
 [testenv:build_docs]


### PR DESCRIPTION
Reverts sunpy/ndcube#752 as astropy 6.1.3 is out.