### PR TITLE
We can't use expanding-code-block in docstrings

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -1550,8 +1550,7 @@ class NDCube(NDCubeBase):
 
         Examples
         --------
-        .. expanding-code-block:: python
-          :summary: Expand to see cube instantiated.
+        .. testsetup::
 
           >>> import astropy.units as u
           >>> import astropy.wcs


### PR DESCRIPTION
It introduces a downstream dependency on our extension