### PR TITLE
Faster shortcut for working out coordinates values for non-correlated WCS 

### DIFF
--- a/changelog/780.bugfix.rst
+++ b/changelog/780.bugfix.rst
@@ -1,0 +1,1 @@
+Added an internal method to shortcut non-correlated axes avoiding the creation of a full coordinate grid, reducing memory use in specific circumstances.

--- a/ndcube/conftest.py
+++ b/ndcube/conftest.py
@@ -198,6 +198,30 @@ def wcs_3d_lt_ln_l():
 
 
 @pytest.fixture
+def wcs_3d_wave_lt_ln():
+    header = {
+        'CTYPE1': 'WAVE    ',
+        'CUNIT1': 'Angstrom',
+        'CDELT1': 0.2,
+        'CRPIX1': 0,
+        'CRVAL1': 10,
+
+        'CTYPE2': 'HPLT-TAN',
+        'CUNIT2': 'deg',
+        'CDELT2': 0.5,
+        'CRPIX2': 2,
+        'CRVAL2': 0.5,
+
+        'CTYPE3': 'HPLN-TAN    ',
+        'CUNIT3': 'deg',
+        'CDELT3': 0.4,
+        'CRPIX3': 2,
+        'CRVAL3': 1,
+    }
+    return WCS(header=header)
+
+
+@pytest.fixture
 def wcs_2d_lt_ln():
     spatial = {
         'CTYPE1': 'HPLT-TAN',
@@ -442,6 +466,24 @@ def ndcube_3d_ln_lt_l_ec_time(wcs_3d_l_lt_ln, time_and_simple_extra_coords_2d):
     )
     cube._extra_coords = time_and_simple_extra_coords_2d
     cube._extra_coords._ndcube = cube
+    return cube
+
+
+@pytest.fixture
+def ndcube_3d_wave_lt_ln_ec_time(wcs_3d_wave_lt_ln):
+    shape = (3, 4, 5)
+    wcs_3d_wave_lt_ln.array_shape = shape
+    data = data_nd(shape)
+    mask = data > 0
+    cube = NDCube(
+        data,
+        wcs_3d_wave_lt_ln,
+        mask=mask,
+        uncertainty=data,
+    )
+    base_time = Time('2000-01-01', format='fits', scale='utc')
+    timestamps = Time([base_time + TimeDelta(60 * i, format='sec') for i in range(data.shape[0])])
+    cube.extra_coords.add('time', 0, timestamps)
     return cube
 
 

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -503,40 +503,36 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
         pixel_shape = self.data.shape[::-1]
         if pixel_corners:
             pixel_shape = tuple(np.array(pixel_shape) + 1)
-            pixel_ranges = [np.arange(i) - 0.5 for i in pixel_shape]
+            ranges = [np.arange(i) - 0.5 for i in pixel_shape]
         else:
-            pixel_ranges = [np.arange(i) for i in pixel_shape]
+            ranges = [np.arange(i) for i in pixel_shape]
 
         # Limit the pixel dimensions to the ones present in the ExtraCoords
         if isinstance(wcs, ExtraCoords):
-            pixel_ranges = [pixel_ranges[i] for i in wcs.mapping]
+            ranges = [ranges[i] for i in wcs.mapping]
             wcs = wcs.wcs
             if wcs is None:
                 return []
+
         # This value of zero will be returned as a throwaway for unneeded axes, and a numerical value is
         # required so values_to_high_level_objects in the calling function doesn't crash or warn
         world_coords = [0] * wcs.world_n_dim
         for (pixel_axes_indices, world_axes_indices) in _split_matrix(wcs.axis_correlation_matrix):
-            if (
-                needed_axes is not None
-                and len(needed_axes)
-                and all(
-                    world_axis not in needed_axes
-                    for world_axis in world_axes_indices
-                )
-            ):
+            if (needed_axes is not None
+                    and len(needed_axes)
+                    and not any(world_axis in needed_axes for world_axis in world_axes_indices)):
                 # needed_axes indicates which values in world_coords will be used by the calling
                 # function, so skip this iteration if we won't be producing any of those values
                 continue
             # First construct a range of pixel indices for this set of coupled dimensions
-            pixel_ranges_subset = [pixel_ranges[idx] for idx in pixel_axes_indices]
-            # Then get a set of non-correlated dimensions
+            sub_range = [ranges[idx] for idx in pixel_axes_indices]
+            # Then get a set of non correlated dimensions
             non_corr_axes = set(range(wcs.pixel_n_dim)) - set(pixel_axes_indices)
             # And inject 0s for those coordinates
             for idx in non_corr_axes:
-                pixel_ranges_subset.insert(idx, 0)
-            # Generate a grid of broadcast-able pixel indices for all pixel dimensions
-            grid = np.meshgrid(*pixel_ranges_subset, indexing='ij')
+                sub_range.insert(idx, 0)
+            # Generate a grid of broadcastable pixel indices for all pixel dimensions
+            grid = np.meshgrid(*sub_range, indexing='ij')
             # Convert to world coordinates
             world = wcs.pixel_to_world_values(*grid)
             # TODO: this isinstance check is to mitigate https://github.com/spacetelescope/gwcs/pull/332
@@ -549,6 +545,7 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
                 array_slice[wcs.axis_correlation_matrix[idx]] = slice(None)
                 tmp_world = world[idx][tuple(array_slice)].T
                 world_coords[idx] = tmp_world
+
         if units:
             for i, (coord, unit) in enumerate(zip(world_coords, wcs.world_axis_units)):
                 world_coords[i] = coord << u.Unit(unit)
@@ -560,27 +557,35 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
         # Docstring in NDCubeABC.
         if isinstance(wcs, BaseHighLevelWCS):
             wcs = wcs.low_level_wcs
+
         orig_wcs = wcs
         if isinstance(wcs, ExtraCoords):
             wcs = wcs.wcs
             if not wcs:
                 return ()
+
         object_names = np.array([wao_comp[0] for wao_comp in wcs.world_axis_object_components])
         unique_obj_names = utils.misc.unique_sorted(object_names)
         world_axes_for_obj = [np.where(object_names == name)[0] for name in unique_obj_names]
+
         # Create a mapping from world index in the WCS to object index in axes_coords
         world_index_to_object_index = {}
         for object_index, world_axes in enumerate(world_axes_for_obj):
             for world_index in world_axes:
                 world_index_to_object_index[world_index] = object_index
+
         world_indices = utils.wcs.calculate_world_indices_from_axes(wcs, axes)
         object_indices = utils.misc.unique_sorted(
             [world_index_to_object_index[world_index] for world_index in world_indices]
         )
+
         axes_coords = self._generate_world_coords(pixel_corners, orig_wcs, world_indices, units=False)
+
         axes_coords = values_to_high_level_objects(*axes_coords, low_level_wcs=wcs)
+
         if not axes:
             return tuple(axes_coords)
+
         return tuple(axes_coords[i] for i in object_indices)
 
     @utils.cube.sanitize_wcs
@@ -588,19 +593,25 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
         # Docstring in NDCubeABC.
         if isinstance(wcs, BaseHighLevelWCS):
             wcs = wcs.low_level_wcs
+
         orig_wcs = wcs
         if isinstance(wcs, ExtraCoords):
             wcs = wcs.wcs
             if not wcs:
                 return ()
+
         world_indices = utils.wcs.calculate_world_indices_from_axes(wcs, axes)
+
         axes_coords = self._generate_world_coords(pixel_corners, orig_wcs, world_indices, units=True)
+
         world_axis_physical_types = wcs.world_axis_physical_types
+
         # If user has supplied axes, extract only the
         # world coords that correspond to those axes.
         if axes:
             axes_coords = [axes_coords[i] for i in world_indices]
             world_axis_physical_types = tuple(np.array(world_axis_physical_types)[world_indices])
+
         # Return in array order.
         # First replace characters in physical types forbidden for namedtuple identifiers.
         identifiers = []

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -550,7 +550,7 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
             ranges = [ranges[i] for i in wcs.mapping]
             wcs = wcs.wcs
             if wcs is None:
-                return []
+                return ()
         # This value of zero will be returned as a throwaway for unneeded axes, and a numerical value is
         # required so values_to_high_level_objects in the calling function doesn't crash or warn
         world_coords = [0] * wcs.world_n_dim
@@ -587,7 +587,7 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
                 world_coords[i] = coord << u.Unit(unit)
         return world_coords
 
-    def _generate_world_coords(self, pixel_corners, wcs, *, needed_axes=None, units=None):
+    def _generate_world_coords(self, pixel_corners, wcs, *, needed_axes, units=None):
         """
         Private method to generate world coordinates.
 
@@ -609,8 +609,6 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
         array-like
             The world coordinates.
         """
-        if isinstance(wcs, ExtraCoords):
-            wcs = wcs.wcs
         axes_are_independent = []
         pixel_axes = set()
         for world_axis in needed_axes:

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -483,7 +483,7 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
         # This will generate only the coordinates that are needed if there is no correlation within the WCS
         # This bypasses the entire rest of the function below which works out the full set of coordinates
         # This only works for WCS that have the same number of world and pixel dimensions
-        if needed_axes is not None and not isinstance(wcs, ExtraCoords) and np.sum(wcs.axis_correlation_matrix[needed_axes]) == 1 and len(self.data.shape) == wcs.world_n_dim:
+        if needed_axes is not None and not isinstance(wcs, ExtraCoords) and np.sum(wcs.axis_correlation_matrix[needed_axes]) == 1:
             lims = (-0.5, self.data.shape[::-1][needed_axes[0]] + 1) if pixel_corners else (0, self.data.shape[::-1][needed_axes[0]])
             indices = [np.arange(lims[0], lims[1]) if wanted else [0] for wanted in wcs.axis_correlation_matrix[needed_axes][0]]
             world_coords = wcs.pixel_to_world_values(*indices)
@@ -525,7 +525,7 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
             # First construct a range of pixel indices for this set of coupled dimensions
             pixel_ranges_subset = [pixel_ranges[idx] for idx in pixel_axes_indices]
             # Then get a set of non-correlated dimensions
-            non_corr_axes = set(list(range(wcs.pixel_n_dim))) - set(pixel_axes_indices)
+            non_corr_axes = set(range(wcs.pixel_n_dim)) - set(pixel_axes_indices)
             # And inject 0s for those coordinates
             for idx in non_corr_axes:
                 pixel_ranges_subset.insert(idx, 0)

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -483,6 +483,28 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
 
 
     def _generate_independent_world_coords(self, pixel_corners, wcs, pixel_axes, units):
+        """
+        Generate world coordinates for independent axes.
+
+        The idea is to workout only the specific grid that is needed for independent axes.
+        This speeds up the calculation of world coordinates and reduces memory usage.
+
+        Parameters
+        ----------
+        pixel_corners : bool
+            If one needs pixel corners, otherwise pixel centers.
+        wcs : astropy.wcs.WCS
+            The WCS.
+        pixel_axes : array-like
+            The pixel axes.
+        units : bool
+            If units are needed.
+
+        Returns
+        -------
+        array-like
+            The world coordinates.
+        """
         naxes = len(self.data.shape)
         pixel_indices = [np.array([0], dtype=int).reshape([1] * naxes).squeeze()] * naxes
         for pixel_axis in pixel_axes:
@@ -506,9 +528,28 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
         return world_coords
 
     def _generate_dependent_world_coords(self, pixel_corners, wcs, pixel_axes, units):
-        # Create a meshgrid of all pixel coordinates.
-        # If the user wants pixel corners, set pixel values to pixel corners.
-        # Else make pixel centers.
+        """
+        Generate world coordinates for dependent axes.
+
+        This will work out the exact grid that is needed for dependent axes
+        and can be time and memory consuming.
+
+        Parameters
+        ----------
+        pixel_corners : bool
+            If one needs pixel corners, otherwise pixel centers.
+        wcs : astropy.wcs.WCS
+            The WCS.
+        pixel_axes : array-like
+            The pixel axes.
+        units : bool
+            If units are needed.
+
+        Returns
+        -------
+        array-like
+            The world coordinates.
+        """
         pixel_shape = self.data.shape[::-1]
         if pixel_corners:
             pixel_shape = tuple(np.array(pixel_shape) + 1)
@@ -553,6 +594,27 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
 
 
     def _generate_world_coords(self, pixel_corners, wcs, *, needed_axes=None, units=None):
+        """
+        Private method to generate world coordinates.
+
+        Handles both dependent and independent axes.
+
+        Parameters
+        ----------
+        pixel_corners : bool
+            If one needs pixel corners, otherwise pixel centers.
+        wcs : astropy.wcs.WCS
+            The WCS.
+        needed_axes : array-like
+            The axes that are needed.
+        units : bool
+            If units are needed.
+
+        Returns
+        -------
+        array-like
+            The world coordinates.
+        """
         # TODO: Workout why I need this twice now.
         if isinstance(wcs, ExtraCoords):
             wcs = wcs.wcs

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -481,8 +481,10 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
 
     def _generate_world_coords(self, pixel_corners, wcs, needed_axes=None, *, units):
         # LOLOLOLOLOLOLOLO - sHORT cIRCUIT fOR nON-cORRELATED wORLD cOORDINATES
-        if needed_axes is not None and not isinstance(wcs, ExtraCoords) and np.sum(wcs.axis_correlation_matrix[needed_axes]) == 1:
-            world_coords = wcs.pixel_to_world_values(*[0 for _ in range(len(wcs.axis_correlation_matrix[needed_axes][0])-1)], np.arange(self.data.shape[::-1][needed_axes[0]]))
+        if not pixel_corners and needed_axes is not None and not isinstance(wcs, ExtraCoords) and np.sum(wcs.axis_correlation_matrix[needed_axes]) == 1:
+            indices = [np.arange(self.data.shape[::-1][needed_axes[0]]).tolist() if wanted else 0
+                    for wanted in wcs.axis_correlation_matrix[needed_axes][0]]
+            world_coords = wcs.pixel_to_world_values(*indices)
             if units:
                 world_coords = world_coords << u.Unit(wcs.world_axis_units[needed_axes[0]])
             return world_coords

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -483,8 +483,9 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
         # This will generate only the coordinates that are needed if there is no correlation within the WCS
         # This bypasses the entire rest of the function below which works out the full set of coordinates
         # This only works for WCS that have the same number of world and pixel dimensions
-        if not pixel_corners and needed_axes is not None and not isinstance(wcs, ExtraCoords) and np.sum(wcs.axis_correlation_matrix[needed_axes]) == 1 and len(self.data.shape) == wcs.world_n_dim:
-            indices = [np.arange(self.data.shape[::-1][needed_axes[0]]) if wanted else [0] for wanted in wcs.axis_correlation_matrix[needed_axes][0]]
+        if needed_axes is not None and not isinstance(wcs, ExtraCoords) and np.sum(wcs.axis_correlation_matrix[needed_axes]) == 1 and len(self.data.shape) == wcs.world_n_dim:
+            lims = (-0.5, self.data.shape[::-1][needed_axes[0]] + 1) if pixel_corners else (0, self.data.shape[::-1][needed_axes[0]])
+            indices = [np.arange(lims[0], lims[1]) if wanted else [0] for wanted in wcs.axis_correlation_matrix[needed_axes][0]]
             world_coords = wcs.pixel_to_world_values(*indices)
             if units:
                 world_coords = world_coords << u.Unit(wcs.world_axis_units[needed_axes[0]])

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -237,11 +237,16 @@ def test_axis_world_coords_single(axes, ndcube_3d_ln_lt_l):
 
 @pytest.mark.parametrize("axes", [[-1], [2], ["em"]])
 def test_axis_world_coords_single_pixel_corners(axes, ndcube_3d_ln_lt_l):
+
+    # We go from 4 pixels to 6 pixels when we add pixel corners
+    coords = ndcube_3d_ln_lt_l.axis_world_coords_values(*axes, pixel_corners=False)
+    assert u.allclose(coords[0], [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09] * u.m)
+
     coords = ndcube_3d_ln_lt_l.axis_world_coords_values(*axes, pixel_corners=True)
-    assert u.allclose(coords, [1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09] * u.m)
+    assert u.allclose(coords[0], [1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09, 1.11e-09] * u.m)
 
     coords = ndcube_3d_ln_lt_l.axis_world_coords(*axes, pixel_corners=True)
-    assert u.allclose(coords, [1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09] * u.m)
+    assert u.allclose(coords[0], [1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09, 1.11e-09] * u.m)
 
 
 @pytest.mark.parametrize(("ndc", "item"),

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -235,7 +235,7 @@ def test_axis_world_coords_single(axes, ndcube_3d_ln_lt_l):
     assert u.allclose(coords[0], [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09] * u.m)
 
 
-def test_axis_world_coords_crazy(ndcube_3d_wave_lt_ln_ec_time):
+def test_axis_world_coords_combined_wcs(ndcube_3d_wave_lt_ln_ec_time):
     # This replicates a specific NDCube test in the visualization.rst
     coords = ndcube_3d_wave_lt_ln_ec_time.axis_world_coords('time', wcs=ndcube_3d_wave_lt_ln_ec_time.combined_wcs)
     assert len(coords) == 1

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -178,9 +178,19 @@ def test_axis_world_coords_wave_ec(ndcube_3d_l_ln_lt_ectime):
 
     coords = cube.axis_world_coords()
     assert len(coords) == 2
+    assert isinstance(coords[0], SkyCoord)
+    assert coords[0].shape == (5, 8)
+    assert isinstance(coords[1], SpectralCoord)
+    assert coords[1].shape == (10,)
 
     coords = cube.axis_world_coords(wcs=cube.combined_wcs)
     assert len(coords) == 3
+    assert isinstance(coords[0], SkyCoord)
+    assert coords[0].shape == (5, 8)
+    assert isinstance(coords[1], SpectralCoord)
+    assert coords[1].shape == (10,)
+    assert isinstance(coords[2], Time)
+    assert coords[2].shape == (5,)
 
     coords = cube.axis_world_coords(wcs=cube.extra_coords)
     assert len(coords) == 1
@@ -199,8 +209,6 @@ def test_axis_world_coords_empty_ec(ndcube_3d_l_ln_lt_ectime):
 
     # slice the cube so extra_coords is empty, and then try and run axis_world_coords
     awc = sub_cube.axis_world_coords(wcs=sub_cube.extra_coords)
-    assert awc == ()
-    sub_cube._generate_world_coords(pixel_corners=False, wcs=sub_cube.extra_coords, units=True)
     assert awc == ()
 
 

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -235,6 +235,20 @@ def test_axis_world_coords_single(axes, ndcube_3d_ln_lt_l):
     assert u.allclose(coords[0], [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09] * u.m)
 
 
+def test_axis_world_coords_crazy(ndcube_3d_wave_lt_ln_ec_time):
+    # This replicates a specific NDCube test in the visualization.rst
+    coords = ndcube_3d_wave_lt_ln_ec_time.axis_world_coords('time', wcs=ndcube_3d_wave_lt_ln_ec_time.combined_wcs)
+    assert len(coords) == 1
+    assert isinstance(coords[0], Time)
+    assert np.all(coords[0] == Time(['2000-01-01T00:00:00.000', '2000-01-01T00:01:00.000', '2000-01-01T00:02:00.000']))
+
+    # This fails and returns the wrong coords
+    coords = ndcube_3d_wave_lt_ln_ec_time.axis_world_coords_values('time', wcs=ndcube_3d_wave_lt_ln_ec_time.combined_wcs)
+    assert len(coords) == 1
+    assert isinstance(coords.time, Time)
+    assert np.all(coords.time == Time(['2000-01-01T00:00:00.000', '2000-01-01T00:01:00.000', '2000-01-01T00:02:00.000']))
+
+
 @pytest.mark.parametrize("axes", [[-1], [2], ["em"]])
 def test_axis_world_coords_single_pixel_corners(axes, ndcube_3d_ln_lt_l):
 

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -12,6 +12,7 @@ import astropy.wcs
 from astropy.coordinates import SkyCoord, SpectralCoord
 from astropy.io import fits
 from astropy.nddata import UnknownUncertainty
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
 from astropy.units import UnitsError
 from astropy.wcs import WCS
@@ -236,17 +237,16 @@ def test_axis_world_coords_single(axes, ndcube_3d_ln_lt_l):
 
 
 def test_axis_world_coords_combined_wcs(ndcube_3d_wave_lt_ln_ec_time):
-    # This replicates a specific NDCube test in the visualization.rst
+    # This replicates a specific NDCube object in visualization.rst
     coords = ndcube_3d_wave_lt_ln_ec_time.axis_world_coords('time', wcs=ndcube_3d_wave_lt_ln_ec_time.combined_wcs)
     assert len(coords) == 1
     assert isinstance(coords[0], Time)
     assert np.all(coords[0] == Time(['2000-01-01T00:00:00.000', '2000-01-01T00:01:00.000', '2000-01-01T00:02:00.000']))
 
-    # This fails and returns the wrong coords
     coords = ndcube_3d_wave_lt_ln_ec_time.axis_world_coords_values('time', wcs=ndcube_3d_wave_lt_ln_ec_time.combined_wcs)
     assert len(coords) == 1
-    assert isinstance(coords.time, Time)
-    assert np.all(coords.time == Time(['2000-01-01T00:00:00.000', '2000-01-01T00:01:00.000', '2000-01-01T00:02:00.000']))
+    assert isinstance(coords.time, u.Quantity)
+    assert_quantity_allclose(coords.time, [0, 60, 120] * u.second)
 
 
 @pytest.mark.parametrize("axes", [[-1], [2], ["em"]])
@@ -271,10 +271,10 @@ def test_axis_world_coords_single_pixel_corners(axes, ndcube_3d_ln_lt_l):
                          indirect=("ndc",))
 def test_axis_world_coords_sliced_all_3d(ndc, item):
     coords = ndc[item].axis_world_coords_values()
-    assert u.allclose(coords, [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09] * u.m)
+    assert u.allclose(coords[0], [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09] * u.m)
 
     coords = ndc[item].axis_world_coords()
-    assert u.allclose(coords, [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09] * u.m)
+    assert u.allclose(coords[0], [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09] * u.m)
 
 
 @pytest.mark.parametrize(("ndc", "item"),


### PR DESCRIPTION
Fixes https://github.com/sunpy/ndcube/issues/585 

So in my case, I use a DKIST compound model which has two coupled pixel axes and a time axes. 
If I want just the time axis, the current code will work out the entire grid leading to a very dense and memory intense results. 

So I added a really specific hack which works for my code and seems to not break the rest of the test suite. 

TODO:

Unit tests:
- [ ] EDGE CASES - THERE SHOULD BE SOME?