### PR TITLE
Fix a cropping issue with irispy

### DIFF
--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -687,7 +687,8 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
                     points[i][j] = u.Quantity(value, unit=unit)
                 if value is not None:
                     try:
-                        points[i][j] = points[i][j].to(wcs.world_axis_units[j])
+                        target_unit = wcs.world_axis_units[j]
+                        points[i][j] = points[i][j].to_value(target_unit) if target_unit else points[i][j].value
                     except UnitsError as err:
                         raise UnitsError(f"Unit '{points[i][j].unit}' of coordinate object {j} in point {i} is "
                                          f"incompatible with WCS unit '{wcs.world_axis_units[j]}'") from err

--- a/ndcube/tests/test_ndcube_slice_and_crop.py
+++ b/ndcube/tests/test_ndcube_slice_and_crop.py
@@ -2,7 +2,9 @@ from textwrap import dedent
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
+import astropy
 import astropy.units as u
 import astropy.wcs
 from astropy.coordinates import SkyCoord, SpectralCoord
@@ -204,6 +206,33 @@ def test_crop(ndcube_4d_ln_lt_l_t):
     lower_corner = [coord[0] for coord in intervals]
     upper_corner = [coord[-1] for coord in intervals]
     expected = cube[1:3, 0:2, 0:2, 0:3]
+    output = cube.crop(lower_corner, upper_corner)
+    helpers.assert_cubes_equal(output, expected)
+
+
+@pytest.mark.skipif(Version(astropy.__version__) < Version("7.2"), reason="requires astropy>=7.2 for preserve_units")
+def test_crop_high_level_coords_with_non_degree_celestial_units():
+    data = np.arange(10000).reshape(100, 100)
+    header = fits.Header()
+    header["NAXIS"] = 2
+    header["NAXIS1"] = 100
+    header["NAXIS2"] = 100
+    header["CTYPE1"] = "RA---TAN"
+    header["CTYPE2"] = "DEC--TAN"
+    header["CUNIT1"] = "arcsec"
+    header["CUNIT2"] = "arcsec"
+    header["CRPIX1"] = 1
+    header["CRPIX2"] = 1
+    header["CRVAL1"] = 0
+    header["CRVAL2"] = 0
+    header["CDELT1"] = 1
+    header["CDELT2"] = 1
+    cube = NDCube(data, wcs=WCS(header, preserve_units=True))
+
+    lower_corner = cube.wcs.pixel_to_world(0, 56)
+    upper_corner = cube.wcs.pixel_to_world(99, 58)
+
+    expected = cube[56:59, 0:100]
     output = cube.crop(lower_corner, upper_corner)
     helpers.assert_cubes_equal(output, expected)
 

--- a/ndcube/utils/cube.py
+++ b/ndcube/utils/cube.py
@@ -5,7 +5,9 @@ from itertools import chain
 import numpy as np
 
 import astropy.nddata
+import astropy.units as u
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS, HighLevelWCSWrapper, SlicedLowLevelWCS
+from astropy.wcs.wcsapi.high_level_api import high_level_objects_to_values
 
 from ndcube.utils import wcs as wcs_utils
 from ndcube.utils.exceptions import warn_user
@@ -107,6 +109,33 @@ def sanitize_crop_inputs(points, wcs):
     return False, points, wcs
 
 
+def _high_level_objects_to_pixel_values(low_level_wcs, *world_objects):
+    """
+    Convert high-level world objects to pixel values.
+
+    Astropy's high-level WCS path can hand low-level WCSes celestial values in
+    degrees even when the low-level WCS advertises angular world units such as
+    arcsec. Normalize any string-based component units to the WCS world-axis
+    units before calling the low-level inverse transform.
+    """
+    world_values = list(high_level_objects_to_values(*world_objects, low_level_wcs=low_level_wcs))
+    for i, (_, _, attr) in enumerate(low_level_wcs.world_axis_object_components):
+        if not isinstance(attr, str):
+            continue
+        source_unit_name = attr.rsplit(".", 1)[-1]
+        target_unit_name = low_level_wcs.world_axis_units[i]
+        if not target_unit_name:
+            continue
+        try:
+            source_unit = u.Unit(source_unit_name)
+            target_unit = u.Unit(target_unit_name)
+        except Exception:  # NOQA: BLE001
+            continue
+        if source_unit != target_unit and source_unit.is_equivalent(target_unit):
+            world_values[i] = (world_values[i] * source_unit).to_value(target_unit)
+    return low_level_wcs.world_to_pixel_values(*world_values)
+
+
 def get_crop_item_from_points(points, wcs, crop_by_values, keepdims, original_shape):
     """
     Find slice item that crops to minimum cube in array-space containing specified world points.
@@ -182,7 +211,7 @@ def get_crop_item_from_points(points, wcs, crop_by_values, keepdims, original_sh
         # in the list corresponding to its axis.
         # Use the to_pixel methods to preserve fractional indices for future rounding.
         point_pixel_indices = (sliced_wcs.world_to_pixel_values(*sliced_point) if crop_by_values
-                               else HighLevelWCSWrapper(sliced_wcs).world_to_pixel(*sliced_point))
+                               else _high_level_objects_to_pixel_values(sliced_wcs, *sliced_point))
         # For each pixel axis associated with this point, place the pixel coords for
         # that pixel axis into the corresponding list within combined_points_pixel_idx.
         if sliced_wcs.pixel_n_dim == 1:


### PR DESCRIPTION
I decided to use preserve_units as I pin to astropy 7.2 for irispy and it causes cropping issues now with the WCS where I was cropping to a location to get a 1D spectra from a 3D cube.

```
  File "/home/nabil/Git/irispy/examples/misc/00_v34_rasters.py", line 101, in <module>
    mg_ii_k_unflipped_spectra = mg_ii_k_unflipped[0].crop(lower_corner, lower_corner)
  File "/home/nabil/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/ndcube/ndcube.py", line 626, in crop
    item = self._get_crop_item(*points, wcs=wcs, keepdims=keepdims)
  File "/home/nabil/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/ndcube/utils/cube.py", line 58, in wcs_wrapper
    return func(*params.args, **params.kwargs)
  File "/home/nabil/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/ndcube/ndcube.py", line 652, in _get_crop_item
    return utils.cube.get_crop_item_from_points(points, wcs, False, keepdims=keepdims,
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                original_shape=self.data.shape)
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nabil/.local/share/mamba/envs/irispy/lib/python3.14/site-packages/ndcube/utils/cube.py", line 218, in get_crop_item_from_points
    raise ValueError(f"All world points associated with array axis {array_axis}"
                     " are outside the range of the NDCube being cropped.")
ValueError: All world points associated with array axis 0 are outside the range of the NDCube being cropped.
```

This patch fixes that, but maybe it's actually a bug upstream but I don't know. 