### PR TITLE
Add NDCube._extra_attrs_to_copy for subclass attribute propagation

### DIFF
--- a/changelog/940.feature.rst
+++ b/changelog/940.feature.rst
@@ -1,0 +1,1 @@
+Added the ``NDCube._extra_attrs_to_copy`` extension point. Subclasses can declare instance attributes that are automatically propagated to cubes derived through arithmetic operations (``_new_instance``) and through ``to_nddata`` when the target type is a subclass carrying the same attributes.

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -378,6 +378,15 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
     _extra_coords = NDCubeLinkedDescriptor(ExtraCoords)
     _global_coords = NDCubeLinkedDescriptor(GlobalCoords)
 
+    # Names of additional instance attributes which subclasses want propagated
+    # (by reference) to instances derived through `_new_instance` (e.g.
+    # arithmetic operations) and `to_nddata` when the target type carries the
+    # same attributes. Subclasses should override this with a tuple of
+    # attribute names. Note these attributes are not automatically modified
+    # when a cube is sliced; subclasses with shape-dependent attributes must
+    # handle slicing themselves.
+    _extra_attrs_to_copy = ()
+
     def __init__(self, data, wcs=None, uncertainty=None, mask=None, meta=None,
                  unit=None, copy=False, psf=None, *, extra_coords=None, global_coords=None, **kwargs):
 
@@ -963,6 +972,9 @@ class NDCube(NDCubeBase):
             new_cube._extra_coords = deepcopy(self.extra_coords)
         if self.global_coords is not None:
             new_cube._global_coords = deepcopy(self.global_coords)
+        for attr in self._extra_attrs_to_copy:
+            if hasattr(self, attr):
+                setattr(new_cube, attr, getattr(self, attr))
         return new_cube
 
     def __neg__(self):
@@ -1635,6 +1647,12 @@ class NDCube(NDCubeBase):
           array([[1., 1., 1.],
                  [1., 1., 1.]])
         """
+        # If the target type carries the same subclass-specific attributes as
+        # this cube, copy them by default unless explicitly overridden.
+        if isinstance(nddata_type, type) and issubclass(nddata_type, type(self)):
+            for attr in self._extra_attrs_to_copy:
+                if hasattr(self, attr):
+                    kwargs.setdefault(attr, "copy")
         # Put all NDData kwargs in a dict
         user_kwargs = {"data": data,
                        "wcs": wcs,

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -378,6 +378,15 @@ class NDCubeBase(NDCubeABC, astropy.nddata.NDData, NDCubeSlicingMixin):
     _extra_coords = NDCubeLinkedDescriptor(ExtraCoords)
     _global_coords = NDCubeLinkedDescriptor(GlobalCoords)
 
+    # Names of additional instance attributes which subclasses want propagated
+    # (by reference) to instances derived through `_new_instance` (e.g.
+    # arithmetic operations) and `to_nddata` when the target type carries the
+    # same attributes. Subclasses should override this with a tuple of
+    # attribute names. Note these attributes are not automatically modified
+    # when a cube is sliced; subclasses with shape-dependent attributes must
+    # handle slicing themselves.
+    _extra_attrs_to_copy = ()
+
     def __init__(self, data, wcs=None, uncertainty=None, mask=None, meta=None,
                  unit=None, copy=False, psf=None, *, extra_coords=None, global_coords=None, **kwargs):
 
@@ -968,6 +977,9 @@ class NDCube(NDCubeBase):
             new_cube._extra_coords = deepcopy(self.extra_coords)
         if self.global_coords is not None:
             new_cube._global_coords = deepcopy(self.global_coords)
+        for attr in self._extra_attrs_to_copy:
+            if hasattr(self, attr):
+                setattr(new_cube, attr, getattr(self, attr))
         return new_cube
 
     def __neg__(self):
@@ -1640,6 +1652,12 @@ class NDCube(NDCubeBase):
           array([[1., 1., 1.],
                  [1., 1., 1.]])
         """
+        # If the target type carries the same subclass-specific attributes as
+        # this cube, copy them by default unless explicitly overridden.
+        if isinstance(nddata_type, type) and issubclass(nddata_type, type(self)):
+            for attr in self._extra_attrs_to_copy:
+                if hasattr(self, attr):
+                    kwargs.setdefault(attr, "copy")
         # Put all NDData kwargs in a dict
         user_kwargs = {"data": data,
                        "wcs": wcs,

--- a/ndcube/ndcube.py
+++ b/ndcube/ndcube.py
@@ -978,8 +978,7 @@ class NDCube(NDCubeBase):
         if self.global_coords is not None:
             new_cube._global_coords = deepcopy(self.global_coords)
         for attr in self._extra_attrs_to_copy:
-            if hasattr(self, attr):
-                setattr(new_cube, attr, getattr(self, attr))
+            setattr(new_cube, attr, getattr(self, attr))
         return new_cube
 
     def __neg__(self):
@@ -1652,12 +1651,6 @@ class NDCube(NDCubeBase):
           array([[1., 1., 1.],
                  [1., 1., 1.]])
         """
-        # If the target type carries the same subclass-specific attributes as
-        # this cube, copy them by default unless explicitly overridden.
-        if isinstance(nddata_type, type) and issubclass(nddata_type, type(self)):
-            for attr in self._extra_attrs_to_copy:
-                if hasattr(self, attr):
-                    kwargs.setdefault(attr, "copy")
         # Put all NDData kwargs in a dict
         user_kwargs = {"data": data,
                        "wcs": wcs,
@@ -1671,8 +1664,14 @@ class NDCube(NDCubeBase):
         user_kwargs = {key: getattr(self, key)
                        if isinstance(value, str) and value == "copy" else value
                        for key, value in user_kwargs.items()}
-        # Construct and return new instance.
-        return nddata_type(**user_kwargs)
+        new_nddata = nddata_type(**user_kwargs)
+        # Propagate subclass-specific attributes by reference, as in _new_instance,
+        # unless explicitly overridden via kwargs.
+        if isinstance(nddata_type, type) and issubclass(nddata_type, type(self)):
+            for attr in self._extra_attrs_to_copy:
+                if attr not in kwargs:
+                    setattr(new_nddata, attr, getattr(self, attr))
+        return new_nddata
 
 
 def _create_masked_array_for_rebinning(data, mask, operation_ignores_mask):

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -293,3 +293,47 @@ def test_custom_tonddata_type(ndcube_2d_ln_lt):
     assert new_ndd.spam == "Eggs"
     assert new_ndd.data is ndc.data
     assert new_ndd.wcs is ndc.wcs
+
+
+class SidecarCube(NDCube):
+    """NDCube subclass declaring extra attributes to propagate to derived cubes."""
+
+    _extra_attrs_to_copy = ("observer", "calibration_level")
+
+    def __init__(self, *args, **kwargs):
+        self.observer = kwargs.pop("observer", None)
+        self.calibration_level = kwargs.pop("calibration_level", 0)
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture
+def sidecar_cube(wcs_3d_lt_ln_l):
+    cube = SidecarCube(np.ones((2, 3, 4)), wcs=wcs_3d_lt_ln_l)
+    cube.observer = "earth"
+    cube.calibration_level = 2
+    return cube
+
+
+def test_extra_attrs_to_copy_propagate_through_arithmetic(sidecar_cube):
+    doubled = sidecar_cube * 2
+    assert type(doubled) is SidecarCube
+    assert doubled.observer == "earth"
+    assert doubled.calibration_level == 2
+
+    negated = -sidecar_cube
+    assert negated.observer == "earth"
+    assert negated.calibration_level == 2
+
+
+def test_extra_attrs_to_copy_propagate_through_to_nddata(sidecar_cube):
+    copied = sidecar_cube.to_nddata(nddata_type=SidecarCube)
+    assert copied.observer == "earth"
+    assert copied.calibration_level == 2
+
+    # Explicit kwargs override the automatic copy.
+    overridden = sidecar_cube.to_nddata(nddata_type=SidecarCube, observer="sdo")
+    assert overridden.observer == "sdo"
+
+    # Types which do not carry the attributes are unaffected.
+    plain = sidecar_cube.to_nddata(nddata_type=astropy.nddata.NDData)
+    assert not hasattr(plain, "observer")

--- a/ndcube/tests/test_ndcube.py
+++ b/ndcube/tests/test_ndcube.py
@@ -337,3 +337,13 @@ def test_extra_attrs_to_copy_propagate_through_to_nddata(sidecar_cube):
     # Types which do not carry the attributes are unaffected.
     plain = sidecar_cube.to_nddata(nddata_type=astropy.nddata.NDData)
     assert not hasattr(plain, "observer")
+
+
+def test_extra_attrs_to_copy_without_constructor_kwargs(wcs_3d_lt_ln_l):
+    class BareCube(NDCube):
+        _extra_attrs_to_copy = ("observer",)
+
+    cube = BareCube(np.ones((2, 3, 4)), wcs=wcs_3d_lt_ln_l)
+    cube.observer = "earth"
+    assert (cube * 2).observer == "earth"
+    assert cube.to_nddata(nddata_type=BareCube).observer == "earth"


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

Subclasses can declare instance attributes that are automatically propagated (by reference) to cubes derived through _new_instance (arithmetic operations) and through to_nddata when the target type is a subclass carrying the same attributes. This removes the need for subclasses to override both methods just to keep domain-specific metadata alive on derived cubes. Slicing is deliberately not covered, as shape-dependent attributes cannot be sliced generically.

This is a controversial change and due to something I have to do in irispy as I have attached (to Stuart's horror) lots of new attrs to make my life easier. 

I think this will not be merged in, and the fix is for me to attach more of the attrs into the metadata instead. 

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [X] Test/benchmark generation
- [X] Documentation (including examples)
- [x] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
