### PR TITLE
Reduce memory consuption in axis_world_coords (again)

### DIFF
--- a/changelog/780.bugfix.rst
+++ b/changelog/780.bugfix.rst
@@ -1,1 +1,0 @@
-Added an internal method to shortcut non-correlated axes avoiding the creation of a full coordinate grid, reducing memory use in specific circumstances.

--- a/changelog/798.bugfix.rst
+++ b/changelog/798.bugfix.rst
@@ -1,0 +1,1 @@
+Added an internal code to shortcut non-correlated axes avoiding the creation of a full coordinate grid, reducing memory use in specific circumstances.

--- a/ndcube/conftest.py
+++ b/ndcube/conftest.py
@@ -292,6 +292,86 @@ def wcs_3d_ln_lt_t_rotated():
     return WCS(header=h_rotated)
 
 
+@pytest.fixture
+def wcs_3d_ln_lt_l_coupled():
+    # WCS for a 3D data cube with two celestial axes and one wavelength axis.
+    # The latitudinal dimension is coupled to the third pixel dimension through
+    # a single off diagonal element in the PCij matrix
+    header = {
+        'CTYPE1': 'HPLN-TAN',
+        'CRPIX1': 5,
+        'CDELT1': 5,
+        'CUNIT1': 'arcsec',
+        'CRVAL1': 0.0,
+
+        'CTYPE2': 'HPLT-TAN',
+        'CRPIX2': 5,
+        'CDELT2': 5,
+        'CUNIT2': 'arcsec',
+        'CRVAL2': 0.0,
+
+        'CTYPE3': 'WAVE',
+        'CRPIX3': 1.0,
+        'CDELT3': 1,
+        'CUNIT3': 'Angstrom',
+        'CRVAL3': 1.0,
+
+        'PC1_1': 1,
+        'PC1_2': 0,
+        'PC1_3': 0,
+        'PC2_1': 0,
+        'PC2_2': 1,
+        'PC2_3': -1.0,
+        'PC3_1': 0.0,
+        'PC3_2': 0.0,
+        'PC3_3': 1.0,
+
+        'WCSAXES': 3,
+
+        'DATEREF': "2020-01-01T00:00:00"
+    }
+    return WCS(header=header)
+
+
+@pytest.fixture
+def wcs_3d_ln_lt_t_coupled():
+    # WCS for a 3D data cube with two celestial axes and one time axis.
+    header = {
+        'CTYPE1': 'HPLN-TAN',
+        'CRPIX1': 5,
+        'CDELT1': 5,
+        'CUNIT1': 'arcsec',
+        'CRVAL1': 0.0,
+
+        'CTYPE2': 'HPLT-TAN',
+        'CRPIX2': 5,
+        'CDELT2': 5,
+        'CUNIT2': 'arcsec',
+        'CRVAL2': 0.0,
+
+        'CTYPE3': 'UTC',
+        'CRPIX3': 1.0,
+        'CDELT3': 1,
+        'CUNIT3': 's',
+        'CRVAL3': 1.0,
+
+        'PC1_1': 1,
+        'PC1_2': 0,
+        'PC1_3': 0,
+        'PC2_1': 0,
+        'PC2_2': 1,
+        'PC2_3': 0,
+        'PC3_1': 0,
+        'PC3_2': 1,
+        'PC3_3': 1,
+
+        'WCSAXES': 3,
+
+        'DATEREF': "2020-01-01T00:00:00"
+    }
+    return WCS(header=header)
+
+
 ################################################################################
 # Extra and Global Coords Fixtures
 ################################################################################
@@ -517,6 +597,31 @@ def ndcube_3d_rotated(wcs_3d_ln_lt_t_rotated, simple_extra_coords_3d):
     )
     cube._extra_coords = simple_extra_coords_3d
     return cube
+
+
+@pytest.fixture
+def ndcube_3d_coupled(wcs_3d_ln_lt_l_coupled):
+    shape = (128, 256, 512)
+    wcs_3d_ln_lt_l_coupled.array_shape = shape
+    data = data_nd(shape)
+    mask = data > 0
+    return NDCube(
+        data,
+        wcs_3d_ln_lt_l_coupled,
+        mask=mask,
+        uncertainty=data,
+    )
+
+
+@pytest.fixture
+def ndcube_3d_coupled_time(wcs_3d_ln_lt_t_coupled):
+    shape = (128, 256, 512)
+    wcs_3d_ln_lt_t_coupled.array_shape = shape
+    data = data_nd(shape)
+    return NDCube(
+        data,
+        wcs_3d_ln_lt_t_coupled,
+    )
 
 
 @pytest.fixture

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -306,10 +306,10 @@ def test_axis_world_coords_single_pixel_corners(axes, ndcube_3d_ln_lt_l):
     assert u.allclose(coords[0], [1.02e-09, 1.04e-09, 1.06e-09, 1.08e-09] * u.m)
 
     coords = ndcube_3d_ln_lt_l.axis_world_coords_values(*axes, pixel_corners=True)
-    assert u.allclose(coords[0], [1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09, 1.11e-09] * u.m)
+    assert u.allclose(coords, [1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09] * u.m)
 
     coords = ndcube_3d_ln_lt_l.axis_world_coords(*axes, pixel_corners=True)
-    assert u.allclose(coords[0], [1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09, 1.11e-09] * u.m)
+    assert u.allclose(coords, [1.01e-09, 1.03e-09, 1.05e-09, 1.07e-09, 1.09e-09] * u.m)
 
 
 @pytest.mark.parametrize(("ndc", "item"),

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -230,6 +230,20 @@ def test_axis_world_coords_wave_ec(ndcube_3d_l_ln_lt_ectime):
     assert coords[0].shape == (5,)
 
 
+@pytest.mark.limit_memory("12 MB")
+def test_axis_world_coords_wave_coupled_dims(ndcube_3d_coupled):
+    cube = ndcube_3d_coupled
+
+    cube.axis_world_coords('em.wl')
+
+
+@pytest.mark.limit_memory("12 MB")
+def test_axis_world_coords_time_coupled_dims(ndcube_3d_coupled_time):
+    cube = ndcube_3d_coupled_time
+
+    cube.axis_world_coords('time')
+
+
 def test_axis_world_coords_empty_ec(ndcube_3d_l_ln_lt_ectime):
     cube = ndcube_3d_l_ln_lt_ectime
     sub_cube = cube[:, 0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ tests = [
   "pytest-mpl>=0.12",
   "pytest-xdist",
   "pytest",
+  "pytest-memray",
   "scipy",
   "specutils",
   "sunpy>=5.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ tests = [
   "pytest-mpl>=0.12",
   "pytest-xdist",
   "pytest",
-  "pytest-memray",
+  "pytest-memray; sys_platform != 'win32'",
   "scipy",
   "specutils",
   "sunpy>=5.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,11 @@ addopts =
     --doctest-continue-on-failure
 mpl-results-path = figure_test_images
 mpl-use-full-test-name = true
+remote_data_strict = True
+doctest_subpackage_requires =
+    docs/explaining_ndcube/* = numpy>=2.0.0
+markers =
+    limit_memory: pytest-memray marker to fail a test if too much memory used
 filterwarnings =
     # Turn all warnings into errors so they do not pass silently.
     error
@@ -53,6 +58,3 @@ filterwarnings =
     ignore:FigureCanvasAgg is non-interactive, and thus cannot be shown:UserWarning
     # Oldestdeps from gWCS
     ignore:pkg_resources is deprecated as an API:DeprecationWarning
-remote_data_strict = True
-doctest_subpackage_requires =
-    docs/explaining_ndcube/* = numpy>=2.0.0


### PR DESCRIPTION
This PR works, as an alternative to #780 by not generating mesh coords for unneeded pixel axes.

i.e. if the pixel axes are not correlated with a requested world axis then don't generate the coords in the mesh.