### PR TITLE
Avoid using deprecated `astropy.utils.isiterable()`

### DIFF
--- a/ndcube/extra_coords/table_coord.py
+++ b/ndcube/extra_coords/table_coord.py
@@ -15,7 +15,6 @@ from astropy.modeling import models
 from astropy.modeling.models import tabular_model
 from astropy.modeling.tabular import _Tabular
 from astropy.time import Time
-from astropy.utils import isiterable
 from astropy.wcs.wcsapi.wrappers.sliced_wcs import combine_slices, sanitize_slices
 
 try:
@@ -915,7 +914,7 @@ class MultipleTableCoordinate(BaseTableCoordinate):
         from_high_level_coordinates method in gwcs.
         """
         quantities = dropped_frame.coordinate_to_quantity(*highlevel_coords)
-        if isiterable(quantities):
+        if np.iterable(quantities):
             quantities = tuple(q.value for q in quantities)
         return quantities
 


### PR DESCRIPTION
## PR Description

[`astropy.utils.isiterable()`](https://docs.astropy.org/en/latest/api/astropy.utils.misc.isiterable.html) is being deprecated because it duplicates [`numpy.iterable()`](https://numpy.org/doc/1.23/reference/generated/numpy.iterable.html), which can be used as a drop-in replacement.