### PR TITLE
Name expected world objects in crop component-count error

### DIFF
--- a/changelog/939.feature.rst
+++ b/changelog/939.feature.rst
@@ -1,0 +1,1 @@
+The error raised by `~ndcube.NDCube.crop` when a point has the wrong number of components now lists the expected world objects and their order.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -642,8 +642,13 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
         classes = [wcs.world_axis_object_classes[c][0] for c in comp]
         for i, point in enumerate(points):
             if len(point) != len(comp):
+                component_names = ", ".join(
+                    f"{name} ({cls.__name__})" for name, cls in zip(comp, classes))
                 raise ValueError(f"{len(point)} components in point {i} do not match "
-                                 f"WCS with {len(comp)} components.")
+                                 f"WCS with {len(comp)} components. Each point must "
+                                 "have one entry per world object (use None for a "
+                                 "component that should not be cropped), in order: "
+                                 f"{component_names}.")
             for j, value in enumerate(point):
                 if not (value is None or isinstance(value, classes[j])):
                     raise TypeError(f"{type(value)} of component {j} in point {i} is "

--- a/ndcube/tests/test_ndcube_slice_and_crop.py
+++ b/ndcube/tests/test_ndcube_slice_and_crop.py
@@ -617,6 +617,13 @@ def test_crop_all_points_beyond_cube_extent_error(points):
         cube.crop(*points, keepdims=True)
 
 
+def test_crop_length_error_names_world_components(ndcube_4d_ln_lt_l_t):
+    cube = ndcube_4d_ln_lt_l_t
+    interval0 = cube.wcs.array_index_to_world([1, 2], [0, 1], [0, 1], [0, 2])[0]
+    with pytest.raises(ValueError, match=r"one entry per world object"):
+        cube.crop([interval0[0], None], [interval0[-1], None])
+
+
 def test_crop_by_values_quantity_table_coordinate():
     # Regression: QuantityTableCoordinate-based WCS raised
     # "High Level objects are not supported with the native API" because


### PR DESCRIPTION
## PR Description

When a crop point has the wrong number of components, the error now lists the expected world objects and their order, so users migrating from a WCS with fewer world objects learn the fix from the error itself.

This was very frustrating to not know what I need to pass in. 

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [X] Test/benchmark generation
- [X] Documentation (including examples)
- [X] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
